### PR TITLE
fix(docker): use 127.0.0.1 instead of localhost in healthchecks

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -47,7 +47,7 @@ services:
       redis:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "node -e \"fetch('http://localhost:3000/health').then(r => r.ok ? process.exit(0) : process.exit(1)).catch(() => process.exit(1))\""]
+      test: ["CMD-SHELL", "node -e \"fetch('http://127.0.0.1:3000/health').then(r => r.ok ? process.exit(0) : process.exit(1)).catch(() => process.exit(1))\""]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -61,7 +61,7 @@ services:
       backend:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://localhost/ || exit 1"]
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1/ || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
## Summary

- Alpine containers may resolve `localhost` to `::1` (IPv6 loopback) instead of `127.0.0.1`, causing healthchecks to fail even when the service is listening correctly
- Updated both the backend (`node fetch`) and frontend (`wget`) healthchecks to use `127.0.0.1` explicitly

🤖 Generated with [Claude Code](https://claude.com/claude-code)