### PR TITLE
feat(libraries): configurable library storage layout with path templates

### DIFF
--- a/.claude/agents/database.md
+++ b/.claude/agents/database.md
@@ -29,6 +29,7 @@ Read all existing schema files in `apps/backend/src/db/schema/` and the current 
 - Generate migrations using Drizzle Kit after schema changes.
 - Review generated SQL before committing — Drizzle Kit occasionally produces suboptimal migrations.
 - Each migration is forward-only. No down migrations in this project.
+- **Always register new migrations in `apps/backend/src/db/migrations/meta/_journal.json`.** Drizzle's auto-migration runner only applies migrations listed in this journal. A SQL file that exists on disk but is missing from the journal will never be executed, causing `relation does not exist` errors at runtime. After creating a migration file, add the corresponding `{ idx, version, when, tag, breakpoints }` entry to the journal.
 
 ## Seed Data
 

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -33,6 +33,9 @@ Read `docs/ARCHITECTURE.md`, `docs/CONVENTIONS.md`, and `docs/TYPES.md` first. T
 - Logging: are log entries structured with service context?
 - Database: are column and table names `snake_case`?
 
+**Migration hygiene:**
+- For every `.sql` file in `apps/backend/src/db/migrations/`, verify there is a matching entry in `apps/backend/src/db/migrations/meta/_journal.json`. A migration file with no journal entry will never be applied by the auto-migration runner — this causes runtime `relation does not exist` errors that are hard to trace.
+
 **Structural concerns:**
 - Are there utility functions that should be service methods or vice versa?
 - Are there files that don't have a clear home in the documented project structure?

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -11,6 +11,7 @@ import { metadataFieldRoutes, modelMetadataRoute } from './routes/metadata.js';
 import { bulkRoutes } from './routes/bulk.js';
 import { collectionRoutes } from './routes/collections.js';
 import { fileRoutes } from './routes/files.js';
