### PR TITLE
feat: configurable cover image aspect ratio in library view

### DIFF
--- a/apps/frontend/src/components/models/ModelCard.tsx
+++ b/apps/frontend/src/components/models/ModelCard.tsx
@@ -4,6 +4,7 @@ import type { ModelCard as ModelCardType } from '@alexandria/shared';
 import { Badge } from '../ui/badge';
 import { formatFileSize } from '../../lib/format';
 import { cn } from '../../lib/utils';
+import { useDisplayPreferences } from '../../hooks/use-display-preferences';
 
 interface ModelCardProps {
   model: ModelCardType;
@@ -39,6 +40,7 @@ function StatusIndicator({ status }: { status: ModelCardType['status'] }) {
 
 export function ModelCard({ model, selectable, selected, onToggleSelect }: ModelCardProps) {
   const navigate = useNavigate();
+  const { cardAspectRatio } = useDisplayPreferences();
 
   const tags = model.metadata
     .filter((m) => m.fieldSlug === 'tags')
@@ -91,7 +93,7 @@ export function ModelCard({ model, selectable, selected, onToggleSelect }: Model
       )}
 
       {/* Thumbnail area */}
-      <div className="relative aspect-[4/3] overflow-hidden bg-muted">
+      <div className="relative overflow-hidden bg-muted" style={{ aspectRatio: cardAspectRatio }}>
         {thumbnailSrc ? (
           <img
             src={thumbnailSrc}

--- a/apps/frontend/src/components/models/ModelCardSkeleton.tsx
+++ b/apps/frontend/src/components/models/ModelCardSkeleton.tsx
@@ -1,10 +1,13 @@
 import { Skeleton } from '../ui/skeleton';
+import { useDisplayPreferences } from '../../hooks/use-display-preferences';
 
 export function ModelCardSkeleton() {
+  const { cardAspectRatio } = useDisplayPreferences();
+
   return (
     <div className="flex flex-col overflow-hidden rounded-xl border bg-card shadow">
       {/* Thumbnail */}
-      <Skeleton className="aspect-[4/3] w-full rounded-none" />
+      <Skeleton className="w-full rounded-none" style={{ aspectRatio: cardAspectRatio }} />
       {/* Body */}
       <div className="flex flex-col gap-2 p-3">
         <Skeleton className="h-4 w-3/4" />

--- a/apps/frontend/src/hooks/use-display-preferences.tsx
+++ b/apps/frontend/src/hooks/use-display-preferences.tsx
@@ -1,0 +1,51 @@
+import { createContext, useContext, useState, useCallback, type ReactNode } from 'react';
+
+export type AspectRatio = '1/1' | '2/3' | '3/4' | '4/3';
+
+interface DisplayPreferences {
+  cardAspectRatio: AspectRatio;
+  setCardAspectRatio: (ratio: AspectRatio) => void;
+}
+
+const STORAGE_KEY = 'displayPrefs';
+const DEFAULT_RATIO: AspectRatio = '4/3';
+
+function loadPrefs(): { cardAspectRatio: AspectRatio } {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw) {
+      const parsed = JSON.parse(raw);
+      if (parsed.cardAspectRatio) return parsed;
+    }
+  } catch {
+    // ignore
+  }
+  return { cardAspectRatio: DEFAULT_RATIO };
+}
+
+const DisplayPreferencesContext = createContext<DisplayPreferences | null>(null);
+
+export function DisplayPreferencesProvider({ children }: { children: ReactNode }) {
+  const [cardAspectRatio, setRatioState] = useState<AspectRatio>(() => loadPrefs().cardAspectRatio);
+
+  const setCardAspectRatio = useCallback((ratio: AspectRatio) => {
+    setRatioState(ratio);
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify({ cardAspectRatio: ratio }));
+    } catch {
+      // ignore storage errors
+    }
+  }, []);
+
+  return (
+    <DisplayPreferencesContext.Provider value={{ cardAspectRatio, setCardAspectRatio }}>
+      {children}
+    </DisplayPreferencesContext.Provider>
+  );
+}
+
+export function useDisplayPreferences(): DisplayPreferences {
+  const ctx = useContext(DisplayPreferencesContext);
+  if (!ctx) throw new Error('useDisplayPreferences must be used within DisplayPreferencesProvider');
+  return ctx;
+}

--- a/apps/frontend/src/main.tsx
+++ b/apps/frontend/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { AuthProvider } from './hooks/use-auth';
+import { DisplayPreferencesProvider } from './hooks/use-display-preferences';
 import { Toaster } from './components/ui/toast';
 import App from './App';
 import './index.css';
@@ -21,10 +22,12 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <QueryClientProvider client={queryClient}>
       <BrowserRouter>
-        <AuthProvider>
-          <App />
-          <Toaster />
-        </AuthProvider>
+        <DisplayPreferencesProvider>
+          <AuthProvider>
+            <App />
+            <Toaster />
+          </AuthProvider>
+        </DisplayPreferencesProvider>
       </BrowserRouter>
     </QueryClientProvider>
   </React.StrictMode>

--- a/apps/frontend/src/pages/SettingsPage.tsx
+++ b/apps/frontend/src/pages/SettingsPage.tsx
@@ -4,10 +4,12 @@ import { Plus, Pencil, Trash2, Lock, Filter, Eye } from 'lucide-react';
 import type { MetadataFieldDetail } from '@alexandria/shared';
 import { getFields, deleteField } from '../api/metadata';
 import { useToast } from '../hooks/use-toast';
+import { useDisplayPreferences, type AspectRatio } from '../hooks/use-display-preferences';
 import { FieldDialog } from '../components/metadata/FieldDialog';
 import { AlertDialog } from '../components/ui/alert-dialog';
 import { Button } from '../components/ui/button';
 import { Badge } from '../components/ui/badge';
+import { Select } from '../components/ui/select';
 import { Skeleton } from '../components/ui/skeleton';
 
 const TYPE_LABELS: Record<string, string> = {
@@ -20,9 +22,17 @@ const TYPE_LABELS: Record<string, string> = {
   multi_enum: 'Multi-select',
 };
 
+const ASPECT_RATIO_OPTIONS: { label: string; value: AspectRatio; description: string }[] = [
+  { label: 'Square (1:1)', value: '1/1', description: 'Equal width and height' },
+  { label: 'Portrait — Tall (2:3)', value: '2/3', description: 'Best for character/figure shots' },
+  { label: 'Portrait — Standard (3:4)', value: '3/4', description: 'Common for cards and covers' },
+  { label: 'Landscape (4:3)', value: '4/3', description: 'Current default — wider than tall' },
+];
+
 export function SettingsPage() {
   const queryClient = useQueryClient();
   const { toast } = useToast();
+  const { cardAspectRatio, setCardAspectRatio } = useDisplayPreferences();
 
   const [createOpen, setCreateOpen] = useState(false);
   const [editTarget, setEditTarget] = useState<MetadataFieldDetail | undefined>(undefined);
@@ -53,6 +63,40 @@ export function SettingsPage() {
           Manage metadata fields and other library preferences.
         </p>
       </div>
+
+      {/* Library Display section */}
+      <section className="flex flex-col gap-4">
+        <div>
+          <h2 className="text-base font-semibold text-foreground">Library Display</h2>
+          <p className="text-sm text-muted-foreground">
+            Customize how model cards appear in the library grid.
+          </p>
+        </div>
+        <div className="rounded-xl border p-4 flex flex-col gap-3">
+          <div className="flex items-center justify-between gap-4">
+            <div>
+              <label htmlFor="card-aspect-ratio" className="text-sm font-medium text-foreground">
+                Card Aspect Ratio
+              </label>
+              <p className="text-xs text-muted-foreground mt-0.5">
+                {ASPECT_RATIO_OPTIONS.find((o) => o.value === cardAspectRatio)?.description}
+              </p>
+            </div>
+            <Select
+              id="card-aspect-ratio"
+              value={cardAspectRatio}
+              onChange={(e) => setCardAspectRatio(e.target.value as AspectRatio)}
+              className="w-56"
+            >
+              {ASPECT_RATIO_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </Select>
+          </div>
+        </div>
+      </section>
 
       {/* Metadata Fields section */}
       <section className="flex flex-col gap-4">


### PR DESCRIPTION
## Summary

- Introduces a `DisplayPreferences` context (`use-display-preferences.tsx`) backed by `localStorage` — persists user preferences across sessions
- Adds `DisplayPreferencesProvider` to the app root (`main.tsx`)
- `ModelCard` and `ModelCardSkeleton` now read `cardAspectRatio` from context and apply it via `style={{ aspectRatio }}` (safe for dynamic values, unlike Tailwind's static class system)
- `SettingsPage` gains a new **Library Display** section with a `<Select>` offering four ratio options: Square (1:1), Portrait Tall (2:3), Portrait Standard (3:4), Landscape (4:3)
- Default is `'4/3'` — preserves existing layout for existing users

## Test plan

- [ ] Navigate to `/settings` — confirm "Library Display" section appears above Metadata Fields
- [ ] Change ratio to "Portrait — Tall (2:3)" — navigate to `/` and confirm cards render taller than wide
- [ ] Refresh the page — confirm the selected ratio persists (localStorage)
- [ ] Change back to "Landscape (4:3)" — confirm cards revert to original layout
- [ ] Verify skeleton cards during loading also match the selected ratio

🤖 Generated with [Claude Code](https://claude.com/claude-code)