### PR TITLE
feat: add light/dark/system theme toggle (#7)

### DIFF
--- a/apps/frontend/index.html
+++ b/apps/frontend/index.html
@@ -4,6 +4,14 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Alexandria</title>
+  <script>
+    (function () {
+      var t = localStorage.getItem('theme');
+      if (t === 'dark' || (t !== 'light' && matchMedia('(prefers-color-scheme: dark)').matches)) {
+        document.documentElement.classList.add('dark');
+      }
+    })();
+  </script>
   </head>
   <body>
     <div id="root"></div>

--- a/apps/frontend/src/components/layout/Header.tsx
+++ b/apps/frontend/src/components/layout/Header.tsx
@@ -1,6 +1,7 @@
 import { useLocation, useNavigate } from 'react-router-dom';
-import { LogOut, User } from 'lucide-react';
+import { LogOut, Monitor, Moon, Sun, User } from 'lucide-react';
 import { useAuth } from '../../hooks/use-auth';
+import { useTheme, type Theme } from '../../hooks/use-theme';
 import { Avatar, AvatarFallback } from '../ui/avatar';
 import {
   DropdownMenu,
@@ -32,6 +33,44 @@ function getInitials(displayName: string): string {
     .toUpperCase();
 }
 
+const THEME_OPTIONS: { value: Theme; label: string; icon: React.ComponentType<{ className?: string }> }[] = [
+  { value: 'light', label: 'Light', icon: Sun },
+  { value: 'dark', label: 'Dark', icon: Moon },
+  { value: 'system', label: 'System', icon: Monitor },
+];
+
+function ThemeToggle() {
+  const { theme, setTheme, resolvedTheme } = useTheme();
+
+  const ActiveIcon = theme === 'system' ? Monitor : resolvedTheme === 'dark' ? Moon : Sun;
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          className="flex h-8 w-8 items-center justify-center rounded-md outline-none hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring"
+          aria-label="Toggle theme"
+        >
+          <ActiveIcon className="h-4 w-4 text-muted-foreground" />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        {THEME_OPTIONS.map(({ value, label, icon: Icon }) => (
+          <DropdownMenuItem
+            key={value}
+            onClick={() => setTheme(value)}
+            className={theme === value ? 'font-semibold' : ''}
+          >
+            <Icon className="mr-2 h-4 w-4" />
+            {label}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
 export function Header() {
   const { user, logout } = useAuth();
   const navigate = useNavigate();
@@ -41,6 +80,8 @@ export function Header() {
     <header className="flex h-14 items-center justify-between border-b border-border bg-background px-6">
       <h1 className="text-lg font-semibold text-foreground">{title}</h1>
 
+      <div className="flex items-center gap-2">
+        <ThemeToggle />
       {user && (
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
@@ -77,6 +118,7 @@ export function Header() {
           </DropdownMenuContent>
         </DropdownMenu>
       )}
+      </div>
     </header>
   );
 }

--- a/apps/frontend/src/components/models/BulkActions.tsx
+++ b/apps/frontend/src/components/models/BulkActions.tsx
@@ -177,7 +177,7 @@ export function BulkActions({ selectedIds, onClear, onDeleted }: BulkActionsProp
           <Button
             size="sm"
             variant="ghost"
-            className="text-background hover:text-background hover:bg-white/10"
+            className="text-background hover:text-background hover:bg-black/10 dark:hover:bg-white/10"
             onClick={() => setActivePanel(activePanel === 'tag' ? null : 'tag')}
           >
             <Tag className="h-4 w-4 mr-1.5" />
@@ -199,7 +199,7 @@ export function BulkActions({ selectedIds, onClear, onDeleted }: BulkActionsProp
           <Button
             size="sm"
             variant="ghost"
-            className="text-background hover:text-background hover:bg-white/10"
+            className="text-background hover:text-background hover:bg-black/10 dark:hover:bg-white/10"
             onClick={() => setActivePanel(activePanel === 'collection' ? null : 'collection')}
           >
             <FolderPlus className="h-4 w-4 mr-1.5" />

--- a/apps/frontend/src/components/models/FileTree.tsx
+++ b/apps/frontend/src/components/models/FileTree.tsx
@@ -20,7 +20,7 @@ interface FileNodeProps {
 function FileIcon({ fileType }: { fileType?: FileType }) {
   switch (fileType) {
     case 'stl':
-      return <Box className="h-4 w-4 text-amber-600 flex-shrink-0" />;
+      return <Box className="h-4 w-4 text-amber-600 dark:text-amber-500 flex-shrink-0" />;
     case 'image':
       return <Image className="h-4 w-4 text-blue-500 flex-shrink-0" />;
     case 'document':

--- a/apps/frontend/src/components/upload/RecentUploads.tsx
+++ b/apps/frontend/src/components/upload/RecentUploads.tsx
@@ -8,7 +8,7 @@ import type { ModelCard } from '@alexandria/shared';
 function StatusBadge({ status }: { status: ModelCard['status'] }) {
   if (status === 'processing') {
     return (
-      <span className="flex items-center gap-1 text-xs text-amber-600">
+      <span className="flex items-center gap-1 text-xs text-amber-600 dark:text-amber-500">
         <Loader2 className="h-3 w-3 animate-spin" />
         Processing
       </span>
@@ -23,7 +23,7 @@ function StatusBadge({ status }: { status: ModelCard['status'] }) {
     );
   }
   return (
-    <span className="flex items-center gap-1 text-xs text-emerald-600">
+    <span className="flex items-center gap-1 text-xs text-emerald-600 dark:text-emerald-500">
       <CheckCircle2 className="h-3 w-3" />
       Ready
     </span>

--- a/apps/frontend/src/components/upload/UploadProgress.tsx
+++ b/apps/frontend/src/components/upload/UploadProgress.tsx
@@ -75,7 +75,7 @@ export function UploadProgress({ modelId }: UploadProgressProps) {
   if (status.status === 'ready') {
     return (
       <div className="space-y-2">
-        <div className="flex items-center gap-2 text-sm text-emerald-600">
+        <div className="flex items-center gap-2 text-sm text-emerald-600 dark:text-emerald-500">
           <CheckCircle2 className="h-4 w-4 shrink-0" />
           <span>Model is ready.</span>
         </div>

--- a/apps/frontend/src/hooks/use-theme.ts
+++ b/apps/frontend/src/hooks/use-theme.ts
@@ -1,0 +1,92 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+export type Theme = 'light' | 'dark' | 'system';
+
+interface ThemeContextValue {
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+  resolvedTheme: 'light' | 'dark';
+}
+
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+const STORAGE_KEY = 'theme';
+
+function getSystemTheme(): 'light' | 'dark' {
+  if (typeof window === 'undefined') return 'light';
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+
+function applyTheme(theme: Theme): 'light' | 'dark' {
+  const resolved = theme === 'system' ? getSystemTheme() : theme;
+  const root = document.documentElement;
+  if (resolved === 'dark') {
+    root.classList.add('dark');
+  } else {
+    root.classList.remove('dark');
+  }
+  return resolved;
+}
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setThemeState] = useState<Theme>(() => {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY) as Theme | null;
+      if (stored === 'light' || stored === 'dark' || stored === 'system') {
+        return stored;
+      }
+    } catch {
+      // localStorage not available
+    }
+    return 'system';
+  });
+
+  const [resolvedTheme, setResolvedTheme] = useState<'light' | 'dark'>(
+    () => (theme === 'system' ? getSystemTheme() : theme)
+  );
+
+  // Apply theme on mount and when theme changes
+  useEffect(() => {
+    const resolved = applyTheme(theme);
+    setResolvedTheme(resolved);
+  }, [theme]);
+
+  // Listen for system preference changes when theme is 'system'
+  useEffect(() => {
+    if (theme !== 'system') return;
+
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+    function handleChange() {
+      const resolved = applyTheme('system');
+      setResolvedTheme(resolved);
+    }
+
+    mediaQuery.addEventListener('change', handleChange);
+    return () => {
+      mediaQuery.removeEventListener('change', handleChange);
+    };
+  }, [theme]);
+
+  function setTheme(newTheme: Theme) {
+    try {
+      localStorage.setItem(STORAGE_KEY, newTheme);
+    } catch {
+      // localStorage not available
+    }
+    setThemeState(newTheme);
+  }
+
+  return React.createElement(
+    ThemeContext.Provider,
+    { value: { theme, setTheme, resolvedTheme } },
+    children
+  );
+}
+
+export function useTheme(): ThemeContextValue {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+}

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -43,6 +43,45 @@
     --sidebar-accent: 30 15% 22%;
     --sidebar-accent-foreground: 30 20% 92%;
   }
+
+  .dark {
+    /* Warm dark theme */
+    --background: 25 15% 10%;
+    --foreground: 30 15% 90%;
+
+    --card: 25 15% 13%;
+    --card-foreground: 30 15% 90%;
+
+    --popover: 25 15% 13%;
+    --popover-foreground: 30 15% 90%;
+
+    /* Amber primary unchanged */
+    --primary: 35 92% 48%;
+    --primary-foreground: 40 100% 98%;
+
+    --secondary: 25 12% 20%;
+    --secondary-foreground: 30 15% 80%;
+
+    --muted: 25 12% 18%;
+    --muted-foreground: 25 10% 55%;
+
+    --accent: 35 30% 20%;
+    --accent-foreground: 35 70% 75%;
+
+    --destructive: 0 72% 51%;
+    --destructive-foreground: 0 0% 98%;
+
+    --border: 25 12% 22%;
+    --input: 25 12% 22%;
+    --ring: 35 92% 48%;
+
+    /* Sidebar — slightly darker than body in dark mode */
+    --sidebar: 25 18% 7%;
+    --sidebar-foreground: 30 15% 80%;
+    --sidebar-border: 25 15% 15%;
+    --sidebar-accent: 25 15% 14%;
+    --sidebar-accent-foreground: 30 20% 88%;
+  }
 }
 
 @layer base {

--- a/apps/frontend/src/main.tsx
+++ b/apps/frontend/src/main.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { AuthProvider } from './hooks/use-auth';
 import { DisplayPreferencesProvider } from './hooks/use-display-preferences';
+import { ThemeProvider } from './hooks/use-theme';
 import { Toaster } from './components/ui/toast';
 import App from './App';
 import './index.css';
@@ -22,12 +23,14 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <QueryClientProvider client={queryClient}>
       <BrowserRouter>
+        <ThemeProvider>
         <DisplayPreferencesProvider>
           <AuthProvider>
             <App />
             <Toaster />
           </AuthProvider>
         </DisplayPreferencesProvider>
+        </ThemeProvider>
       </BrowserRouter>
     </QueryClientProvider>
   </React.StrictMode>

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -366,6 +366,14 @@ Use React's built-in state management (useState, useReducer, useContext) unless 
 
 API data caching and synchronization: use React Query (TanStack Query) for server state management. This handles caching, refetching, pagination, and optimistic updates.
 
+### Theming
+
+Dark mode is implemented via a `dark` class on `<html>`. `ThemeProvider` (`src/hooks/use-theme.ts`) manages the active theme (`'light' | 'dark' | 'system'`), persists it to `localStorage`, and applies or removes the `dark` class on `document.documentElement`. When theme is `'system'`, it follows `prefers-color-scheme`.
+
+Color tokens are defined as CSS custom properties in `src/index.css`. shadcn/ui components consume these tokens automatically. Hardcoded Tailwind color utilities (e.g., `bg-gray-800`) must use explicit `dark:` variants — they do not pick up the CSS variable system.
+
+`ThemeProvider` must wrap the app root in `main.tsx` for `useTheme` to be available anywhere in the tree.
+
 ---
 
 ## Testing Conventions


### PR DESCRIPTION
## Summary

- Adds `ThemeProvider` + `useTheme` hook with `light`/`dark`/`system` modes, `localStorage` persistence, and `prefers-color-scheme` media query support
- Adds flash-prevention inline script to `index.html` so dark-mode users see no white flash on load
- Adds theme toggle dropdown (Sun/Moon/Monitor icons) to the `Header`
- Adds `.dark {}` CSS variable block to `index.css` with warm dark theme matching the existing amber brand palette
- Audits hardcoded Tailwind color utilities across `FileTree`, `BulkActions`, `RecentUploads`, and `UploadProgress` — adds `dark:` variants where needed
- Updates `docs/CONVENTIONS.md` with a Theming subsection

## Test plan

- [ ] Toggle Light/Dark/System from the header dropdown — confirm `dark` class applied/removed on `<html>`
- [ ] Set theme to Dark, reload — confirm no white flash before dark styles apply
- [ ] Set theme to System — confirm it follows `prefers-color-scheme` and updates live if OS preference changes
- [ ] Confirm preference survives page reload via `localStorage`
- [ ] Check BulkActions floating bar hover states in both light and dark mode
- [ ] Check file type icons, status badges, and upload progress indicators for contrast in dark mode

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)