+import { libraryRoutes } from './routes/libraries.js';
 import { startIngestionWorker } from './workers/ingestion.worker.js';
 
 export async function buildApp(): Promise<ReturnType<typeof Fastify>> {
@@ -65,6 +66,7 @@ export async function buildApp(): Promise<ReturnType<typeof Fastify>> {
   await app.register(bulkRoutes, { prefix: '/bulk' });
   await app.register(collectionRoutes, { prefix: '/collections' });
   await app.register(fileRoutes, { prefix: '/files' });
+  await app.register(libraryRoutes, { prefix: '/libraries' });
 
   // Start background workers
   startIngestionWorker();

--- a/apps/backend/src/db/migrations/0005_add_libraries.sql
+++ b/apps/backend/src/db/migrations/0005_add_libraries.sql
@@ -1,0 +1,45 @@
+-- Add libraries table and associate models with libraries (issue #42).
+--
+-- Libraries are admin-managed storage locations. Each library defines a root
+-- filesystem path and a path_template string that controls how models are laid
+-- out on disk within that root (e.g. "{artist}/{year}/{name}").
+--
+-- Libraries are NOT user-owned — they are shared across the system and
+-- administered by site admins.
+--
+-- models.library_id is nullable: existing models pre-date the library system
+-- and have no library assignment. Making it non-nullable here would break every
+-- existing row. Non-nullable enforcement (if ever required) belongs in a future
+-- migration once all models have been assigned.
+--
+-- ON DELETE SET NULL on models.library_id: deleting a library orphans its
+-- models (library_id → NULL) rather than cascading a delete to potentially
+-- thousands of model records.
+
+--> statement-breakpoint
+CREATE TABLE "libraries" (
+  "id"            uuid         NOT NULL DEFAULT gen_random_uuid(),
+  "name"          TEXT         NOT NULL UNIQUE,
+  "slug"          TEXT         NOT NULL,
+  "root_path"     text         NOT NULL,
+  "path_template" text         NOT NULL,
+  "created_at"    timestamptz  NOT NULL DEFAULT now(),
+  "updated_at"    timestamptz  NOT NULL DEFAULT now(),
+  CONSTRAINT "libraries_pkey" PRIMARY KEY ("id")
+);
+--> statement-breakpoint
+-- Lookup libraries by name (admin UI search)
+CREATE INDEX "libraries_name_idx" ON "libraries" ("name");
+--> statement-breakpoint
+-- Unique index on slug for fast slug resolution
+CREATE UNIQUE INDEX "libraries_slug_idx" ON "libraries" ("slug");
+
+--> statement-breakpoint
+ALTER TABLE "models"
+  ADD COLUMN "library_id" uuid
+  REFERENCES "libraries"("id") ON DELETE SET NULL;
+--> statement-breakpoint
+-- FK index: PostgreSQL does not auto-create indexes on FK columns.
+-- Used for listing all models in a library (browse view) and for the
+-- ON DELETE SET NULL scan that clears library_id when a library is removed.
+CREATE INDEX "models_library_id_idx" ON "models" ("library_id");

--- a/apps/backend/src/db/migrations/meta/_journal.json
+++ b/apps/backend/src/db/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1772000000000,
       "tag": "0004_add_preview_crop_scale",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1772100000000,
+      "tag": "0005_add_libraries",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/backend/src/db/schema/index.ts
+++ b/apps/backend/src/db/schema/index.ts
@@ -6,3 +6,4 @@ export * from './thumbnail.js';
 export * from './metadata.js';
 export * from './tag.js';
 export * from './collection.js';
+export * from './library.js';

--- a/apps/backend/src/db/schema/library.ts
+++ b/apps/backend/src/db/schema/library.ts
@@ -1,0 +1,32 @@
+import { pgTable, uuid, text, timestamp, index, uniqueIndex } from 'drizzle-orm/pg-core';
+
+// Libraries table — admin-managed storage locations. A library defines where
+// models are stored on disk and how their paths are structured via a template.
+// Libraries are NOT user-owned; they are configured by administrators and shared
+// across all users in the system.
+export const libraries = pgTable(
+  'libraries',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    // Human-readable display name for the library (e.g., "Main Library")
+    name: text('name').notNull().unique(),
+    // URL-safe slug for the library (e.g., "main-library-a1b2")
+    slug: text('slug').notNull().unique(),
+    // Absolute filesystem path to the library's root storage directory
+    rootPath: text('root_path').notNull(),
+    // Template string controlling how models are laid out within rootPath
+    // (e.g., "{artist}/{year}/{name}" — same syntax as the folder import pattern)
+    pathTemplate: text('path_template').notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => [
+    // Lookup libraries by name (admin UI search)
+    index('libraries_name_idx').on(table.name),
+    // Unique index on slug for fast slug resolution
+    uniqueIndex('libraries_slug_idx').on(table.slug),
+  ],
+);
+
+export type LibraryRow = typeof libraries.$inferSelect;
+export type NewLibraryRow = typeof libraries.$inferInsert;

--- a/apps/backend/src/routes/libraries.ts
+++ b/apps/backend/src/routes/libraries.ts
@@ -1,0 +1,82 @@
+import type { FastifyInstance } from 'fastify';
+import type { CreateLibraryInput, UpdateLibraryInput } from '@alexandria/shared';
+import { createLibrarySchema, updateLibrarySchema } from '@alexandria/shared';
+import { requireAuth } from '../middleware/auth.js';
+import { validate } from '../middleware/validate.js';
+import { libraryService } from '../services/library.service.js';
+
+export async function libraryRoutes(app: FastifyInstance): Promise<void> {
+  // GET / — list all libraries
+  app.get(
+    '/',
+    { preHandler: [requireAuth] },
+    async (_request, reply) => {
+      const libraries = await libraryService.listLibraries();
+
+      return reply.status(200).send({ data: libraries, meta: null, errors: null });
+    },
+  );
+
+  // POST / — create a library
+  app.post(
+    '/',
+    { preHandler: [requireAuth, validate(createLibrarySchema)] },
+    async (request, reply) => {
+      const body = request.body as CreateLibraryInput;
+      const library = await libraryService.createLibrary(body);
+
+      return reply.status(201).send({ data: library, meta: null, errors: null });
+    },
+  );
+
+  // GET /:id — get library by id
+  app.get(
+    '/:id',
+    { preHandler: [requireAuth] },
+    async (request, reply) => {
+      const { id } = request.params as { id: string };
+      const library = await libraryService.getLibraryById(id);
+
+      return reply.status(200).send({ data: library, meta: null, errors: null });
+    },
+  );
+
+  // PATCH /:id — update a library
+  app.patch(
+    '/:id',
+    { preHandler: [requireAuth, validate(updateLibrarySchema)] },
+    async (request, reply) => {
+      const { id } = request.params as { id: string };
+      const body = request.body as UpdateLibraryInput;
+      const library = await libraryService.updateLibrary(id, body);
+
+      return reply.status(200).send({ data: library, meta: null, errors: null });
+    },
+  );
+
+  // DELETE /:id — delete a library
+  app.delete(
+    '/:id',
+    { preHandler: [requireAuth] },
+    async (request, reply) => {
+      const { id } = request.params as { id: string };
+      await libraryService.deleteLibrary(id);
+
+      return reply.status(200).send({ data: null, meta: null, errors: null });
+    },
+  );
+
+  // GET /:id/models — list models in a library
+  app.get(
+    '/:id/models',
+    { preHandler: [requireAuth] },
+    async (request, reply) => {
+      const { id } = request.params as { id: string };
+      // Verify library exists before fetching models
+      await libraryService.getLibraryById(id);
+      const models = await libraryService.getModelsByLibraryId(id);
+
+      return reply.status(200).send({ data: models, meta: null, errors: null });
+    },
+  );
+}

--- a/apps/backend/src/services/file-processing.service.ts
+++ b/apps/backend/src/services/file-processing.service.ts
@@ -367,12 +367,12 @@ export class FileProcessingService {
 
   async copyManifestToStorage(
     extractDir: string,
-    modelId: string,
     manifest: FileManifest,
     storage: IStorageService,
+    getStoragePath: (relativePath: string) => string,
   ): Promise<void> {
     for (const entry of manifest.entries) {
-      const storagePath = `models/${modelId}/${entry.relativePath}`;
+      const storagePath = getStoragePath(entry.relativePath);
       const sourcePath = path.join(extractDir, entry.relativePath);
       const readStream = fs.createReadStream(sourcePath);
       await storage.store(storagePath, readStream);

--- a/apps/backend/src/services/ingestion.service.ts
+++ b/apps/backend/src/services/ingestion.service.ts
@@ -156,6 +156,7 @@ export class IngestionService {
       pattern: importConfig.pattern,
       strategy: importConfig.strategy,
       userId,
+      ...(importConfig.libraryId !== undefined && { libraryId: importConfig.libraryId }),
     });
 
     logger.info({ jobId, sourcePath: importConfig.sourcePath, pattern: importConfig.pattern }, 'Folder import job enqueued');
@@ -165,7 +166,7 @@ export class IngestionService {
   async processFolderImportJob(
     job: Job<FolderImportJobPayload>,
   ): Promise<void> {
-    const { sourcePath, pattern, strategy, userId } = job.data;
+    const { sourcePath, pattern, strategy, userId, libraryId } = job.data;
     const parsedPattern = parsePattern(pattern);
     const importStrategy = createImportStrategy(strategy);
 
@@ -188,7 +189,7 @@ export class IngestionService {
 
       for (const model of discovered) {
         try {
-          await this.processDiscoveredModel(model, importStrategy, userId, job);
+          await this.processDiscoveredModel(model, importStrategy, userId, job, libraryId);
           processed++;
         } catch (err) {
           failed++;
@@ -265,6 +266,7 @@ export class IngestionService {
     importStrategy: import('./import-strategy.service.js').IImportStrategy,
     userId: string,
     job: Job,
+    libraryId?: string,
   ): Promise<void> {
     const slug = generateSlug(discovered.name);
 
@@ -275,6 +277,7 @@ export class IngestionService {
       userId,
       sourceType: 'folder_import',
       status: 'processing',
+      ...(libraryId !== undefined && { libraryId }),
     });
 
     try {

--- a/apps/backend/src/services/job.service.ts
+++ b/apps/backend/src/services/job.service.ts
@@ -8,6 +8,9 @@ export interface IngestionJobPayload {
   tempFilePath: string;
   originalFilename: string;
   userId: string;
+  libraryId: string;
+  modelSlug: string;
+  metadata?: Record<string, string>;
 }
 
 export interface FolderImportJobPayload {
@@ -15,7 +18,7 @@ export interface FolderImportJobPayload {
   pattern: string;
   strategy: ImportStrategy;
   userId: string;
-  libraryId?: string;
+  libraryId: string;
 }
 
 const INGESTION_QUEUE = 'ingestion';

--- a/apps/backend/src/services/job.service.ts
+++ b/apps/backend/src/services/job.service.ts
@@ -15,6 +15,7 @@ export interface FolderImportJobPayload {
   pattern: string;
   strategy: ImportStrategy;
   userId: string;
+  libraryId?: string;
 }
 
 const INGESTION_QUEUE = 'ingestion';

--- a/apps/backend/src/services/library.service.ts
+++ b/apps/backend/src/services/library.service.ts
@@ -1,0 +1,189 @@
+import { eq, asc } from 'drizzle-orm';
+import type { Library as LibraryApi } from '@alexandria/shared';
+import { pathTemplateSchema } from '@alexandria/shared';
+import type { CreateLibraryInput, UpdateLibraryInput } from '@alexandria/shared';
+import { db } from '../db/index.js';
+import type { Database } from '../db/index.js';
+import { libraries, models } from '../db/schema/index.js';
+import { notFound, conflict, validationError } from '../utils/errors.js';
+import { createLogger } from '../utils/logger.js';
+import { generateSlug } from '../utils/slug.js';
+
+type LibraryRow = typeof libraries.$inferSelect;
+
+const logger = createLogger('LibraryService');
+
+function toLibrary(row: LibraryRow): LibraryApi {
+  return {
+    id: row.id,
+    name: row.name,
+    slug: row.slug,
+    rootPath: row.rootPath,
+    pathTemplate: row.pathTemplate,
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+  };
+}
+
+export class LibraryService {
+  constructor(private readonly database: Database) {}
+
+  async listLibraries(): Promise<LibraryApi[]> {
+    logger.info({ service: 'LibraryService' }, 'Listing all libraries');
+
+    const rows = await this.database
+      .select()
+      .from(libraries)
+      .orderBy(asc(libraries.createdAt));
+
+    return rows.map(toLibrary);
+  }
+
+  async getLibraryById(id: string): Promise<LibraryApi> {
+    logger.info({ service: 'LibraryService', libraryId: id }, 'Getting library by id');
+
+    const [row] = await this.database
+      .select()
+      .from(libraries)
+      .where(eq(libraries.id, id))
+      .limit(1);
+
+    if (!row) {
+      throw notFound(`Library not found: ${id}`);
+    }
+
+    return toLibrary(row);
+  }
+
+  async createLibrary(input: CreateLibraryInput): Promise<LibraryApi> {
+    logger.info({ service: 'LibraryService', name: input.name }, 'Creating library');
+
+    const templateResult = pathTemplateSchema.safeParse(input.pathTemplate);
+    if (!templateResult.success) {
+      throw validationError(
+        templateResult.error.errors[0]?.message ?? 'Invalid path template',
+        'pathTemplate',
+      );
+    }
+
+    const slug = generateSlug(input.name);
+
+    let row: LibraryRow;
+    try {
+      const [inserted] = await this.database
+        .insert(libraries)
+        .values({
+          name: input.name,
+          slug,
+          rootPath: input.rootPath,
+          pathTemplate: input.pathTemplate,
+        })
+        .returning();
+      row = inserted;
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (message.includes('unique') || message.includes('duplicate')) {
+        throw conflict(`A library named "${input.name}" already exists`);
+      }
+      throw err;
+    }
+
+    logger.info({ service: 'LibraryService', libraryId: row.id }, 'Library created');
+
+    return toLibrary(row);
+  }
+
+  async updateLibrary(id: string, input: UpdateLibraryInput): Promise<LibraryApi> {
+    logger.info({ service: 'LibraryService', libraryId: id }, 'Updating library');
+
+    const [current] = await this.database
+      .select()
+      .from(libraries)
+      .where(eq(libraries.id, id))
+      .limit(1);
+
+    if (!current) {
+      throw notFound(`Library not found: ${id}`);
+    }
+
+    if (input.pathTemplate !== undefined) {
+      const templateResult = pathTemplateSchema.safeParse(input.pathTemplate);
+      if (!templateResult.success) {
+        throw validationError(
+          templateResult.error.errors[0]?.message ?? 'Invalid path template',
+          'pathTemplate',
+        );
+      }
+    }
+
+    const updateValues: Partial<{
+      name: string;
+      rootPath: string;
+      pathTemplate: string;
+      updatedAt: Date;
+    }> = {
+      updatedAt: new Date(),
+    };
+
+    if (input.name !== undefined) updateValues.name = input.name;
+    // NOTE: Updating rootPath or pathTemplate does not retroactively re-path models
+    // already stored at the old path. This is a known limitation for MVP.
+    if (input.rootPath !== undefined) updateValues.rootPath = input.rootPath;
+    if (input.pathTemplate !== undefined) updateValues.pathTemplate = input.pathTemplate;
+
+    let updated: LibraryRow;
+    try {
+      const [result] = await this.database
+        .update(libraries)
+        .set(updateValues)
+        .where(eq(libraries.id, id))
+        .returning();
+      updated = result;
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (message.includes('unique') || message.includes('duplicate')) {
+        throw conflict(`A library named "${input.name}" already exists`);
+      }
+      throw err;
+    }
+
+    logger.info({ service: 'LibraryService', libraryId: id }, 'Library updated');
+
+    return toLibrary(updated);
+  }
+
+  async deleteLibrary(id: string): Promise<void> {
+    logger.info({ service: 'LibraryService', libraryId: id }, 'Deleting library');
+
+    const [row] = await this.database
+      .select({ id: libraries.id })
+      .from(libraries)
+      .where(eq(libraries.id, id))
+      .limit(1);
+
+    if (!row) {
+      throw notFound(`Library not found: ${id}`);
+    }
+
+    await this.database.delete(libraries).where(eq(libraries.id, id));
+
+    logger.info({ service: 'LibraryService', libraryId: id }, 'Library deleted');
+  }
+
+  // Returns model IDs for models assigned to a library.
+  // Full model card assembly (thumbnails, metadata) requires PresenterService
+  // integration and is deferred to a future phase.
+  async getModelsByLibraryId(libraryId: string): Promise<string[]> {
+    logger.info({ service: 'LibraryService', libraryId }, 'Getting models by library id');
+
+    const rows = await this.database
+      .select({ id: models.id })
+      .from(models)
+      .where(eq(models.libraryId, libraryId))
+      .orderBy(asc(models.createdAt));
+
+    return rows.map((r) => r.id);
+  }
+}
+
+export const libraryService = new LibraryService(db);

--- a/apps/backend/src/services/model.service.ts
+++ b/apps/backend/src/services/model.service.ts
@@ -12,6 +12,7 @@ export interface CreateModelData {
   sourceType: ModelSourceType;
   status: ModelStatus;
   originalFilename?: string;
+  libraryId?: string;
 }
 
 export interface CreateModelFileData {
@@ -49,6 +50,7 @@ export class ModelService {
         sourceType: data.sourceType,
         status: data.status,
         originalFilename: data.originalFilename ?? null,
+        libraryId: data.libraryId ?? null,
       })
       .returning({ id: models.id });
 

--- a/apps/backend/src/workers/ingestion.worker.ts
+++ b/apps/backend/src/workers/ingestion.worker.ts
@@ -18,7 +18,7 @@ export function startIngestionWorker(): void {
   ingestionWorker = new Worker(
     INGESTION_QUEUE,
     async (job: Job<IngestionJobPayload>) => {
-      const { modelId, tempFilePath, userId } = job.data;
+      const { modelId, tempFilePath, userId, libraryId, modelSlug, metadata } = job.data;
 
       logger.info({ jobId: job.id, modelId }, 'Ingestion job started');
 
@@ -28,6 +28,9 @@ export function startIngestionWorker(): void {
         tempFilePath,
         userId,
         job,
+        libraryId,
+        modelSlug,
+        metadata,
       );
 
       logger.info({ jobId: job.id, modelId }, 'Ingestion job completed');

--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import { CollectionsPage } from './pages/CollectionsPage';
 import { CollectionDetailPage } from './pages/CollectionDetailPage';
 import { SettingsPage } from './pages/SettingsPage';
 import { UploadPage } from './pages/UploadPage';
+import { LibrariesPage } from './pages/LibrariesPage';
 
 function ProtectedRoute({ children }: { children: React.ReactNode }) {
   const { isAuthenticated, isLoading } = useAuth();
@@ -46,6 +47,7 @@ export default function App() {
         <Route path="collections/:id" element={<CollectionDetailPage />} />
         <Route path="upload" element={<UploadPage />} />
         <Route path="settings" element={<SettingsPage />} />
+        <Route path="libraries" element={<LibrariesPage />} />
       </Route>
       {/* Catch-all */}
       <Route path="*" element={<Navigate to="/" replace />} />

--- a/apps/frontend/src/api/libraries.ts
+++ b/apps/frontend/src/api/libraries.ts
@@ -1,0 +1,29 @@
+import type {
+  ApiResponse,
+  Library,
+  CreateLibraryRequest,
+  UpdateLibraryRequest,
+} from '@alexandria/shared';
+import { get, post, patch, del } from './client';
+
+export async function getLibraries(): Promise<ApiResponse<Library[]>> {
+  return get<Library[]>('/libraries');
+}
+
+export async function getLibrary(id: string): Promise<ApiResponse<Library>> {
+  return get<Library>(`/libraries/${id}`);
+}
+
+export async function createLibrary(data: CreateLibraryRequest): Promise<Library> {
+  const response = await post<Library>('/libraries', data);
+  return response.data;
+}
+
+export async function updateLibrary(id: string, data: UpdateLibraryRequest): Promise<Library> {
+  const response = await patch<Library>(`/libraries/${id}`, data);
+  return response.data;
+}
+
+export async function deleteLibrary(id: string): Promise<void> {
+  await del(`/libraries/${id}`);
+}

--- a/apps/frontend/src/api/models.ts
+++ b/apps/frontend/src/api/models.ts
@@ -54,6 +54,8 @@ const MAX_CHUNK_RETRIES = 3;
 
 export async function uploadModel(
   file: File,
+  libraryId: string,
+  metadata?: Record<string, string>,
   onProgress?: (pct: number) => void
 ): Promise<{ modelId: string }> {
   const totalChunks = Math.max(1, Math.ceil(file.size / CHUNK_SIZE));
@@ -61,7 +63,7 @@ export async function uploadModel(
   // 1. Initiate chunked upload session
   const initResponse = await post<{ uploadId: string; expiresAt: string }>(
     '/models/upload/init',
-    { filename: file.name, totalSize: file.size, totalChunks },
+    { filename: file.name, totalSize: file.size, totalChunks, libraryId, ...(metadata ? { metadata } : {}) },
   );
   const { uploadId } = initResponse.data;
 

--- a/apps/frontend/src/components/layout/Sidebar.tsx
+++ b/apps/frontend/src/components/layout/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { NavLink } from 'react-router-dom';
-import { LayoutGrid, FolderOpen, Upload, Settings, BookOpen, ChevronLeft, ChevronRight } from 'lucide-react';
+import { LayoutGrid, FolderOpen, Upload, Settings, BookOpen, Database, ChevronLeft, ChevronRight } from 'lucide-react';
 import { cn } from '../../lib/utils';
 
 interface NavItem {
@@ -11,6 +11,7 @@ interface NavItem {
 const navItems: NavItem[] = [
   { label: 'Library', to: '/', icon: LayoutGrid },
   { label: 'Collections', to: '/collections', icon: FolderOpen },
+  { label: 'Libraries', to: '/libraries', icon: Database },
   { label: 'Upload', to: '/upload', icon: Upload },
   { label: 'Settings', to: '/settings', icon: Settings },
 ];

--- a/apps/frontend/src/components/libraries/LibraryDialog.tsx
+++ b/apps/frontend/src/components/libraries/LibraryDialog.tsx
@@ -1,0 +1,188 @@
+import { useEffect, useState } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import type { Library, CreateLibraryRequest, UpdateLibraryRequest } from '@alexandria/shared';
+import { pathTemplateSchema } from '@alexandria/shared';
+import { createLibrary, updateLibrary } from '../../api/libraries';
+import { useToast } from '../../hooks/use-toast';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '../ui/dialog';
+import { Button } from '../ui/button';
+import { Input } from '../ui/input';
+import { Label } from '../ui/label';
+
+interface LibraryDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  library?: Library;
+  onSuccess?: (library: Library) => void;
+}
+
+export function LibraryDialog({ open, onOpenChange, library, onSuccess }: LibraryDialogProps) {
+  const isEdit = !!library;
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  const [name, setName] = useState('');
+  const [rootPath, setRootPath] = useState('');
+  const [pathTemplate, setPathTemplate] = useState('');
+  const [pathTemplateError, setPathTemplateError] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    if (open) {
+      setName(library?.name ?? '');
+      setRootPath(library?.rootPath ?? '');
+      setPathTemplate(library?.pathTemplate ?? '');
+      setPathTemplateError(undefined);
+    }
+  }, [open, library]);
+
+  const createMutation = useMutation({
+    mutationFn: (data: CreateLibraryRequest) => createLibrary(data),
+    onSuccess: (result) => {
+      queryClient.invalidateQueries({ queryKey: ['libraries'] });
+      toast({ title: 'Library created' });
+      onOpenChange(false);
+      onSuccess?.(result);
+    },
+    onError: () => {
+      toast({ title: 'Failed to create library', variant: 'destructive' });
+    },
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: (data: UpdateLibraryRequest) => updateLibrary(library!.id, data),
+    onSuccess: (result) => {
+      queryClient.invalidateQueries({ queryKey: ['libraries'] });
+      toast({ title: 'Library updated' });
+      onOpenChange(false);
+      onSuccess?.(result);
+    },
+    onError: () => {
+      toast({ title: 'Failed to update library', variant: 'destructive' });
+    },
+  });
+
+  const isLoading = createMutation.isPending || updateMutation.isPending;
+
+  function validatePathTemplate(value: string): string | undefined {
+    const result = pathTemplateSchema.safeParse(value);
+    if (!result.success) {
+      return result.error.errors[0]?.message ?? 'Invalid path template';
+    }
+    return undefined;
+  }
+
+  function handlePathTemplateChange(value: string) {
+    setPathTemplate(value);
+    if (pathTemplateError) {
+      setPathTemplateError(validatePathTemplate(value));
+    }
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+
+    const templateError = validatePathTemplate(pathTemplate);
+    if (templateError) {
+      setPathTemplateError(templateError);
+      return;
+    }
+
+    if (isEdit) {
+      updateMutation.mutate({
+        name: name.trim(),
+        rootPath: rootPath.trim(),
+        pathTemplate: pathTemplate.trim(),
+      });
+    } else {
+      createMutation.mutate({
+        name: name.trim(),
+        rootPath: rootPath.trim(),
+        pathTemplate: pathTemplate.trim(),
+      });
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>{isEdit ? 'Edit Library' : 'New Library'}</DialogTitle>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="library-name">Name</Label>
+            <Input
+              id="library-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="e.g. Main Library"
+              required
+              autoFocus
+            />
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="library-root-path">Root Path</Label>
+            <Input
+              id="library-root-path"
+              value={rootPath}
+              onChange={(e) => setRootPath(e.target.value)}
+              placeholder="/data/libraries"
+              required
+            />
+            <p className="text-xs text-muted-foreground">
+              Absolute path on the server filesystem where this library's files will be stored.
+            </p>
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="library-path-template">Path Template</Label>
+            <Input
+              id="library-path-template"
+              value={pathTemplate}
+              onChange={(e) => handlePathTemplateChange(e.target.value)}
+              placeholder="{library}/{model}"
+              required
+            />
+            {pathTemplateError ? (
+              <p className="text-xs text-destructive">{pathTemplateError}</p>
+            ) : (
+              <p className="text-xs text-muted-foreground">
+                Defines the folder structure inside the root path.{' '}
+                <span className="font-mono">{'{library}'}</span> must be first,{' '}
+                <span className="font-mono">{'{model}'}</span> must be last. Use{' '}
+                <span className="font-mono">{'{metadata.<slug>}'}</span> for metadata-based
+                subfolders in between (e.g.{' '}
+                <span className="font-mono">{'{library}/{metadata.artist}/{model}'}</span>).
+              </p>
+            )}
+          </div>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={isLoading}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              disabled={isLoading || !name.trim() || !rootPath.trim() || !pathTemplate.trim()}
+            >
+              {isLoading ? 'Saving...' : isEdit ? 'Save Changes' : 'Create Library'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/frontend/src/components/upload/DropZone.tsx
+++ b/apps/frontend/src/components/upload/DropZone.tsx
@@ -1,144 +1,206 @@
 import { useCallback, useRef, useState } from 'react';
-import { UploadCloud, FileArchive, X } from 'lucide-react';
+import { useQuery } from '@tanstack/react-query';
+import { Link } from 'react-router-dom';
+import { UploadCloud, FileArchive, X, AlertCircle } from 'lucide-react';
 import { SUPPORTED_ARCHIVE_EXTENSIONS } from '@alexandria/shared';
+import type { Library, MetadataFieldDetail } from '@alexandria/shared';
 import { uploadModel } from '../../api/models';
+import { getLibraries } from '../../api/libraries';
+import { getFields } from '../../api/metadata';
 import { formatFileSize } from '../../lib/format';
 import { cn } from '../../lib/utils';
 import { Button } from '../ui/button';
+import { Label } from '../ui/label';
+import { Input } from '../ui/input';
+import { Select } from '../ui/select';
 import { UploadProgress } from './UploadProgress';
 
 type UploadState =
-  | { phase: 'idle' }
-  | { phase: 'selected'; file: File }
-  | { phase: 'uploading'; file: File; pct: number }
+  | { phase: 'loading' }
+  | { phase: 'no_library' }
+  | { phase: 'idle'; selectedLibraryId: string; metadataValues: Record<string, string> }
+  | { phase: 'selected'; file: File; selectedLibraryId: string; metadataValues: Record<string, string> }
+  | { phase: 'uploading'; file: File; pct: number; selectedLibraryId: string; metadataValues: Record<string, string> }
   | { phase: 'processing'; file: File; modelId: string }
-  | { phase: 'error'; file: File; message: string };
+  | { phase: 'error'; file?: File; message: string; selectedLibraryId: string; metadataValues: Record<string, string> };
+
+function extractMetadataSlugs(template: string): string[] {
+  return [...template.matchAll(/\{metadata\.([a-z0-9_-]+)\}/g)].map(m => m[1]);
+}
 
 export function DropZone() {
-  const [state, setState] = useState<UploadState>({ phase: 'idle' });
+  const [state, setState] = useState<UploadState>({ phase: 'loading' });
   const [isDragging, setIsDragging] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const selectFile = useCallback((file: File) => {
-    const lower = file.name.toLowerCase();
-    if (!SUPPORTED_ARCHIVE_EXTENSIONS.some((ext) => lower.endsWith(ext))) {
-      setState({ phase: 'error', file, message: 'Only .zip, .rar, .7z, and .tar.gz archives are supported.' });
+  const { data: libraries, isLoading: librariesLoading } = useQuery<Library[]>({
+    queryKey: ['libraries'],
+    queryFn: () => getLibraries().then(r => r.data),
+    staleTime: 60_000,
+  });
+
+  const { data: allFields = [] } = useQuery<MetadataFieldDetail[]>({
+    queryKey: ['metadata-fields'],
+    queryFn: getFields,
+    staleTime: 60_000,
+  });
+
+  // Transition from loading once libraries arrive
+  if (state.phase === 'loading' && !librariesLoading && libraries !== undefined) {
+    if (libraries.length === 0) {
+      setState({ phase: 'no_library' });
+    } else {
+      setState({ phase: 'idle', selectedLibraryId: '', metadataValues: {} });
+    }
+  }
+
+  const selectedLibraryId =
+    state.phase !== 'loading' && state.phase !== 'no_library' && state.phase !== 'processing'
+      ? state.selectedLibraryId
+      : '';
+
+  const metadataValues =
+    state.phase !== 'loading' && state.phase !== 'no_library' && state.phase !== 'processing'
+      ? state.metadataValues
+      : {};
+
+  const selectedLibrary = libraries?.find(l => l.id === selectedLibraryId) ?? null;
+  const requiredSlugs = selectedLibrary ? extractMetadataSlugs(selectedLibrary.pathTemplate) : [];
+
+  const allMetadataFilled =
+    selectedLibraryId !== '' &&
+    requiredSlugs.every(slug => (metadataValues[slug] ?? '').trim().length > 0);
+
+  const hasFile = state.phase === 'selected' || state.phase === 'error';
+  const file = (state.phase === 'selected' || (state.phase === 'error' && state.file)) ? (state as { file: File }).file : null;
+
+  const canUpload = allMetadataFilled && file !== null && state.phase === 'selected';
+
+  const handleLibraryChange = useCallback((e: React.ChangeEvent<HTMLSelectElement>) => {
+    const id = e.target.value;
+    setState(prev => {
+      if (prev.phase === 'loading' || prev.phase === 'no_library' || prev.phase === 'processing') return prev;
+      return { ...prev, selectedLibraryId: id, metadataValues: {} };
+    });
+  }, []);
+
+  const handleMetadataChange = useCallback((slug: string, value: string) => {
+    setState(prev => {
+      if (prev.phase === 'loading' || prev.phase === 'no_library' || prev.phase === 'processing') return prev;
+      return { ...prev, metadataValues: { ...prev.metadataValues, [slug]: value } };
+    });
+  }, []);
+
+  const selectFile = useCallback((f: File) => {
+    const lower = f.name.toLowerCase();
+    if (!SUPPORTED_ARCHIVE_EXTENSIONS.some(ext => lower.endsWith(ext))) {
+      setState(prev => {
+        if (prev.phase === 'loading' || prev.phase === 'no_library' || prev.phase === 'processing') return prev;
+        return {
+          phase: 'error',
+          file: f,
+          message: 'Only .zip, .rar, .7z, and .tar.gz archives are supported.',
+          selectedLibraryId: prev.selectedLibraryId,
+          metadataValues: prev.metadataValues,
+        };
+      });
       return;
     }
-    setState({ phase: 'selected', file });
+    setState(prev => {
+      if (prev.phase === 'loading' || prev.phase === 'no_library' || prev.phase === 'processing') return prev;
+      return { phase: 'selected', file: f, selectedLibraryId: prev.selectedLibraryId, metadataValues: prev.metadataValues };
+    });
   }, []);
 
-  const startUpload = useCallback(async (file: File) => {
-    setState({ phase: 'uploading', file, pct: 0 });
+  const clearFile = useCallback(() => {
+    setState(prev => {
+      if (prev.phase === 'loading' || prev.phase === 'no_library' || prev.phase === 'processing') return prev;
+      return { phase: 'idle', selectedLibraryId: prev.selectedLibraryId, metadataValues: prev.metadataValues };
+    });
+  }, []);
+
+  const startUpload = useCallback(async (f: File, libId: string, metaValues: Record<string, string>) => {
+    const filteredMeta: Record<string, string> = {};
+    for (const [k, v] of Object.entries(metaValues)) {
+      if (v.trim().length > 0) filteredMeta[k] = v;
+    }
+    setState({ phase: 'uploading', file: f, pct: 0, selectedLibraryId: libId, metadataValues: metaValues });
     try {
-      const { modelId } = await uploadModel(file, (pct) => {
-        setState({ phase: 'uploading', file, pct });
+      const { modelId } = await uploadModel(f, libId, filteredMeta, (pct) => {
+        setState(prev => prev.phase === 'uploading' ? { ...prev, pct } : prev);
       });
-      setState({ phase: 'processing', file, modelId });
+      setState({ phase: 'processing', file: f, modelId });
     } catch (err: unknown) {
-      const message =
-        err instanceof Error ? err.message : 'Upload failed. Please try again.';
-      setState({ phase: 'error', file, message });
+      const message = err instanceof Error ? err.message : 'Upload failed. Please try again.';
+      setState({ phase: 'error', file: f, message, selectedLibraryId: libId, metadataValues: metaValues });
     }
   }, []);
 
-  const handleDrop = useCallback(
-    (e: React.DragEvent) => {
-      e.preventDefault();
-      setIsDragging(false);
-      const file = e.dataTransfer.files[0];
-      if (file) selectFile(file);
-    },
-    [selectFile]
-  );
-
-  const handleDragOver = (e: React.DragEvent) => {
+  const handleDrop = useCallback((e: React.DragEvent) => {
     e.preventDefault();
-    setIsDragging(true);
-  };
+    setIsDragging(false);
+    const f = e.dataTransfer.files[0];
+    if (f) selectFile(f);
+  }, [selectFile]);
 
+  const handleDragOver = (e: React.DragEvent) => { e.preventDefault(); setIsDragging(true); };
   const handleDragLeave = () => setIsDragging(false);
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (file) selectFile(file);
-    // reset so re-selecting the same file triggers onChange
+    const f = e.target.files?.[0];
+    if (f) selectFile(f);
     e.target.value = '';
   };
 
   const reset = () => {
-    setState({ phase: 'idle' });
+    setState({ phase: 'idle', selectedLibraryId: selectedLibraryId, metadataValues: {} });
   };
 
-  // Idle/drop zone
-  if (state.phase === 'idle') {
+  // Loading state
+  if (state.phase === 'loading') {
     return (
-      <div
-        onDrop={handleDrop}
-        onDragOver={handleDragOver}
-        onDragLeave={handleDragLeave}
-        onClick={() => inputRef.current?.click()}
-        className={cn(
-          'flex flex-col items-center justify-center gap-4 rounded-xl border-2 border-dashed p-16 cursor-pointer transition-colors',
-          isDragging
-            ? 'border-primary bg-primary/5'
-            : 'border-border bg-muted/30 hover:border-primary/60 hover:bg-muted/50'
-        )}
-        role="button"
-        tabIndex={0}
-        aria-label="Upload archive file"
-        onKeyDown={(e) => {
-          if (e.key === 'Enter' || e.key === ' ') inputRef.current?.click();
-        }}
-      >
-        <UploadCloud
-          className={cn(
-            'h-12 w-12 transition-colors',
-            isDragging ? 'text-primary' : 'text-muted-foreground/60'
-          )}
-        />
-        <div className="text-center space-y-1">
-          <p className="text-base font-medium text-foreground">
-            Drag &amp; drop an archive here, or click to browse
-          </p>
-          <p className="text-sm text-muted-foreground">Supports .zip, .rar, .7z, and .tar.gz archives</p>
-        </div>
-        <input
-          ref={inputRef}
-          type="file"
-          accept=".zip,.rar,.7z,.tar.gz,.tgz,application/zip,application/x-rar-compressed,application/x-7z-compressed,application/x-tar"
-          className="sr-only"
-          onChange={handleInputChange}
-          tabIndex={-1}
-        />
+      <div className="rounded-xl border bg-muted/30 p-12 flex items-center justify-center">
+        <div className="h-8 w-8 rounded-full border-2 border-primary border-t-transparent animate-spin" />
       </div>
     );
   }
 
-  // File selected — confirm before upload
-  if (state.phase === 'selected') {
+  // No libraries — blocking gate
+  if (state.phase === 'no_library') {
+    return (
+      <div className="rounded-xl border border-amber-500/40 bg-amber-50 dark:bg-amber-950/20 p-6 flex items-start gap-3">
+        <AlertCircle className="h-5 w-5 text-amber-600 dark:text-amber-400 shrink-0 mt-0.5" />
+        <div className="space-y-2">
+          <p className="text-sm font-medium text-amber-800 dark:text-amber-300">No libraries configured</p>
+          <p className="text-sm text-amber-700 dark:text-amber-400">
+            You need to create a library before uploading models.
+          </p>
+          <Link
+            to="/libraries"
+            className="inline-block text-sm font-medium text-primary hover:underline"
+          >
+            Go to Libraries
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  // Processing
+  if (state.phase === 'processing') {
     return (
       <div className="rounded-xl border bg-card p-6 space-y-4">
         <div className="flex items-start gap-3">
           <FileArchive className="h-8 w-8 text-primary shrink-0 mt-0.5" />
           <div className="flex-1 min-w-0">
             <p className="text-sm font-medium truncate">{state.file.name}</p>
-            <p className="text-xs text-muted-foreground">{formatFileSize(state.file.size)}</p>
+            <p className="text-xs text-muted-foreground">Upload complete — processing job running</p>
           </div>
-          <button
-            onClick={reset}
-            className="text-muted-foreground hover:text-foreground transition-colors"
-            aria-label="Remove selected file"
-          >
-            <X className="h-4 w-4" />
-          </button>
         </div>
-        <div className="flex gap-2">
-          <Button onClick={() => startUpload(state.file)}>Upload</Button>
-          <Button variant="outline" onClick={reset}>
-            Cancel
-          </Button>
-        </div>
+        <UploadProgress modelId={state.modelId} />
+        <Button variant="outline" size="sm" onClick={() => setState({ phase: 'idle', selectedLibraryId: selectedLibraryId, metadataValues: {} })}>
+          Upload another
+        </Button>
       </div>
     );
   }
@@ -170,38 +232,113 @@ export function DropZone() {
     );
   }
 
-  // Processing (upload done, job running)
-  if (state.phase === 'processing') {
-    return (
-      <div className="rounded-xl border bg-card p-6 space-y-4">
-        <div className="flex items-start gap-3">
-          <FileArchive className="h-8 w-8 text-primary shrink-0 mt-0.5" />
-          <div className="flex-1 min-w-0">
-            <p className="text-sm font-medium truncate">{state.file.name}</p>
-            <p className="text-xs text-muted-foreground">Upload complete — processing job running</p>
-          </div>
-        </div>
-        <UploadProgress modelId={state.modelId} />
-        <Button variant="outline" size="sm" onClick={reset}>
-          Upload another
-        </Button>
-      </div>
-    );
-  }
+  // idle, selected, error — main form UI
+  const currentFile = state.phase === 'selected' ? state.file : state.phase === 'error' ? state.file : undefined;
 
-  // Error
   return (
-    <div className="rounded-xl border border-destructive/40 bg-destructive/5 p-6 space-y-3">
-      <div className="flex items-start gap-3">
-        <FileArchive className="h-8 w-8 text-destructive/60 shrink-0 mt-0.5" />
-        <div className="flex-1 min-w-0">
-          <p className="text-sm font-medium truncate">{state.file.name}</p>
-          <p className="text-sm text-destructive mt-1">{state.message}</p>
-        </div>
+    <div className="space-y-4">
+      {/* Library selector */}
+      <div className="space-y-1.5">
+        <Label htmlFor="library-select">Library</Label>
+        <Select
+          id="library-select"
+          value={selectedLibraryId}
+          onChange={handleLibraryChange}
+          disabled={false}
+        >
+          <option value="" disabled>Select a library</option>
+          {(libraries ?? []).map(lib => (
+            <option key={lib.id} value={lib.id}>{lib.name}</option>
+          ))}
+        </Select>
       </div>
-      <Button variant="outline" size="sm" onClick={reset}>
-        Try again
-      </Button>
+
+      {/* Required metadata fields */}
+      {selectedLibraryId && requiredSlugs.map(slug => {
+        const field = allFields.find(f => f.slug === slug);
+        const displayName = field?.name ?? slug;
+        return (
+          <div key={slug} className="space-y-1.5">
+            <Label htmlFor={`meta-${slug}`}>{displayName}</Label>
+            <Input
+              id={`meta-${slug}`}
+              value={metadataValues[slug] ?? ''}
+              onChange={e => handleMetadataChange(slug, e.target.value)}
+              placeholder={`Enter ${displayName}`}
+            />
+          </div>
+        );
+      })}
+
+      {/* Error message (validation) */}
+      {state.phase === 'error' && (
+        <div className="flex items-start gap-2 rounded-lg border border-destructive/40 bg-destructive/5 px-3 py-3 text-sm text-destructive">
+          <AlertCircle className="h-4 w-4 shrink-0 mt-0.5" />
+          <span>{state.message}</span>
+        </div>
+      )}
+
+      {/* Drop zone */}
+      <div
+        onDrop={handleDrop}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onClick={() => inputRef.current?.click()}
+        className={cn(
+          'flex flex-col items-center justify-center gap-4 rounded-xl border-2 border-dashed p-12 cursor-pointer transition-colors',
+          isDragging ? 'border-primary bg-primary/5' : 'border-border bg-muted/30 hover:border-primary/60 hover:bg-muted/50'
+        )}
+        role="button"
+        tabIndex={0}
+        aria-label="Upload archive file"
+        onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') inputRef.current?.click(); }}
+      >
+        {currentFile ? (
+          <div className="flex items-center gap-3">
+            <FileArchive className="h-6 w-6 text-primary" />
+            <div>
+              <p className="text-sm font-medium">{currentFile.name}</p>
+              <p className="text-xs text-muted-foreground">{formatFileSize(currentFile.size)}</p>
+            </div>
+            <button
+              onClick={e => { e.stopPropagation(); clearFile(); }}
+              aria-label="Remove file"
+              className="text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+        ) : (
+          <>
+            <UploadCloud className={cn('h-10 w-10', isDragging ? 'text-primary' : 'text-muted-foreground/60')} />
+            <p className="text-sm text-muted-foreground">Drag &amp; drop or click to select archive</p>
+          </>
+        )}
+        <input
+          ref={inputRef}
+          type="file"
+          className="sr-only"
+          onChange={handleInputChange}
+          tabIndex={-1}
+          accept=".zip,.rar,.7z,.tar.gz,.tgz"
+        />
+      </div>
+
+      <div className="flex gap-2">
+        <Button
+          onClick={() => {
+            if (file) startUpload(file, selectedLibraryId, metadataValues);
+          }}
+          disabled={!canUpload}
+        >
+          Upload
+        </Button>
+        {hasFile && (
+          <Button variant="outline" onClick={reset}>
+            Cancel
+          </Button>
+        )}
+      </div>
     </div>
   );
 }

--- a/apps/frontend/src/pages/LibrariesPage.tsx
+++ b/apps/frontend/src/pages/LibrariesPage.tsx
@@ -1,0 +1,180 @@
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { Plus, Pencil, Trash2, Database } from 'lucide-react';
+import type { Library } from '@alexandria/shared';
+import { getLibraries, deleteLibrary } from '../api/libraries';
+import { useToast } from '../hooks/use-toast';
+import { LibraryDialog } from '../components/libraries/LibraryDialog';
+import { AlertDialog } from '../components/ui/alert-dialog';
+import { Button } from '../components/ui/button';
+import { Skeleton } from '../components/ui/skeleton';
+
+export function LibrariesPage() {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  const [createOpen, setCreateOpen] = useState(false);
+  const [editTarget, setEditTarget] = useState<Library | undefined>(undefined);
+  const [deleteTarget, setDeleteTarget] = useState<Library | undefined>(undefined);
+
+  const { data: libraries, isLoading } = useQuery({
+    queryKey: ['libraries'],
+    queryFn: () => getLibraries(),
+    select: (res) => res.data,
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => deleteLibrary(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['libraries'] });
+      toast({ title: 'Library deleted' });
+      setDeleteTarget(undefined);
+    },
+    onError: () => {
+      toast({ title: 'Failed to delete library', variant: 'destructive' });
+    },
+  });
+
+  return (
+    <div className="flex flex-col gap-8 max-w-4xl">
+      <div>
+        <h1 className="text-2xl font-bold text-foreground">Libraries</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Manage storage libraries and their folder layout templates.
+        </p>
+      </div>
+
+      <section className="flex flex-col gap-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <h2 className="text-base font-semibold text-foreground">Storage Libraries</h2>
+            <p className="text-sm text-muted-foreground">
+              Each library defines a root path and how models are organized within it.
+            </p>
+          </div>
+          <Button size="sm" onClick={() => setCreateOpen(true)}>
+            <Plus className="h-4 w-4 mr-1.5" />
+            New Library
+          </Button>
+        </div>
+
+        <div className="rounded-xl border overflow-hidden">
+          {isLoading ? (
+            <div className="flex flex-col divide-y">
+              {Array.from({ length: 3 }).map((_, i) => (
+                <div key={i} className="flex items-center gap-4 px-4 py-4">
+                  <Skeleton className="h-4 w-40" />
+                  <Skeleton className="h-4 w-48" />
+                  <Skeleton className="h-4 w-32 ml-auto" />
+                </div>
+              ))}
+            </div>
+          ) : !libraries || libraries.length === 0 ? (
+            <div className="flex flex-col items-center justify-center py-12 gap-3 text-center">
+              <Database className="h-10 w-10 text-muted-foreground/40" />
+              <div>
+                <p className="text-sm font-medium text-foreground">No libraries yet</p>
+                <p className="text-sm text-muted-foreground mt-1">
+                  Create a library to define where models are stored.
+                </p>
+              </div>
+              <Button size="sm" onClick={() => setCreateOpen(true)}>
+                <Plus className="h-4 w-4 mr-1.5" />
+                Create your first library
+              </Button>
+            </div>
+          ) : (
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b bg-muted/30">
+                  <th className="text-left font-medium text-muted-foreground px-4 py-2.5">Name</th>
+                  <th className="text-left font-medium text-muted-foreground px-4 py-2.5">
+                    Root Path
+                  </th>
+                  <th className="text-left font-medium text-muted-foreground px-4 py-2.5">
+                    Path Template
+                  </th>
+                  <th className="px-4 py-2.5" />
+                </tr>
+              </thead>
+              <tbody className="divide-y">
+                {libraries.map((lib) => (
+                  <LibraryRow
+                    key={lib.id}
+                    library={lib}
+                    onEdit={() => setEditTarget(lib)}
+                    onDelete={() => setDeleteTarget(lib)}
+                  />
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+      </section>
+
+      <LibraryDialog open={createOpen} onOpenChange={setCreateOpen} />
+
+      {editTarget && (
+        <LibraryDialog
+          open={!!editTarget}
+          onOpenChange={(open) => {
+            if (!open) setEditTarget(undefined);
+          }}
+          library={editTarget}
+        />
+      )}
+
+      {deleteTarget && (
+        <AlertDialog
+          open={!!deleteTarget}
+          onOpenChange={(open) => {
+            if (!open) setDeleteTarget(undefined);
+          }}
+          title={`Delete "${deleteTarget.name}"?`}
+          description="This library definition will be removed. Files already stored on disk will not be deleted."
+          confirmLabel="Delete Library"
+          destructive
+          isLoading={deleteMutation.isPending}
+          onConfirm={() => deleteMutation.mutate(deleteTarget.id)}
+        />
+      )}
+    </div>
+  );
+}
+
+interface LibraryRowProps {
+  library: Library;
+  onEdit: () => void;
+  onDelete: () => void;
+}
+
+function LibraryRow({ library, onEdit, onDelete }: LibraryRowProps) {
+  return (
+    <tr className="hover:bg-muted/20 transition-colors">
+      <td className="px-4 py-3">
+        <span className="font-medium text-foreground">{library.name}</span>
+      </td>
+      <td className="px-4 py-3 font-mono text-xs text-muted-foreground">
+        {library.rootPath}
+      </td>
+      <td className="px-4 py-3 font-mono text-xs text-muted-foreground">
+        {library.pathTemplate}
+      </td>
+      <td className="px-4 py-3">
+        <div className="flex items-center justify-end gap-1">
+          <Button variant="ghost" size="icon" className="h-7 w-7" onClick={onEdit}>
+            <Pencil className="h-3.5 w-3.5" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7 text-destructive hover:text-destructive"
+            onClick={onDelete}
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+          </Button>
+        </div>
+      </td>
+    </tr>
+  );
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -168,6 +168,14 @@ No other service knows about this routing. To every consumer, tags are just anot
 
 Collections are an organizational structure, not metadata. A model's relationship to a collection is about where you put it, not what it is. This is why collections remain a separate entity while Artist and Tags moved into the metadata system.
 
+### LibraryService
+
+**Owns:** Library CRUD — creating, reading, updating, and deleting Library records. Admin-managed.
+
+**Does not own:** File I/O, model ingestion, path resolution execution.
+
+**Behavior:** Provides CRUD operations for Library entities. Libraries are admin-managed storage hierarchies with configurable path templates. Library names are unique. Updating rootPath or pathTemplate does not retroactively re-path already-stored models (known MVP limitation).
+
 ### AuthService
 
 **Owns:** User CRUD, password hashing, authentication, session creation and validation.
@@ -280,6 +288,16 @@ Collections are an organizational structure, not metadata. A model's relationshi
 | POST | /bulk/collection | Add/remove models from collections | CollectionService |
 | POST | /bulk/delete | Delete multiple models | ModelService → StorageService |
 
+**Libraries**
+| Method | Route | Purpose | Service Chain |
+|--------|-------|---------|---------------|
+| GET | /libraries | List all libraries | LibraryService |
+| POST | /libraries | Create library | LibraryService |
+| GET | /libraries/:id | Library detail | LibraryService |
+| PATCH | /libraries/:id | Update library | LibraryService |
+| DELETE | /libraries/:id | Delete library | LibraryService |
+| GET | /libraries/:id/models | Model IDs in library | LibraryService |
+
 ---
 
 ## Decision Log
@@ -321,3 +339,6 @@ All API responses use `{ data, meta, errors }`. No raw arrays, no inconsistent s
 
 ### D12: Services never format HTTP responses
 Services throw typed errors or return domain data. Routes and middleware handle HTTP status codes and envelope formatting. Services have no knowledge of HTTP.
+
+### D13: Libraries are admin-managed storage namespaces
+Libraries own the physical storage layout for model files. They are not user-scoped — a single library can hold models from any user. Library path templates control where files physically live on disk. The `{library}` token in a path template resolves to the library's name at import time; renaming a library after models are stored does not re-path existing files. This is a known MVP limitation that may be addressed in a future phase alongside Issue #43 (library ACL and per-user collection scoping).

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -298,6 +298,16 @@ logger.info(`Processing started for model ${modelId} in job ${jobId}`);
 - Join tables have composite primary keys on both foreign keys.
 - Indexes: created explicitly for foreign keys, slug fields, and any column used in WHERE clauses or JOINs. The schema file documents why each index exists.
 
+### Migrations
+
+Migration SQL files live in `apps/backend/src/db/migrations/`. **Every new migration file must also be registered in `apps/backend/src/db/migrations/meta/_journal.json`** — Drizzle's auto-migration runner reads only this journal to determine which migrations are pending. A SQL file that exists on disk but is not in the journal will never be applied.
+
+When adding a migration:
+1. Create the SQL file (e.g., `0006_my_change.sql`)
+2. Add the corresponding entry to `_journal.json` with the correct `idx`, `tag` (filename without `.sql`), and a `when` timestamp
+
+Migrations are forward-only. No down migrations in this project.
+
 ### Slug Generation
 
 Slugs are generated from names using a consistent utility function:

--- a/docs/TYPES.md
+++ b/docs/TYPES.md
@@ -51,6 +51,7 @@ interface Model {
   fileCount: number;
   fileHash: string | null;
   previewImageFileId: string | null; // user-selected cover image; null = first-image fallback
+  libraryId: string | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -165,6 +166,20 @@ interface Collection {
 ```
 
 Join table `collection_models`: `{ collectionId: string, modelId: string }`
+
+### Library
+
+```typescript
+interface Library {
+  id: string;
+  name: string;
+  slug: string;
+  rootPath: string;
+  pathTemplate: string;
+  createdAt: string;
+  updatedAt: string;
+}
+```
 
 ---
 
@@ -314,6 +329,18 @@ interface CollectionDetail {
   updatedAt: string;
 }
 ```
+
+### Library Response Types
+
+```typescript
+interface LibrarySummary {
+  id: string;
+  name: string;
+  slug: string;
+}
+```
+
+`LibraryDetail` was removed as it was identical to `Library` — the `Library` domain type is returned directly for full detail responses.
 
 ### Auth Response Types
 
@@ -474,6 +501,22 @@ interface BulkDeleteRequest {
 }
 ```
 
+### Library Requests
+
+```typescript
+interface CreateLibraryRequest {
+  name: string;
+  rootPath: string;  // absolute filesystem path
+  pathTemplate: string;  // e.g. "{library}/{metadata.artist}/{model}"
+}
+
+interface UpdateLibraryRequest {
+  name?: string;
+  rootPath?: string;
+  pathTemplate?: string;
+}
+```
+
 ### Query Parameters
 
 ```typescript
@@ -539,8 +582,10 @@ User ──owns──→ Model ──has many──→ ModelFile ──has many�
   │               ├──has many──→ model_tags ──references──→ Tag
   │               │             (optimized metadata storage)
   │               │
-  │               └──many to many──→ Collection ──self-references──→ Collection
-  │                   (via collection_models)     (via parentCollectionId)
+  │               ├──many to many──→ Collection ──self-references──→ Collection
+  │               │   (via collection_models)     (via parentCollectionId)
+  │               │
+  │               └──belongs to (optional)──→ Library
   │
   └──owns──→ Collection
 ```

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -3,3 +3,4 @@ export * from './model.js';
 export * from './metadata.js';
 export * from './collection.js';
 export * from './api.js';
+export * from './library.js';

--- a/packages/shared/src/types/library.ts
+++ b/packages/shared/src/types/library.ts
@@ -1,0 +1,27 @@
+export interface Library {
+  id: string;
+  name: string;
+  slug: string;
+  rootPath: string;
+  pathTemplate: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface LibrarySummary {
+  id: string;
+  name: string;
+  slug: string;
+}
+
+export interface CreateLibraryRequest {
+  name: string;
+  rootPath: string;
+  pathTemplate: string;
+}
+
+export interface UpdateLibraryRequest {
+  name?: string;
+  rootPath?: string;
+  pathTemplate?: string;
+}

--- a/packages/shared/src/types/model.ts
+++ b/packages/shared/src/types/model.ts
@@ -8,6 +8,7 @@ export interface Model {
   slug: string;
   description: string | null;
   userId: string;
+  libraryId: string | null;
   sourceType: ModelSourceType;
   status: ModelStatus;
   originalFilename: string | null;
@@ -124,6 +125,7 @@ export interface ImportConfig {
   pattern: string;
   strategy: ImportStrategy;
   deleteAfterUpload?: boolean;
+  libraryId?: string;
 }
 
 export interface ParsedPatternSegment {

--- a/packages/shared/src/types/model.ts
+++ b/packages/shared/src/types/model.ts
@@ -120,14 +120,6 @@ export interface JobStatus {
 export type ImportStrategy = 'hardlink' | 'copy' | 'move';
 export type ImportPhase = 'scanning' | 'importing' | 'processing' | 'complete' | 'error';
 
-export interface ImportConfig {
-  sourcePath: string;
-  pattern: string;
-  strategy: ImportStrategy;
-  deleteAfterUpload?: boolean;
-  libraryId?: string;
-}
-
 export interface ParsedPatternSegment {
   type: 'collection' | 'metadata' | 'model';
   metadataSlug?: string;

--- a/packages/shared/src/validation/import.ts
+++ b/packages/shared/src/validation/import.ts
@@ -5,4 +5,5 @@ export const importConfigSchema = z.object({
   pattern: z.string().min(1, 'Pattern is required'),
   strategy: z.enum(['hardlink', 'copy', 'move']),
   deleteAfterUpload: z.boolean().optional(),
+  libraryId: z.string().uuid().optional(),
 });

--- a/packages/shared/src/validation/import.ts
+++ b/packages/shared/src/validation/import.ts
@@ -5,5 +5,7 @@ export const importConfigSchema = z.object({
   pattern: z.string().min(1, 'Pattern is required'),
   strategy: z.enum(['hardlink', 'copy', 'move']),
   deleteAfterUpload: z.boolean().optional(),
-  libraryId: z.string().uuid().optional(),
+  libraryId: z.string().uuid(),
 });
+
+export type ImportConfig = z.infer<typeof importConfigSchema>;

--- a/packages/shared/src/validation/index.ts
+++ b/packages/shared/src/validation/index.ts
@@ -5,3 +5,4 @@ export * from './import.js';
 export * from './search.js';
 export * from './collection.js';
 export * from './upload.js';
+export * from './library.js';

--- a/packages/shared/src/validation/library.test.ts
+++ b/packages/shared/src/validation/library.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from 'vitest';
+import { createLibrarySchema } from './library.js';
+
+describe('createLibrarySchema — pathTemplate validation', () => {
+  it('should pass for template {library}/{metadata.artist}/{model}', () => {
+    const result = createLibrarySchema.safeParse({
+      name: 'My Library',
+      rootPath: '/data/models',
+      pathTemplate: '{library}/{metadata.artist}/{model}',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('should pass for template /data/{library}/{metadata.category}/{metadata.artist}/{model}', () => {
+    const result = createLibrarySchema.safeParse({
+      name: 'My Library',
+      rootPath: '/data/models',
+      pathTemplate: '/data/{library}/{metadata.category}/{metadata.artist}/{model}',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('should pass for minimal template {library}/{model}', () => {
+    const result = createLibrarySchema.safeParse({
+      name: 'My Library',
+      rootPath: '/data/models',
+      pathTemplate: '{library}/{model}',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('should fail when {library} is missing from template', () => {
+    const result = createLibrarySchema.safeParse({
+      name: 'My Library',
+      rootPath: '/data/models',
+      pathTemplate: '{metadata.artist}/{model}',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should fail when {model} is not the last token', () => {
+    const result = createLibrarySchema.safeParse({
+      name: 'My Library',
+      rootPath: '/data/models',
+      pathTemplate: '{library}/{model}/{metadata.artist}',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should fail when {model} is missing entirely', () => {
+    const result = createLibrarySchema.safeParse({
+      name: 'My Library',
+      rootPath: '/data/models',
+      pathTemplate: '{library}/{metadata.artist}',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should fail when {library} appears after another variable token', () => {
+    const result = createLibrarySchema.safeParse({
+      name: 'My Library',
+      rootPath: '/data/models',
+      pathTemplate: '{metadata.artist}/{library}/{model}',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should fail with empty template string', () => {
+    const result = createLibrarySchema.safeParse({
+      name: 'My Library',
+      rootPath: '/data/models',
+      pathTemplate: '',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should fail when template has no tokens at all', () => {
+    const result = createLibrarySchema.safeParse({
+      name: 'My Library',
+      rootPath: '/data/models',
+      pathTemplate: 'just/a/plain/path',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should fail when an intermediate token is not a metadata slug', () => {
+    const result = createLibrarySchema.safeParse({
+      name: 'My Library',
+      rootPath: '/data/models',
+      pathTemplate: '{library}/{unknown_token}/{model}',
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('createLibrarySchema — name validation', () => {
+  it('should fail when name is empty', () => {
+    const result = createLibrarySchema.safeParse({
+      name: '',
+      rootPath: '/data/models',
+      pathTemplate: '{library}/{model}',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should pass when name is a non-empty string', () => {
+    const result = createLibrarySchema.safeParse({
+      name: 'Valid Name',
+      rootPath: '/data/models',
+      pathTemplate: '{library}/{model}',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('should fail when name is missing', () => {
+    const result = createLibrarySchema.safeParse({
+      rootPath: '/data/models',
+      pathTemplate: '{library}/{model}',
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('createLibrarySchema — rootPath validation', () => {
+  it('should fail when rootPath is empty', () => {
+    const result = createLibrarySchema.safeParse({
+      name: 'My Library',
+      rootPath: '',
+      pathTemplate: '{library}/{model}',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should pass when rootPath is a non-empty string', () => {
+    const result = createLibrarySchema.safeParse({
+      name: 'My Library',
+      rootPath: '/some/path',
+      pathTemplate: '{library}/{model}',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('should fail when rootPath is missing', () => {
+    const result = createLibrarySchema.safeParse({
+      name: 'My Library',
+      pathTemplate: '{library}/{model}',
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/shared/src/validation/library.ts
+++ b/packages/shared/src/validation/library.ts
@@ -1,0 +1,64 @@
+import { z } from 'zod';
+
+function validatePathTemplate(template: string): boolean {
+  if (!template) return false;
+
+  const tokenPattern = /\{([^}]+)\}/g;
+  const tokens: string[] = [];
+  let match: RegExpExecArray | null;
+
+  while ((match = tokenPattern.exec(template)) !== null) {
+    tokens.push(match[1]);
+  }
+
+  if (tokens.length === 0) return false;
+
+  if (!tokens.includes('library')) return false;
+
+  if (tokens[tokens.length - 1] !== 'model') return false;
+
+  const libraryIndex = tokens.indexOf('library');
+
+  if (libraryIndex !== 0) return false;
+
+  const metadataSlugPattern = /^metadata\.[a-z0-9-]+$/;
+  for (let i = 1; i < tokens.length - 1; i++) {
+    if (!metadataSlugPattern.test(tokens[i])) return false;
+  }
+
+  return true;
+}
+
+export const pathTemplateSchema = z
+  .string()
+  .min(1)
+  .refine(validatePathTemplate, {
+    message:
+      'Path template must start with {library}, end with {model}, and intermediate tokens must be {metadata.<slug>} where slug is lowercase alphanumeric + hyphens',
+  });
+
+export const createLibrarySchema = z.object({
+  name: z.string().min(1).max(255),
+  rootPath: z
+    .string()
+    .min(1)
+    .refine((v) => v.startsWith('/'), { message: 'rootPath must be an absolute path starting with /' }),
+  pathTemplate: pathTemplateSchema,
+});
+
+export const updateLibrarySchema = z
+  .object({
+    name: z.string().min(1).max(255).optional(),
+    rootPath: z
+      .string()
+      .min(1)
+      .refine((v) => v.startsWith('/'), { message: 'rootPath must be an absolute path starting with /' })
+      .optional(),
+    pathTemplate: pathTemplateSchema.optional(),
+  })
+  .refine((data) => Object.keys(data).length > 0, {
+    message: 'At least one field must be provided',
+  });
+
+export type CreateLibraryInput = z.infer<typeof createLibrarySchema>;
+export type UpdateLibraryInput = z.infer<typeof updateLibrarySchema>;

--- a/packages/shared/src/validation/upload.ts
+++ b/packages/shared/src/validation/upload.ts
@@ -11,6 +11,8 @@ export const uploadInitSchema = z.object({
   ),
   totalSize: z.number().int().positive().max(5 * 1024 * 1024 * 1024), // 5GB
   totalChunks: z.number().int().positive().max(1000),
+  libraryId: z.string().uuid(),
+  metadata: z.record(z.string()).optional(),
 });
 
 export const chunkIndexParamsSchema = z.object({

--- a/packages/shared/vitest.config.ts
+++ b/packages/shared/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    exclude: ['dist/**', 'node_modules/**'],
+  },
+});


### PR DESCRIPTION
## Summary

- Adds the `Library` entity — an admin-managed storage hierarchy with a configurable `pathTemplate` that controls where model files physically live on disk
- Path templates support `{library}`, `{model}`, and `{metadata.<slug>}` tokens with validation rules: `{library}` must precede other variable tokens, `{model}` must be last
- Libraries are not user-owned (no `user_id`) — admin-managed, as specified for consumption by issue #43

## Changes

**Database**
- New `libraries` table: `id`, `name` (unique), `slug`, `root_path`, `path_template`, `created_at`, `updated_at`
- `models` gains nullable `library_id` FK with `ON DELETE SET NULL`
- Migration: `0005_add_libraries.sql`

**Shared package**
- `Library`, `LibrarySummary`, `CreateLibraryRequest`, `UpdateLibraryRequest` types
- `createLibrarySchema` / `updateLibrarySchema` Zod schemas with full path template validation
- `libraryId?: string` added to `ImportConfig` and `Model`

**Backend**
- `LibraryService`: full CRUD with slug generation, unique name enforcement (DB constraint + AppError)
- `StorageService`: `resolveModelPath()` for template resolution + `sanitizePathSegment()` with path traversal prevention
- `IngestionService` / `JobService` / `ModelService`: optional `libraryId` threading through folder import pipeline
- Routes: `GET/POST/PATCH/DELETE /libraries` + `GET /libraries/:id/models` (returns model UUIDs; full ModelCard assembly deferred pending PresenterService integration)

**Frontend**
- `src/api/libraries.ts` — typed API client
- `LibraryDialog` component — create/edit form with client-side path template validation via shared Zod schema
- `LibrariesPage` — admin table with loading/empty states
- Sidebar "Libraries" link + App router entry

**Documentation**
- `TYPES.md` — Library entity, response types, request types, Type Relationship Map updated
- `ARCHITECTURE.md` — LibraryService inventory, Libraries route map, Decision Log D13
- `API.md` — full Libraries section with all 6 endpoints documented

## Tests

53 tests passing:
- `sanitizePathSegment` — 13 unit tests
- `resolveModelPath` — 10 unit tests (including path traversal prevention)
- `createLibrarySchema` / path template Zod validation — 16 unit tests (including `packages/shared` vitest setup)
- Existing 14 StorageService tests still passing

## Cross-issue dependency

Per the issue: the `Library` entity deliberately omits `user_id` to satisfy the ACL model described in issue #43 (libraries as storage hierarchies + per-user collections). Neither should merge without the other being accounted for.

## Test plan

- [ ] Run `npx vitest run` — all 53 feature tests pass
- [ ] Apply migration (`0005_add_libraries.sql`) to a dev DB and verify table structure
- [ ] Create a library via `POST /libraries` with a valid path template
- [ ] Verify template validation rejects bad templates (missing `{library}`, `{model}` not last)
- [ ] Verify `DELETE /library/:id` NULLs `models.library_id` rather than deleting models
- [ ] Verify `GET /libraries/:id/models` returns an array of model UUIDs
- [ ] Open the Libraries page in the frontend — create, edit, delete a library

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #42