### PR TITLE
feat: add CLAUDE.md, custom skills, and Claude reviewer workflow

### DIFF
--- a/.claude/skills/new-bug-issue/SKILL.md
+++ b/.claude/skills/new-bug-issue/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: new-bug-issue
+description: Interactively create a new bug GitHub issue for the Alexandria project
+---
+
+The user wants to create a new bug report issue on GitHub for the Alexandria project.
+
+Follow these steps:
+
+1. Ask the user for the following information (ask all at once in a single message):
+   - **Title**: A short, descriptive title for the bug
+   - **Symptom**: What is actually happening? (observed behavior)
+   - **Expected behavior**: What should happen instead?
+   - **Affected area**: Which part of the system? (frontend / backend / database / other)
+   - **Priority**: P1 (critical/blocking), P2 (significant), or P3 (minor/cosmetic)
+   - **Files to touch** (optional): Any files you already know are involved
+
+2. Based on the answers, derive the appropriate GitHub labels:
+   - Always include: `bug`
+   - Affected area → `area:frontend`, `area:backend`, or `area:database`
+   - Priority → `priority:p1`, `priority:p2`, or `priority:p3`
+
+3. Create the issue using the gh CLI:
+
+```
+gh issue create \
+  --repo Rukongai/Alexandria \
+  --title "<title>" \
+  --body "<body>" \
+  --label "bug,<area-label>,<priority-label>"
+```
+
+Use this body format:
+```
+## Symptom
+<what is actually happening>
+
+## Expected Behavior
+<what should happen>
+
+## Root Cause / Suspected Cause
+<known root cause, or "Unknown — needs investigation">
+
+## Files to Touch
+<list of files, or "TBD">
+```
+
+4. Report the URL of the created issue to the user.

--- a/.claude/skills/new-feature-issue/SKILL.md
+++ b/.claude/skills/new-feature-issue/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: new-feature-issue
+description: Interactively create a new feature request GitHub issue for the Alexandria project
+---
+
+The user wants to create a new feature request issue on GitHub for the Alexandria project.
+
+Follow these steps:
+
+1. Ask the user for the following information (ask all at once in a single message):
+   - **Title**: A short, descriptive title for the feature
+   - **Description**: What should this feature do? What problem does it solve?
+   - **Domains involved**: Which agents/layers are needed? (frontend / backend / database — pick all that apply)
+   - **Priority**: P2 (significant) or P3 (nice-to-have)
+   - **Implementation notes** (optional): Any known approach, constraints, or files to touch
+
+2. Based on the answers, derive the appropriate GitHub labels:
+   - Always include: `enhancement`
+   - Each domain → `area:frontend`, `area:backend`, `area:database` (include all that apply)
+   - Priority → `priority:p2` or `priority:p3`
+
+3. Create the issue using the gh CLI:
+
+```
+gh issue create \
+  --repo Rukongai/Alexandria \
+  --title "<title>" \
+  --body "<body>" \
+  --label "enhancement,<area-labels>,<priority-label>"
+```
+
+Use this body format:
+```
+## Description
+<what the feature does and what problem it solves>
+
+## Implementation Notes
+<known approach, constraints, or "TBD">
+
+## Files to Touch
+<known files, or "TBD">
+```
+
+4. Report the URL of the created issue to the user.

