### PR TITLE
build(docker): add CI workflow and production Dockerfiles

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,49 @@
+name: Build and Push Docker Images
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    strategy:
+      matrix:
+        include:
+          - name: backend
+            dockerfile: docker/Dockerfile.backend
+            image: ghcr.io/rukongai/alexandria-backend
+          - name: frontend
+            dockerfile: docker/Dockerfile.frontend
+            image: ghcr.io/rukongai/alexandria-frontend
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push ${{ matrix.name }} image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: true
+          tags: |
+            ${{ matrix.image }}:latest
+            ${{ matrix.image }}:${{ github.sha }}
+          cache-from: type=gha,scope=${{ matrix.name }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.name }}

--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -1,4 +1,4 @@
-FROM node:22-slim AS base
+FROM node:22-slim AS builder
 WORKDIR /app
 
 # Install build tools for native modules (argon2) and runtime libs for 7zip-bin
@@ -18,11 +18,29 @@ RUN npm ci
 COPY packages/shared/ packages/shared/
 COPY apps/backend/ apps/backend/
 
-# Build shared package
+# Build shared package then backend
 RUN npm run build --workspace=packages/shared
+RUN npm run build --workspace=apps/backend
 
-# Expose port
+FROM node:22-slim AS production
+WORKDIR /app
+
+# Install runtime lib needed by 7zip-bin native binary
+RUN apt-get update && apt-get install -y libstdc++6 && rm -rf /var/lib/apt/lists/*
+
+# Copy root node_modules (includes workspace symlinks for @alexandria/shared)
+COPY --from=builder /app/node_modules ./node_modules
+
+# Copy shared package (symlink target for node_modules/@alexandria/shared)
+COPY --from=builder /app/packages/shared/dist ./packages/shared/dist
+COPY --from=builder /app/packages/shared/package.json ./packages/shared/package.json
+
+# Copy compiled backend
+COPY --from=builder /app/apps/backend/dist ./apps/backend/dist
+COPY --from=builder /app/apps/backend/package.json ./apps/backend/package.json
+
+COPY --from=builder /app/package.json ./package.json
+
 EXPOSE 3000
 
-# Run with tsx for development
-CMD ["npx", "tsx", "apps/backend/src/server.ts"]
+CMD ["node", "apps/backend/dist/server.js"]

--- a/docker/Dockerfile.frontend
+++ b/docker/Dockerfile.frontend
@@ -1,4 +1,4 @@
-FROM node:22-slim AS base
+FROM node:22-slim AS builder
 WORKDIR /app
 
 # Copy workspace root files
@@ -15,13 +15,15 @@ RUN npm ci
 COPY packages/shared/ packages/shared/
 COPY apps/frontend/ apps/frontend/
 
-# Build shared package
+# Build shared package then frontend
 RUN npm run build --workspace=packages/shared
+RUN npm run build --workspace=apps/frontend
 
-# Expose Vite dev port
-EXPOSE 5173
+FROM nginx:stable-alpine AS production
 
-WORKDIR /app/apps/frontend
+COPY --from=builder /app/apps/frontend/dist /usr/share/nginx/html
+COPY docker/nginx.conf /etc/nginx/conf.d/default.conf
 
-# Run Vite dev server (accessible from host)
-CMD ["npx", "vite", "--host", "0.0.0.0"]
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -60,14 +60,12 @@ services:
       context: ..
       dockerfile: docker/Dockerfile.frontend
     ports:
-      - "5173:5173"
-    environment:
-      VITE_API_URL: http://backend:3000
+      - "80:80"
     depends_on:
       backend:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "node -e \"fetch('http://localhost:5173/').then(r => r.ok ? process.exit(0) : process.exit(1)).catch(() => process.exit(1))\""]
+      test: ["CMD-SHELL", "wget -qO- http://localhost/ || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 3

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,0 +1,18 @@
+server {
+    listen 80;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Proxy API requests to backend, stripping the /api prefix
+    location /api/ {
+        proxy_pass http://backend:3000/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+    # SPA routing — serve index.html for all non-file routes
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
## Summary

- Add `.github/workflows/docker-build.yml` — builds and pushes `alexandria-backend` and `alexandria-frontend` images to GHCR on every push to `main`, tagged with both `latest` and the commit SHA; uses GHA layer caching scoped per image
- Convert `Dockerfile.backend` to a multi-stage build: builder stage compiles TypeScript, production stage runs the compiled output via `node` (replaces `tsx` dev transpiler)
- Convert `Dockerfile.frontend` to a multi-stage build: builder stage runs `vite build`, production stage serves the static assets via `nginx:stable-alpine`
- Add `docker/nginx.conf` — proxies `/api/` to the backend (matching the Vite dev proxy rewrite), with SPA fallback routing via `try_files`
- Remove defunct `VITE_API_URL` from docker-compose frontend service (it was only ever the Vite dev server's proxy target, not a runtime variable)
- Update frontend docker-compose port to `80:80`

## Test plan

- [ ] `docker build -f docker/Dockerfile.backend .` builds without errors
- [ ] `docker build -f docker/Dockerfile.frontend .` builds without errors
- [ ] `docker compose -f docker/docker-compose.yml up` starts all four services healthy
- [ ] Frontend loads at `http://localhost` and API calls reach the backend via `/api/`
- [ ] After merging to `main`, confirm GitHub Actions workflow runs and images appear in GHCR

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)