### PR TITLE
fix(docker): copy SQL migrations into backend image

### DIFF
--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -39,6 +39,9 @@ COPY --from=builder /app/packages/shared/package.json ./packages/shared/package.
 COPY --from=builder /app/apps/backend/dist ./apps/backend/dist
 COPY --from=builder /app/apps/backend/package.json ./apps/backend/package.json
 
+# Copy migrations (SQL files are not compiled, must be copied separately)
+COPY --from=builder /app/apps/backend/src/db/migrations ./apps/backend/dist/db/migrations
+
 COPY --from=builder /app/package.json ./package.json
 
 EXPOSE 3000


### PR DESCRIPTION
## Summary

- The `Dockerfile.backend` production stage was missing the SQL migration files — they live in `src/db/migrations/` and are not emitted by `tsc` into `dist/`
- On startup the server calls `drizzle migrate()` pointing at `apps/backend/dist/db/migrations/`, which didn't exist, causing `process.exit(1)` immediately
- Added a `COPY` in the production stage to place migrations at the correct resolved path

## Test plan

- [ ] Build the backend image locally and verify `apps/backend/dist/db/migrations/` exists in the container
- [ ] Deploy the stack via Portainer — backend should start, run migrations, and pass its healthcheck
- [ ] Frontend should follow once backend is healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)