--- a/.claude/skills/work-on-issue/SKILL.md
+++ b/.claude/skills/work-on-issue/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: work-on-issue
+description: Fetch a GitHub issue, create the correct branch, and load relevant docs to begin work
+argument-hint: "[issue-number]"
+---
+
+The user wants to start working on a GitHub issue for the Alexandria project.
+
+The skill may be invoked with an issue number argument (e.g., `/work-on-issue 42`) or without one.
+
+Follow these steps:
+
+1. **Get the issue number**
+   - If an issue number was provided as an argument, use it.
+   - If no number was provided, run:
+     ```
+     gh issue list --repo Rukongai/Alexandria --limit 20
+     ```
+     Show the list to the user and ask them to pick an issue number.
+
+2. **Fetch issue details**
+   ```
+   gh issue view <number> --repo Rukongai/Alexandria
+   ```
+   Read the title, body, and labels carefully.
+
+3. **Determine branch type**
+   - If the issue has a `bug` label → use `fix/` prefix
+   - If the issue has an `enhancement` label → use `feat/` prefix
+   - If unclear → ask the user
+
+4. **Create a branch slug** from the issue title:
+   - Lowercase, replace spaces/special chars with hyphens
+   - Keep it short (3–5 words max)
+   - Example: issue #42 "Fix thumbnail generation crash" → `fix/42-thumbnail-generation-crash`
+
+5. **Create and switch to the branch**
+   ```
+   git checkout main && git pull && git checkout -b <branch-name>
+   ```
+
+6. **Load relevant docs** based on issue type:
+
+   For a **bug** (`fix/` branch):
+   - Read `docs/ARCHITECTURE.md` — locate the service boundary
+   - Read `docs/CONVENTIONS.md` — confirm correct patterns
+   - Read `docs/TYPES.md` if the bug involves API contracts or shared types
+
+   For a **feature** (`feat/` branch):
+   - Read `docs/ARCHITECTURE.md` — understand where the feature fits
+   - Read `docs/TYPES.md` — identify new or changed types
+   - Read `docs/CONVENTIONS.md` — confirm correct patterns
+   - Read `docs/API.md` if the feature involves new or modified endpoints
+
+7. **Report to the user**:
+   - Issue title and number
+   - Branch created
+   - Which docs were loaded
+   - A brief summary of the issue and the relevant area(s) identified from the docs
+   - Ask the user how they'd like to proceed, or begin work if instructions are clear

