### PR TITLE
fix: register 0002_add_preview_image_file_id in migration journal

### DIFF
--- a/apps/backend/src/db/migrations/meta/_journal.json
+++ b/apps/backend/src/db/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1771825200000,
       "tag": "0001_add_models_fts",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1771906380000,
+      "tag": "0002_add_preview_image_file_id",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Adds missing entry for `0002_add_preview_image_file_id` to `meta/_journal.json`
- Drizzle's `migrate()` only applies SQL files listed in the journal; without this entry, the `preview_image_file_id` column was never created
- Fixes `DatabaseError: column "preview_image_file_id" does not exist` on every `GET /models` request

## Root Cause

`0002_add_preview_image_file_id.sql` existed but its journal entry was absent, so the migration was silently skipped on every server start.

## Test plan

- [ ] Run `migrate.ts` — should apply `0002` and complete without error
- [ ] `GET /models` returns `200` with `previewImageFileId` present on model card objects
- [ ] No `DatabaseError` in backend logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)