### PR TITLE
feat(backend): run seed automatically on startup after migrations

### DIFF
--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -2,6 +2,7 @@ import { migrate } from 'drizzle-orm/node-postgres/migrator';
 import { buildApp } from './app.js';
 import { config } from './config/index.js';
 import { db, pool } from './db/index.js';
+import { runSeed } from './db/seed.js';
 
 async function main(): Promise<void> {
   const app = await buildApp();
@@ -12,6 +13,8 @@ async function main(): Promise<void> {
       migrationsFolder: new URL('./db/migrations', import.meta.url).pathname,
     });
     app.log.info({ service: 'Server' }, 'Database migrations complete');
+    await runSeed();
+    app.log.info({ service: 'Server' }, 'Database seed complete');
   } catch (err) {
     app.log.error({ service: 'Server', err }, 'Database migration failed');
     await pool.end();


### PR DESCRIPTION
## Summary

- Extracted seed logic into an exported `runSeed()` function that `server.ts` calls after migrations
- The seed is idempotent (`onConflictDoNothing`) so running on every startup is safe
- Guarded the standalone script entrypoint with `import.meta.url` check so importing the module doesn't trigger the seed prematurely
- Default credentials on fresh deploy: `admin@alexandria.local` / `changeme` (override via `SEED_ADMIN_EMAIL`, `SEED_ADMIN_PASSWORD`, `SEED_ADMIN_DISPLAY_NAME`)

## Test plan

- [x] Built image locally and verified startup log order: migrations → seed → server listening
- [x] Full stack spun up healthy with `admin@alexandria.local` user created automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)