### PR TITLE
fix(search): exclude error and processing models from default library browse

### DIFF
--- a/apps/backend/src/services/search.service.ts
+++ b/apps/backend/src/services/search.service.ts
@@ -141,9 +141,11 @@ export class PostgresSearchService implements ISearchService {
       }
     }
 
-    // Status filter
+    // Status filter — default to 'ready' to exclude processing/error models
     if (params.status) {
       conditions.push(sql`${models.status} = ${params.status}`);
+    } else {
+      conditions.push(sql`${models.status} = 'ready'`);
     }
 
     // File type filter — EXISTS subquery


### PR DESCRIPTION
## Summary

- `SearchService.searchModels` had no default status filter, so models with `status='error'` (failed uploads) and `status='processing'` (in-flight) appeared in the library alongside ready models
- Added a default `status = 'ready'` condition when the caller does not supply an explicit `status` param — callers that need a specific status (e.g. status polling) continue to work unchanged
- Updated 7 search service tests: fixed the one that asserted all-statuses behavior on no filter, and fixed 6 sort/browse tests that referenced the error/processing fixture models

## Test plan

- [ ] `npx vitest run apps/backend/src/services/search.service.test.ts` passes
- [ ] Library browse (no filters) returns only ready models
- [ ] Uploading an archive that fails processing no longer shows the model in the library
- [ ] `GET /models?status=error` still returns error models when explicitly requested

🤖 Generated with [Claude Code](https://claude.com/claude-code)