--- a/.github/workflows/claude-reviewer.yml
+++ b/.github/workflows/claude-reviewer.yml
@@ -1,0 +1,50 @@
+name: Claude Reviewer
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+
+jobs:
+  reviewer:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run Alexandria Reviewer Agent
+        uses: anthropics/claude-code-action@v1
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_REF: ${{ github.base_ref }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            You are running the Alexandria project reviewer agent.
+
+            1. Read `.claude/agents/reviewer.md` — this is your full review checklist.
+            2. Read `docs/ARCHITECTURE.md`, `docs/CONVENTIONS.md`, and `docs/TYPES.md`.
+            3. Run: git diff origin/$BASE_REF...HEAD --name-only
+               to get the list of changed files, then read each one.
+            4. Apply every check in reviewer.md to the changed code.
+            5. Post your findings as a comment on this PR:
+               gh pr comment $PR_NUMBER --body "..."
+
+            Format your comment as:
+            ## Alexandria Code Review
+
+            **Result:** ✅ No issues found  (or ⚠️ N issue(s) found)
+
+            For each issue:
+            - **File:** `path/to/file.ts:line`
+            - **Rule:** (what docs/ARCHITECTURE.md or CONVENTIONS.md says)
+            - **Fix:** (specific actionable change)
+
+            If no issues are found, say so explicitly and briefly summarize what was checked.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,120 @@
+# Alexandria — Claude Code Instructions
+
+## Git Workflow (MANDATORY)
+
+**Never commit directly to `main`.** Every task (bug fix, feature, refactor) must use a branch and a PR.
+
+### Branch Naming
+
+| Type | Format |
+|------|--------|
+| Bug fix with issue | `fix/{issue-number}-{short-slug}` |
+| Feature with issue | `feat/{issue-number}-{short-slug}` |
+| Bug fix without issue | `fix/{short-slug}` |
+| Feature without issue | `feat/{short-slug}` |
+
+### Standard Task Flow
+
+```
+git checkout main && git pull
+git checkout -b fix/<number>-<slug>   # or feat/
+# ... do work ...
+git add <files>
+git commit -m "fix: ..."              # conventional commit format
+gh pr create --title "..." --body "..."
+```
+
+### Commit Format
+
+Follow `docs/CONVENTIONS.md` for conventional commit messages:
+- `fix: ...` for bug fixes
+- `feat: ...` for new features
+- `refactor: ...` for internal changes
+- `test: ...` for test-only changes
+- `docs: ...` for documentation
+
+**Never self-merge.** Leave PRs open for review.
+
+---
+
+## Before Starting Any Task — Load These Docs
+
+| Doc | When to load |
+|-----|-------------|
+| `docs/ARCHITECTURE.md` | Every task |
+| `docs/CONVENTIONS.md` | Every task |
+| `docs/TYPES.md` | When touching API contracts or shared types |
+| `docs/API.md` | When adding or modifying endpoints |
+| `docs/AGENTS.md` | When delegating to sub-agents |
+
+---
+
+## Working on a Bug
+
+### Doc Checklist
+1. `docs/ARCHITECTURE.md` — locate the service boundary where the bug lives
+2. `docs/CONVENTIONS.md` — confirm correct patterns before writing fixes
+3. `docs/TYPES.md` — verify type contracts aren't violated by the fix
+
+### Agent Delegation Matrix
+
+| Area | Agent |
+|------|-------|
+| React component / hook / page / API client | `frontend` |
+| Fastify route / service / middleware / worker | `backend-service` |
+| DB schema / migration / query | `database` |
+| Test coverage | `testing` |
+| Review (always run at end) | `reviewer` |
+| Cross-cutting (spans multiple domains) | Work directly; delegate sub-tasks |
+
+### Bug Fix Process
+1. Fetch issue: `gh issue view <number>`
+2. Create branch: `git checkout main && git pull && git checkout -b fix/<number>-<slug>`
+3. Read relevant source files (don't guess — read first)
+4. Delegate to the appropriate domain agent, or work directly for cross-cutting changes
+5. Run tests: `npx vitest run` (with `DATABASE_URL` if integration tests)
+6. Invoke `reviewer` agent
+7. Create PR: `gh pr create` with `Closes #<number>` in the body
+
+---
+
+## Working on a Feature
+
+### Doc Checklist
+1. `docs/ARCHITECTURE.md` — understand service boundaries and where the feature fits
+2. `docs/TYPES.md` — identify new or changed types, update shared types first
+3. `docs/CONVENTIONS.md` — confirm correct patterns before writing new code
+4. `docs/API.md` — review endpoint contracts; update for any new endpoints
+
+### Agent Delegation Matrix
+
+| Area | Agent |
+|------|-------|
+| React pages / components / hooks | `frontend` |
+| Backend services / routes / workers | `backend-service` |
+| DB columns / tables / migrations | `database` |
+| Multi-domain feature | Delegate each domain; coordinate from main session |
+| Tests | `testing` |
+| Review (always run at end) | `reviewer` |
+| Docs update (always run at end) | `documentation` |
+
+### Feature Process
+1. Fetch issue: `gh issue view <number>`
+2. Create branch: `git checkout main && git pull && git checkout -b feat/<number>-<slug>`
+3. Check if `docs/ARCHITECTURE.md` needs an update before writing code
+4. Delegate to domain agents for each layer (database → backend → frontend)
+5. Coordinate results and resolve any cross-layer dependencies
+6. Run tests
+7. Invoke `reviewer` agent
+8. Invoke `documentation` agent to update `docs/API.md`, `docs/ARCHITECTURE.md`, etc.
+9. Create PR with `Closes #<number>` in the body
+
+---
+
+## Slash Commands
+
+| Command | Purpose |
+|---------|---------|
+| `/new-bug-issue` | Interactively create a new bug GitHub issue |
+| `/new-feature-issue` | Interactively create a new feature GitHub issue |
+| `/work-on-issue [number]` | Fetch an issue, create the correct branch, and load relevant docs |


### PR DESCRIPTION
## Summary
- Adds `CLAUDE.md` with project instructions covering git workflow, doc loading checklist, agent delegation matrix, and slash command reference
- Adds `.claude/skills/` with three custom skills: `new-bug-issue`, `new-feature-issue`, and `work-on-issue`
- Adds `.github/workflows/claude-reviewer.yml` for automated Claude code review on PRs

## Test plan
- [ ] Verify `/new-bug-issue`, `/new-feature-issue`, and `/work-on-issue` skills are discoverable in Claude Code
- [ ] Verify CLAUDE.md instructions load correctly in a new session
- [ ] Verify the Claude reviewer workflow triggers on a new PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)