### PR TITLE
feat(models): user-selectable cover image for library cards

### DIFF
--- a/apps/backend/src/db/migrations/0002_add_preview_image_file_id.sql
+++ b/apps/backend/src/db/migrations/0002_add_preview_image_file_id.sql
@@ -1,0 +1,21 @@
+-- Add user-selectable cover image column to the models table.
+--
+-- preview_image_file_id stores the model_files(id) of the image the user
+-- has chosen as the library card cover. When NULL the frontend falls back
+-- to the first image file found in the model.
+--
+-- ON DELETE SET NULL: removing a model file that was pinned as the preview
+-- automatically reverts the model to the fallback behaviour without any
+-- application-layer cleanup job.
+
+--> statement-breakpoint
+ALTER TABLE "models"
+  ADD COLUMN "preview_image_file_id" uuid
+  REFERENCES "model_files"("id") ON DELETE SET NULL;
+--> statement-breakpoint
+-- FK index: PostgreSQL does not create indexes on FK columns automatically.
+-- This index is used when ON DELETE SET NULL fires (Postgres must locate every
+-- models row that references the deleted model_files row) and also supports
+-- any future query that joins or filters on preview_image_file_id.
+CREATE INDEX "models_preview_image_file_id_idx"
+  ON "models" ("preview_image_file_id");

--- a/apps/backend/src/db/schema/model.ts
+++ b/apps/backend/src/db/schema/model.ts
@@ -42,6 +42,12 @@ export const models = pgTable(
     // name is weighted A (most relevant), description is weighted B.
     // Never set this column from application code.
     searchVector: tsvector('search_vector'),
+    // User-selected cover image for library cards. Nullable — when null, the system
+    // falls back to the first image file in the model.
+    // References model_files(id) ON DELETE SET NULL — enforced in SQL migration.
+    // Note: Drizzle-level .references() is omitted here to avoid the circular import
+    // between model.ts and model-file.ts; the FK constraint lives in the migration SQL.
+    previewImageFileId: uuid('preview_image_file_id'),
   },
   (table) => [
     // Fast lookup by slug for URL-based access
@@ -54,6 +60,8 @@ export const models = pgTable(
     index('models_created_at_idx').on(table.createdAt),
     // GIN index required for efficient tsvector @@ tsquery full-text search
     index('models_search_vector_idx').using('gin', table.searchVector),
+    // FK index: resolve which model owns a preview image file (ON DELETE SET NULL lookup)
+    index('models_preview_image_file_id_idx').on(table.previewImageFileId),
   ],
 );
 

--- a/apps/backend/src/services/search.service.ts
+++ b/apps/backend/src/services/search.service.ts
@@ -259,6 +259,7 @@ export class PostgresSearchService implements ISearchService {
         fileCount: models.fileCount,
         totalSizeBytes: models.totalSizeBytes,
         createdAt: models.createdAt,
+        previewImageFileId: models.previewImageFileId,
         // Include the sort value in the result so we can encode the cursor
         sortValue: sortColumnSql,
       })

--- a/apps/frontend/src/pages/ModelDetailPage.tsx
+++ b/apps/frontend/src/pages/ModelDetailPage.tsx
@@ -68,7 +68,11 @@ export function ModelDetailPage() {
         <div className="flex flex-col lg:flex-row gap-6">
           {/* Left column: gallery + file tree */}
           <div className="flex-1 min-w-0 flex flex-col gap-4">
-            <ImageGallery images={model.images} />
+            <ImageGallery
+              images={model.images}
+              previewImageFileId={model.previewImageFileId}
+              modelId={model.id}
+            />
             <FileTree tree={fileTree} />
           </div>
 

--- a/docs/TYPES.md
+++ b/docs/TYPES.md
@@ -50,6 +50,7 @@ interface Model {
   totalSizeBytes: number;
   fileCount: number;
   fileHash: string | null;
+  previewImageFileId: string | null; // user-selected cover image; null = first-image fallback
   createdAt: string;
   updatedAt: string;
 }
@@ -214,6 +215,7 @@ interface ModelDetail {
   slug: string;
   description: string | null;
   thumbnailUrl: string | null;
+  previewImageFileId: string | null; // user-selected cover image; null = first-image fallback
   metadata: MetadataValue[];
   sourceType: ModelSourceType;
   originalFilename: string | null;
@@ -380,6 +382,7 @@ Shared validation schemas (Zod) for request bodies.
 interface UpdateModelRequest {
   name?: string;
   description?: string | null;
+  previewImageFileId?: string | null; // set to a ModelFile UUID to pin cover; null to revert to fallback
 }
 ```
 

--- a/packages/shared/src/types/model.ts
+++ b/packages/shared/src/types/model.ts
@@ -14,6 +14,7 @@ export interface Model {
   totalSizeBytes: number;
   fileCount: number;
   fileHash: string | null;
+  previewImageFileId: string | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -59,6 +60,7 @@ export interface ModelDetail {
   slug: string;
   description: string | null;
   thumbnailUrl: string | null;
+  previewImageFileId: string | null;
   metadata: import('./metadata').MetadataValue[];
   sourceType: ModelSourceType;
   originalFilename: string | null;
@@ -90,6 +92,7 @@ export interface FileTreeNode {
 export interface UpdateModelRequest {
   name?: string;
   description?: string | null;
+  previewImageFileId?: string | null;
 }
 
 export interface JobStatus {

--- a/packages/shared/src/validation/model.ts
+++ b/packages/shared/src/validation/model.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 export const updateModelSchema = z.object({
   name: z.string().min(1).max(255).optional(),
   description: z.string().nullable().optional(),
+  previewImageFileId: z.string().uuid().nullable().optional(),
 });
 
 export const bulkDeleteSchema = z.object({


### PR DESCRIPTION
## Summary

- Adds `preview_image_file_id` column to `models` (nullable FK → `model_files`, `ON DELETE SET NULL`)
- `PATCH /models/:id` now accepts `previewImageFileId` — validated to be an image file belonging to the model
- `PresenterService` prefers the pinned thumbnail in card and detail views, falling back to the first image when unset
- `ImageGallery` shows an amber "Cover" badge on the pinned image and a "Set cover" hover button on all others; errors surfaced via toast

## Test plan

- [ ] Upload a model with multiple images; verify the first image is used as the card thumbnail by default
- [ ] Open model detail → hover a non-cover thumbnail → click "Set cover" → verify the amber badge moves to the new cover
- [ ] Verify the library card thumbnail updates after setting a new cover
- [ ] Delete the pinned cover image file → verify the model reverts to the first-image fallback (DB `ON DELETE SET NULL`)
- [ ] Attempt to set `previewImageFileId` to a file from a different model (via API) → expect `400 VALIDATION_ERROR`
- [ ] Attempt to set `previewImageFileId` to a non-image file (e.g. an STL) → expect `400 VALIDATION_ERROR`
- [ ] Set cover → network failure → verify destructive toast appears and spinner clears

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)