### PR TITLE
fix(backend): add .js extension to schema/index ESM import

### DIFF
--- a/apps/backend/src/db/index.ts
+++ b/apps/backend/src/db/index.ts
@@ -1,6 +1,6 @@
 import { drizzle } from 'drizzle-orm/node-postgres';
 import pg from 'pg';
-import * as schema from './schema/index';
+import * as schema from './schema/index.js';
 import { config } from '../config/index.js';
 
 const { Pool } = pg;


### PR DESCRIPTION
## Summary

- `apps/backend/src/db/index.ts` imported `./schema/index` without the `.js` extension
- Node ESM requires explicit extensions on local imports — the missing `.js` caused `ERR_MODULE_NOT_FOUND` at runtime despite the compiled file existing at the correct path
- This was the second crash preventing the backend container from starting

## Test plan

- [ ] Build and push new backend image
- [ ] Deploy stack via Portainer — backend should pass migrations and reach healthy state

🤖 Generated with [Claude Code](https://claude.com/claude-code)