### PR TITLE
fix(nginx): disable body size limit for API proxy to allow file uploads

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -9,6 +9,7 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        client_max_body_size 0;
     }
 
     # SPA routing — serve index.html for all non-file routes


### PR DESCRIPTION
## Summary

- nginx's default `client_max_body_size` is 1MB, causing 413 errors on any file upload before the request reached Fastify
- Added `client_max_body_size 0;` to the `/api/` proxy location in `docker/nginx.conf`
- Size enforcement is now delegated entirely to Fastify (100MB multipart limit, chunked upload route)

## Test plan

- [ ] Build and start the Docker stack: `docker compose -f docker/docker-compose.yml up -d --build frontend`
- [ ] Upload a file larger than 1MB via the UI — should no longer return 413
- [ ] Confirm files above Fastify's 100MB multipart limit are still rejected (or use chunked upload for large files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)