### PR TITLE
fix: align filter panel query params and tag matching with frontend

### DIFF
--- a/apps/backend/src/routes/models.ts
+++ b/apps/backend/src/routes/models.ts
@@ -32,11 +32,11 @@ export async function modelRoutes(app: FastifyInstance): Promise<void> {
     async (request, reply) => {
       const rawQuery = request.query as Record<string, unknown>;
 
-      // Extract metadata.* keys into a metadataFilters record
+      // Extract meta_* keys into a metadataFilters record (frontend uses meta_ prefix)
       const metadataFilters: Record<string, string> = {};
       for (const [key, val] of Object.entries(rawQuery)) {
-        if (key.startsWith('metadata.') && typeof val === 'string') {
-          const fieldSlug = key.slice('metadata.'.length);
+        if (key.startsWith('meta_') && typeof val === 'string') {
+          const fieldSlug = key.slice('meta_'.length);
           if (fieldSlug) {
             metadataFilters[fieldSlug] = val;
           }

--- a/apps/backend/src/services/search.service.test.ts
+++ b/apps/backend/src/services/search.service.test.ts
@@ -169,8 +169,6 @@ beforeAll(async () => {
     // Key by the base slug prefix for easier reference
     const key = tagDef.slug.split('-').slice(0, -1).join('-'); // strip timestamp
     tagIds[key] = tag.id;
-    // Store the slug so tests can reference it
-    tagIds[`slug_${key}`] = tagDef.slug;
   }
 
   // Assign tags:
@@ -438,9 +436,8 @@ describe('text search', () => {
 
 describe('metadata filtering', () => {
   it('should filter by single tag and return only models with that tag', async () => {
-    const dragonSlug = tagIds['slug_dragon'];
     const result = await searchService.searchModels({
-      tags: dragonSlug,
+      tags: 'Dragon',
       pageSize: 100,
     });
 
@@ -457,10 +454,8 @@ describe('metadata filtering', () => {
   });
 
   it('should filter by multiple tags with ALL semantics', async () => {
-    const dragonSlug = tagIds['slug_dragon'];
-    const fantasySlug = tagIds['slug_fantasy'];
     const result = await searchService.searchModels({
-      tags: `${dragonSlug},${fantasySlug}`,
+      tags: 'Dragon,Fantasy',
       pageSize: 100,
     });
 
@@ -673,13 +668,11 @@ describe('combined filters', () => {
   });
 
   it('should combine tag filter with status filter', async () => {
-    const dragonSlug = tagIds['slug_dragon'];
-
     // Dragon tag: model[0] (ready) and model[4] (ready)
     // Status = ready: model[0], [1], [2], [4]
     // Intersection: model[0] and model[4]
     const result = await searchService.searchModels({
-      tags: dragonSlug,
+      tags: 'Dragon',
       status: 'ready',
       pageSize: 100,
     });

--- a/apps/backend/src/services/search.service.ts
+++ b/apps/backend/src/services/search.service.ts
@@ -168,15 +168,16 @@ export class PostgresSearchService implements ISearchService {
     }
 
     // Tags filter — ALL semantics (model must have every listed tag)
+    // Matches by tag name (case-insensitive) because listFieldValues returns tag names as values.
     if (params.tags) {
-      const tagSlugs = params.tags.split(',').map((s) => s.trim()).filter(Boolean);
-      if (tagSlugs.length > 0) {
-        for (const slug of tagSlugs) {
+      const tagNames = params.tags.split(',').map((s) => s.trim()).filter(Boolean);
+      if (tagNames.length > 0) {
+        for (const name of tagNames) {
           conditions.push(
             sql`${models.id} IN (
               SELECT mt.model_id FROM model_tags mt
               INNER JOIN tags t ON t.id = mt.tag_id
-              WHERE t.slug = ${slug}
+              WHERE lower(t.name) = lower(${name})
             )`,
           );
         }


### PR DESCRIPTION
## Summary

- Parse `meta_` prefixed query params in `GET /models` route — the frontend sends `meta_<slug>` but the backend was looking for `metadata.<slug>`
- Match tags by name (case-insensitive) instead of slug — `listFieldValues` returns tag names as values, not slugs
- Update `search.service.test.ts` to use tag names directly (removes the slug lookup indirection)

## Test plan

- [ ] Run `npx vitest run` with `DATABASE_URL` set — all search service tests should pass
- [ ] Apply a metadata filter in the FilterPanel UI and confirm results are filtered correctly
- [ ] Apply a tag filter and confirm models with that tag are returned

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)