### PR TITLE
feat(frontend): Model Detail redesign + 3D STL viewer (P2)

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -15,6 +15,8 @@
     "@fontsource/inter": "^5.2.8",
     "@fontsource/inter-tight": "^5.2.7",
     "@fontsource/jetbrains-mono": "^5.2.8",
+    "@react-three/drei": "^10.7.7",
+    "@react-three/fiber": "^9.6.1",
     "@tanstack/react-query": "^5.90.21",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
@@ -22,7 +24,8 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router-dom": "^7.13.0",
-    "tailwind-merge": "^3.5.0"
+    "tailwind-merge": "^3.5.0",
+    "three": "^0.184.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.9.1",
@@ -30,6 +33,7 @@
     "@testing-library/user-event": "^14.6.1",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
+    "@types/three": "^0.184.1",
     "@vitejs/plugin-react": "^4.3.0",
     "autoprefixer": "^10.4.0",
     "jsdom": "^28.1.0",

--- a/apps/frontend/src/components/icons/index.ts
+++ b/apps/frontend/src/components/icons/index.ts
@@ -18,4 +18,6 @@ export {
   ChevronRight as ChevronRightIcon,
   Plus as AddIcon,
   X as CloseIcon,
+  Box as Model3DIcon,
+  RotateCcw as ResetViewIcon,
 } from 'lucide-react';

--- a/apps/frontend/src/components/models/CollectionsList.tsx
+++ b/apps/frontend/src/components/models/CollectionsList.tsx
@@ -25,7 +25,7 @@ export function CollectionsList({ collections }: CollectionsListProps) {
                   to={`/collections/${col.id}`}
                   className="flex items-center gap-2 text-sm text-foreground hover:text-primary transition-colors py-0.5 group"
                 >
-                  <FolderOpen className="h-4 w-4 text-amber-500 flex-shrink-0 group-hover:text-primary transition-colors" />
+                  <FolderOpen className="h-4 w-4 text-muted-foreground flex-shrink-0 group-hover:text-primary transition-colors" />
                   <span className="truncate">{col.name}</span>
                 </Link>
               </li>

--- a/apps/frontend/src/components/models/FileTree.test.tsx
+++ b/apps/frontend/src/components/models/FileTree.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { FileTreeNode } from '@alexandria/shared';
+import { FileTree } from './FileTree';
+
+const TREE: FileTreeNode[] = [
+  {
+    name: 'parts',
+    type: 'directory',
+    children: [
+      { name: 'body.stl', type: 'file', fileType: 'stl', sizeBytes: 100, id: 's1' },
+    ],
+  },
+  { name: 'readme.txt', type: 'file', fileType: 'document', sizeBytes: 10, id: 'd1' },
+];
+
+describe('FileTree', () => {
+  it('fires onOpenStl with the reconstructed relative path for a nested STL', () => {
+    const onOpenStl = vi.fn();
+    render(<FileTree tree={TREE} modelId="m1" onOpenStl={onOpenStl} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /view body\.stl in 3d/i }));
+
+    expect(onOpenStl).toHaveBeenCalledWith({
+      name: 'body.stl',
+      relativePath: 'parts/body.stl',
+      url: '/api/files/models/m1/parts/body.stl',
+    });
+  });
+
+  it('shows no 3D affordance when onOpenStl is omitted', () => {
+    render(<FileTree tree={TREE} modelId="m1" />);
+    expect(screen.queryByRole('button', { name: /in 3d/i })).not.toBeInTheDocument();
+  });
+
+  it('only offers 3D on STL files, not other file types', () => {
+    const onOpenStl = vi.fn();
+    render(<FileTree tree={TREE} modelId="m1" onOpenStl={onOpenStl} />);
+    // readme.txt is a document — no 3D button for it
+    expect(screen.getAllByRole('button', { name: /in 3d/i })).toHaveLength(1);
+  });
+});

--- a/apps/frontend/src/components/models/FileTree.tsx
+++ b/apps/frontend/src/components/models/FileTree.tsx
@@ -10,19 +10,25 @@ import {
 import type { FileTreeNode, FileType } from '@alexandria/shared';
 import { formatFileSize } from '../../lib/format';
 import { cn } from '../../lib/utils';
+import { Model3DIcon } from '../icons';
+import { makeStlRef, type StlFileRef } from '../../lib/model-files';
 
 interface FileNodeProps {
   node: FileTreeNode;
   depth: number;
+  /** Ancestor directory names, used to reconstruct STL relative paths. */
+  pathPrefix: string[];
+  modelId: string;
+  onOpenStl?: (stl: StlFileRef) => void;
   defaultExpanded?: boolean;
 }
 
 function FileIcon({ fileType }: { fileType?: FileType }) {
   switch (fileType) {
     case 'stl':
-      return <Box className="h-4 w-4 text-amber-600 dark:text-amber-500 flex-shrink-0" />;
+      return <Box className="h-4 w-4 text-primary flex-shrink-0" />;
     case 'image':
-      return <Image className="h-4 w-4 text-blue-500 flex-shrink-0" />;
+      return <Image className="h-4 w-4 text-accent-foreground flex-shrink-0" />;
     case 'document':
       return <FileText className="h-4 w-4 text-muted-foreground flex-shrink-0" />;
     default:
@@ -30,7 +36,14 @@ function FileIcon({ fileType }: { fileType?: FileType }) {
   }
 }
 
-function FileNode({ node, depth, defaultExpanded = false }: FileNodeProps) {
+function FileNode({
+  node,
+  depth,
+  pathPrefix,
+  modelId,
+  onOpenStl,
+  defaultExpanded = false,
+}: FileNodeProps) {
   const [expanded, setExpanded] = React.useState(defaultExpanded);
   const paddingLeft = depth * 16;
 
@@ -43,9 +56,9 @@ function FileNode({ node, depth, defaultExpanded = false }: FileNodeProps) {
           style={{ paddingLeft: `${paddingLeft + 8}px` }}
         >
           {expanded ? (
-            <FolderOpen className="h-4 w-4 text-amber-500 flex-shrink-0" />
+            <FolderOpen className="h-4 w-4 text-muted-foreground flex-shrink-0" />
           ) : (
-            <Folder className="h-4 w-4 text-amber-500 flex-shrink-0" />
+            <Folder className="h-4 w-4 text-muted-foreground flex-shrink-0" />
           )}
           <span className="font-medium text-foreground truncate">{node.name}</span>
           {node.children && (
@@ -57,7 +70,14 @@ function FileNode({ node, depth, defaultExpanded = false }: FileNodeProps) {
         {expanded && node.children && (
           <div>
             {node.children.map((child, i) => (
-              <FileNode key={`${child.name}-${i}`} node={child} depth={depth + 1} />
+              <FileNode
+                key={`${child.name}-${i}`}
+                node={child}
+                depth={depth + 1}
+                pathPrefix={[...pathPrefix, node.name]}
+                modelId={modelId}
+                onOpenStl={onOpenStl}
+              />
             ))}
           </div>
         )}
@@ -65,13 +85,27 @@ function FileNode({ node, depth, defaultExpanded = false }: FileNodeProps) {
     );
   }
 
+  const isStl = node.fileType === 'stl';
+  const canView3D = isStl && Boolean(onOpenStl);
+
   return (
     <div
-      className="flex items-center gap-1.5 py-1 px-2 rounded hover:bg-muted/40 text-sm"
+      className="flex items-center gap-1.5 py-1 px-2 rounded hover:bg-muted/40 text-sm group"
       style={{ paddingLeft: `${paddingLeft + 8}px` }}
     >
       <FileIcon fileType={node.fileType} />
       <span className="truncate text-foreground flex-1 min-w-0">{node.name}</span>
+      {canView3D && (
+        <button
+          type="button"
+          onClick={() => onOpenStl!(makeStlRef(modelId, [...pathPrefix, node.name]))}
+          className="flex items-center gap-1 flex-shrink-0 rounded-full px-2 py-0.5 text-xs font-medium text-primary opacity-0 group-hover:opacity-100 focus:opacity-100 hover:bg-primary/10 transition-all"
+          aria-label={`View ${node.name} in 3D`}
+        >
+          <Model3DIcon className="h-3.5 w-3.5" />
+          3D
+        </button>
+      )}
       {node.sizeBytes !== undefined && (
         <span className="text-xs text-muted-foreground flex-shrink-0 ml-2">
           {formatFileSize(node.sizeBytes)}
@@ -95,9 +129,12 @@ function countFiles(nodes: FileTreeNode[]): number {
 
 interface FileTreeProps {
   tree: FileTreeNode[];
+  modelId: string;
+  /** When provided, STL rows show a "view in 3D" affordance. */
+  onOpenStl?: (stl: StlFileRef) => void;
 }
 
-export function FileTree({ tree }: FileTreeProps) {
+export function FileTree({ tree, modelId, onOpenStl }: FileTreeProps) {
   const totalFiles = countFiles(tree);
 
   return (
@@ -115,6 +152,9 @@ export function FileTree({ tree }: FileTreeProps) {
               key={`${node.name}-${i}`}
               node={node}
               depth={0}
+              pathPrefix={[]}
+              modelId={modelId}
+              onOpenStl={onOpenStl}
               defaultExpanded={true}
             />
           ))

--- a/apps/frontend/src/components/models/ModelBreadcrumb.test.tsx
+++ b/apps/frontend/src/components/models/ModelBreadcrumb.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import type { CollectionSummary } from '@alexandria/shared';
+import { ModelBreadcrumb } from './ModelBreadcrumb';
+
+function renderBreadcrumb(props: {
+  collection: CollectionSummary | null;
+  modelName: string;
+}) {
+  return render(
+    <MemoryRouter>
+      <ModelBreadcrumb {...props} />
+    </MemoryRouter>,
+  );
+}
+
+describe('ModelBreadcrumb', () => {
+  it('renders Library and the model name when there is no collection', () => {
+    renderBreadcrumb({ collection: null, modelName: 'Ancient Wyrm' });
+
+    const nav = screen.getByRole('navigation', { name: 'Model breadcrumb' });
+    expect(nav).toBeInTheDocument();
+    expect(screen.getByText('Library')).toBeInTheDocument();
+    expect(screen.getByText('Ancient Wyrm')).toBeInTheDocument();
+    // No collection crumb
+    expect(screen.queryByText('Dragons')).not.toBeInTheDocument();
+  });
+
+  it('renders a linked collection crumb when present', () => {
+    renderBreadcrumb({
+      collection: { id: 'col-1', name: 'Dragons', slug: 'dragons' },
+      modelName: 'Ancient Wyrm',
+    });
+
+    const collectionLink = screen.getByRole('link', { name: 'Dragons' });
+    expect(collectionLink).toHaveAttribute('href', '/collections/col-1');
+  });
+
+  it('links Library to the home route', () => {
+    renderBreadcrumb({ collection: null, modelName: 'Ancient Wyrm' });
+    expect(screen.getByRole('link', { name: 'Library' })).toHaveAttribute(
+      'href',
+      '/',
+    );
+  });
+
+  it('renders the model name as the current page, not a link', () => {
+    renderBreadcrumb({
+      collection: { id: 'col-1', name: 'Dragons', slug: 'dragons' },
+      modelName: 'Ancient Wyrm',
+    });
+
+    const current = screen.getByText('Ancient Wyrm');
+    expect(current).toHaveAttribute('aria-current', 'page');
+    expect(
+      screen.queryByRole('link', { name: 'Ancient Wyrm' }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/components/models/ModelBreadcrumb.tsx
+++ b/apps/frontend/src/components/models/ModelBreadcrumb.tsx
@@ -1,0 +1,90 @@
+import { Link } from 'react-router-dom';
+import type { CollectionSummary } from '@alexandria/shared';
+import { LibraryIcon, CollectionsIcon, ChevronRightIcon } from '../icons';
+
+interface ModelBreadcrumbProps {
+  /** The model's primary collection (collections[0]), or null if it has none. */
+  collection: CollectionSummary | null;
+  modelName: string;
+}
+
+/**
+ * Context breadcrumb for the model detail page.
+ *
+ * Renders: Library › <Collection> › <Model name>
+ * (the collection crumb is omitted when the model has no collections).
+ *
+ * Modeled stylistically on the pivot workspace Breadcrumb, but the
+ * intermediate crumbs are real navigation links.
+ */
+export function ModelBreadcrumb({ collection, modelName }: ModelBreadcrumbProps) {
+  const crumbs: Array<{
+    label: string;
+    to?: string;
+    icon?: React.ReactNode;
+  }> = [
+    { label: 'Library', to: '/', icon: <LibraryIcon className="h-3.5 w-3.5" /> },
+    ...(collection
+      ? [
+          {
+            label: collection.name,
+            to: `/collections/${collection.id}`,
+            icon: <CollectionsIcon className="h-3.5 w-3.5" />,
+          },
+        ]
+      : []),
+    { label: modelName },
+  ];
+
+  return (
+    <nav
+      aria-label="Model breadcrumb"
+      className="flex items-center gap-1 flex-wrap"
+      style={{ fontSize: '12.5px', color: 'var(--ax-fg-muted)' }}
+    >
+      {crumbs.map((crumb, i) => {
+        const isLast = i === crumbs.length - 1;
+        return (
+          <span key={i} className="flex items-center gap-1 min-w-0">
+            {i > 0 && (
+              <ChevronRightIcon
+                className="h-3 w-3 flex-shrink-0"
+                style={{ color: 'var(--ax-fg-subtle)' }}
+                aria-hidden
+              />
+            )}
+            {crumb.icon && (
+              <span
+                className="flex items-center flex-shrink-0"
+                style={{ color: 'var(--ax-fg-muted)' }}
+                aria-hidden
+              >
+                {crumb.icon}
+              </span>
+            )}
+            {crumb.to && !isLast ? (
+              <Link
+                to={crumb.to}
+                className="truncate transition-colors hover:underline"
+                style={{ color: 'var(--ax-fg-muted)' }}
+              >
+                {crumb.label}
+              </Link>
+            ) : (
+              <span
+                className="truncate"
+                style={{
+                  color: isLast ? 'var(--ax-fg)' : 'var(--ax-fg-muted)',
+                  fontWeight: isLast ? 600 : 400,
+                }}
+                aria-current={isLast ? 'page' : undefined}
+              >
+                {crumb.label}
+              </span>
+            )}
+          </span>
+        );
+      })}
+    </nav>
+  );
+}

--- a/apps/frontend/src/components/models/ModelDetailPanel.tsx
+++ b/apps/frontend/src/components/models/ModelDetailPanel.tsx
@@ -1,0 +1,63 @@
+import * as React from 'react';
+import type { ModelDetail, FileTreeNode } from '@alexandria/shared';
+import { ModelInfo } from './ModelInfo';
+import { MetadataPanel } from './MetadataPanel';
+import { CollectionsList } from './CollectionsList';
+import { FileTree } from './FileTree';
+import { PanelTabs, type PanelTab } from './PanelTabs';
+import {
+  CollectionsIcon,
+  SettingsIcon,
+  GroupViewIcon,
+} from '../icons';
+import type { StlFileRef } from '../../lib/model-files';
+
+type PanelTabValue = 'info' | 'collections' | 'files';
+
+interface ModelDetailPanelProps {
+  model: ModelDetail;
+  fileTree: FileTreeNode[];
+  onOpenStl: (stl: StlFileRef) => void;
+}
+
+/**
+ * Tabbed right panel of the model detail page. Hosts the existing detail
+ * sub-components under Info / Collections / Files tabs.
+ */
+export function ModelDetailPanel({
+  model,
+  fileTree,
+  onOpenStl,
+}: ModelDetailPanelProps) {
+  const [tab, setTab] = React.useState<PanelTabValue>('info');
+
+  const tabs: PanelTab<PanelTabValue>[] = [
+    { value: 'info', label: 'Info', Icon: SettingsIcon },
+    {
+      value: 'collections',
+      label: 'Collections',
+      Icon: CollectionsIcon,
+      count: model.collections.length,
+    },
+    { value: 'files', label: 'Files', Icon: GroupViewIcon, count: model.fileCount },
+  ];
+
+  return (
+    <div className="flex flex-col gap-3">
+      <PanelTabs tabs={tabs} value={tab} onChange={setTab} />
+
+      {tab === 'info' && (
+        <div className="flex flex-col gap-3">
+          <ModelInfo model={model} />
+          <MetadataPanel metadata={model.metadata} modelId={model.id} />
+        </div>
+      )}
+
+      {tab === 'collections' && <CollectionsList collections={model.collections} />}
+
+      {tab === 'files' && (
+        <FileTree tree={fileTree} modelId={model.id} onOpenStl={onOpenStl} />
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/src/components/models/ModelDetailSkeleton.tsx
+++ b/apps/frontend/src/components/models/ModelDetailSkeleton.tsx
@@ -3,37 +3,23 @@ import { Skeleton } from '../ui/skeleton';
 export function ModelDetailSkeleton() {
   return (
     <div className="flex flex-col lg:flex-row gap-6">
-      {/* Left column */}
-      <div className="flex-1 min-w-0 flex flex-col gap-4">
-        {/* Gallery skeleton */}
+      {/* Hero column: gallery + 3D action */}
+      <div className="flex-1 min-w-0 flex flex-col gap-3">
         <Skeleton className="w-full aspect-video rounded-xl" />
-        {/* Thumbnail strip */}
         <div className="flex gap-2">
           {[...Array(4)].map((_, i) => (
             <Skeleton key={i} className="h-16 w-16 rounded-lg flex-shrink-0" />
           ))}
         </div>
-        {/* File tree skeleton */}
-        <div className="rounded-xl border border-border bg-card overflow-hidden">
-          <div className="px-4 py-3 border-b border-border bg-muted/30 flex items-center justify-between">
-            <Skeleton className="h-4 w-16" />
-            <Skeleton className="h-3 w-12" />
-          </div>
-          <div className="py-1 px-2 flex flex-col gap-1">
-            {[...Array(6)].map((_, i) => (
-              <div key={i} className="flex items-center gap-2 py-1 px-2" style={{ paddingLeft: `${(i % 3) * 16 + 8}px` }}>
-                <Skeleton className="h-4 w-4 flex-shrink-0" />
-                <Skeleton className={`h-3 ${i % 3 === 0 ? 'w-40' : 'w-32'}`} />
-                {i % 3 !== 0 && <Skeleton className="h-3 w-10 ml-auto" />}
-              </div>
-            ))}
-          </div>
-        </div>
+        <Skeleton className="h-11 w-full rounded-xl" />
       </div>
 
-      {/* Right column */}
-      <div className="lg:w-80 xl:w-96 flex flex-col gap-4 flex-shrink-0">
-        {/* Model info skeleton */}
+      {/* Tabbed panel column */}
+      <div className="lg:w-[380px] xl:w-[420px] flex flex-col gap-3 flex-shrink-0">
+        {/* Tab bar */}
+        <Skeleton className="h-10 w-full rounded-lg" />
+
+        {/* Info card */}
         <div className="rounded-xl border border-border bg-card overflow-hidden">
           <div className="px-4 pt-4 pb-3 border-b border-border/60">
             <Skeleton className="h-6 w-3/4 mb-2" />
@@ -50,7 +36,7 @@ export function ModelDetailSkeleton() {
           </div>
         </div>
 
-        {/* Metadata skeleton */}
+        {/* Metadata card */}
         <div className="rounded-xl border border-border bg-card overflow-hidden">
           <div className="px-4 py-3 border-b border-border bg-muted/30 flex items-center justify-between">
             <Skeleton className="h-4 w-20" />
@@ -63,17 +49,6 @@ export function ModelDetailSkeleton() {
                 <Skeleton className="h-3.5 flex-1" />
               </div>
             ))}
-          </div>
-        </div>
-
-        {/* Collections skeleton */}
-        <div className="rounded-xl border border-border bg-card overflow-hidden">
-          <div className="px-4 py-3 border-b border-border bg-muted/30">
-            <Skeleton className="h-4 w-24" />
-          </div>
-          <div className="px-4 py-3 flex flex-col gap-2">
-            <Skeleton className="h-4 w-36" />
-            <Skeleton className="h-4 w-28" />
           </div>
         </div>
       </div>

--- a/apps/frontend/src/components/models/ModelHero.tsx
+++ b/apps/frontend/src/components/models/ModelHero.tsx
@@ -1,0 +1,52 @@
+import type { ModelDetail } from '@alexandria/shared';
+import { ImageGallery } from './ImageGallery';
+import { Model3DIcon } from '../icons';
+import { getPrimaryStl, type StlFileRef } from '../../lib/model-files';
+
+interface ModelHeroProps {
+  model: ModelDetail;
+  stlFiles: StlFileRef[];
+  onOpenViewer: (stl: StlFileRef) => void;
+}
+
+/**
+ * Hero column of the model detail page: the existing image gallery plus a
+ * prominent "View in 3D" action. The action is hidden entirely when the model
+ * has no STL files.
+ */
+export function ModelHero({ model, stlFiles, onOpenViewer }: ModelHeroProps) {
+  const primaryStl = getPrimaryStl(stlFiles);
+
+  return (
+    <div className="flex flex-col gap-3">
+      <ImageGallery
+        images={model.images}
+        previewImageFileId={model.previewImageFileId}
+        previewCropX={model.previewCropX}
+        previewCropY={model.previewCropY}
+        previewCropScale={model.previewCropScale}
+        modelId={model.id}
+      />
+
+      {primaryStl && (
+        <button
+          type="button"
+          onClick={() => onOpenViewer(primaryStl)}
+          className="inline-flex items-center justify-center gap-2 h-11 px-4 rounded-xl text-sm font-semibold shadow-sm transition-colors"
+          style={{
+            background: 'var(--ax-amber)',
+            color: 'var(--ax-amber-fg, white)',
+          }}
+        >
+          <Model3DIcon className="h-4 w-4" />
+          View in 3D
+          {stlFiles.length > 1 && (
+            <span className="text-xs font-normal opacity-80">
+              ({stlFiles.length} models)
+            </span>
+          )}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/src/components/models/ModelViewer3DModal.test.tsx
+++ b/apps/frontend/src/components/models/ModelViewer3DModal.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { ModelViewer3DModal } from './ModelViewer3DModal';
+import type { StlFileRef } from '../../lib/model-files';
+
+// The real scene imports three.js + WebGL, which jsdom can't run. Mock it with
+// a lightweight stub that echoes the url it was asked to render.
+vi.mock('./ModelViewer3DScene', () => ({
+  default: ({ url }: { url: string }) => <div data-testid="scene" data-url={url} />,
+}));
+
+const STLS: StlFileRef[] = [
+  { name: 'body.stl', relativePath: 'body.stl', url: '/api/files/models/m1/body.stl' },
+  { name: 'base.stl', relativePath: 'base.stl', url: '/api/files/models/m1/base.stl' },
+];
+
+function setup(open: boolean, initial: StlFileRef | null = STLS[0]) {
+  const onOpenChange = vi.fn();
+  render(
+    <ModelViewer3DModal
+      open={open}
+      onOpenChange={onOpenChange}
+      stlFiles={STLS}
+      initialStl={initial}
+    />,
+  );
+  return { onOpenChange };
+}
+
+describe('ModelViewer3DModal', () => {
+  it('renders nothing when closed', () => {
+    setup(false);
+    expect(screen.queryByTestId('scene')).not.toBeInTheDocument();
+  });
+
+  it('shows the initial STL name and loads its scene when open', async () => {
+    setup(true, STLS[0]);
+    expect(await screen.findByRole('heading', { name: 'body.stl' })).toBeInTheDocument();
+    const scene = await screen.findByTestId('scene');
+    expect(scene).toHaveAttribute('data-url', '/api/files/models/m1/body.stl');
+  });
+
+  it('shows an "X of N" indicator and a switcher chip per STL', () => {
+    setup(true, STLS[0]);
+    expect(screen.getByText('1 of 2')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /body\.stl/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /base\.stl/ })).toBeInTheDocument();
+  });
+
+  it('switches the active STL when a chip is clicked', async () => {
+    setup(true, STLS[0]);
+    fireEvent.click(screen.getByRole('button', { name: /base\.stl/ }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('scene')).toHaveAttribute(
+        'data-url',
+        '/api/files/models/m1/base.stl',
+      );
+    });
+    expect(screen.getByText('2 of 2')).toBeInTheDocument();
+  });
+
+  it('calls onOpenChange(false) when the close button is clicked', () => {
+    const { onOpenChange } = setup(true, STLS[0]);
+    fireEvent.click(screen.getByRole('button', { name: /close dialog/i }));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/apps/frontend/src/components/models/ModelViewer3DModal.tsx
+++ b/apps/frontend/src/components/models/ModelViewer3DModal.tsx
@@ -1,0 +1,159 @@
+import * as React from 'react';
+import { Loader2, AlertTriangle } from 'lucide-react';
+import { Dialog, DialogContent, DialogTitle } from '../ui/dialog';
+import { Model3DIcon, ResetViewIcon } from '../icons';
+import type { StlFileRef } from '../../lib/model-files';
+
+// three.js + the scene live in a separate async chunk, loaded only when the
+// viewer first opens. Nothing else in the app imports three statically.
+const ModelViewer3DScene = React.lazy(() => import('./ModelViewer3DScene'));
+
+interface ModelViewer3DModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** All STL files for the model (drives the switcher when more than one). */
+  stlFiles: StlFileRef[];
+  /** The STL to show when the modal opens. */
+  initialStl: StlFileRef | null;
+}
+
+/** Centered spinner shown while the three.js chunk / STL is loading. */
+function ViewerLoading() {
+  return (
+    <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 text-muted-foreground">
+      <Loader2 className="h-7 w-7 animate-spin" />
+      <span className="text-sm">Loading 3D viewer…</span>
+    </div>
+  );
+}
+
+/** Error boundary around the scene; bumping `resetKey` remounts to retry. */
+class SceneErrorBoundary extends React.Component<
+  { resetKey: unknown; onRetry: () => void; children: React.ReactNode },
+  { hasError: boolean }
+> {
+  state = { hasError: false };
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidUpdate(prevProps: { resetKey: unknown }) {
+    if (prevProps.resetKey !== this.props.resetKey && this.state.hasError) {
+      this.setState({ hasError: false });
+    }
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 text-center px-6 text-muted-foreground">
+          <AlertTriangle className="h-8 w-8 text-destructive/70" />
+          <p className="text-sm font-medium text-foreground">
+            Couldn&apos;t load this model
+          </p>
+          <p className="text-xs">
+            The file may be missing, too large, or in an unsupported format.
+          </p>
+          <button
+            type="button"
+            onClick={this.props.onRetry}
+            className="inline-flex items-center gap-1.5 h-8 px-3 rounded-md border border-input bg-background text-sm font-medium hover:bg-accent transition-colors"
+          >
+            <ResetViewIcon className="h-3.5 w-3.5" />
+            Try again
+          </button>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+export function ModelViewer3DModal({
+  open,
+  onOpenChange,
+  stlFiles,
+  initialStl,
+}: ModelViewer3DModalProps) {
+  const [activeStl, setActiveStl] = React.useState<StlFileRef | null>(initialStl);
+  const [retry, setRetry] = React.useState(0);
+
+  // Sync the active STL when the modal is (re)opened on a specific file.
+  React.useEffect(() => {
+    if (open) {
+      setActiveStl(initialStl);
+      setRetry(0);
+    }
+  }, [open, initialStl]);
+
+  const activeIndex = activeStl
+    ? stlFiles.findIndex((s) => s.relativePath === activeStl.relativePath)
+    : -1;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-5xl w-[92vw] h-[85vh] p-0 gap-0 flex flex-col overflow-hidden">
+        {/* Header */}
+        <div className="flex items-center gap-2 px-5 py-3 border-b border-border flex-shrink-0 pr-12">
+          <Model3DIcon className="h-4 w-4 text-muted-foreground flex-shrink-0" />
+          <DialogTitle className="text-sm font-semibold text-foreground truncate">
+            {activeStl?.name ?? '3D viewer'}
+          </DialogTitle>
+          {stlFiles.length > 1 && activeIndex >= 0 && (
+            <span className="text-xs text-muted-foreground flex-shrink-0">
+              {activeIndex + 1} of {stlFiles.length}
+            </span>
+          )}
+        </div>
+
+        {/* Canvas region */}
+        <div
+          className="relative flex-1 min-h-0"
+          style={{ background: 'var(--ax-bg-sunk)' }}
+        >
+          {activeStl ? (
+            <SceneErrorBoundary
+              resetKey={`${activeStl.url}#${retry}`}
+              onRetry={() => setRetry((r) => r + 1)}
+            >
+              <React.Suspense fallback={<ViewerLoading />}>
+                <ModelViewer3DScene key={`${activeStl.url}#${retry}`} url={activeStl.url} />
+              </React.Suspense>
+            </SceneErrorBoundary>
+          ) : (
+            <div className="absolute inset-0 flex items-center justify-center text-sm text-muted-foreground">
+              No 3D file selected
+            </div>
+          )}
+        </div>
+
+        {/* File switcher */}
+        {stlFiles.length > 1 && (
+          <div className="flex items-center gap-2 px-4 py-2.5 border-t border-border overflow-x-auto flex-shrink-0">
+            {stlFiles.map((stl) => {
+              const isActive = stl.relativePath === activeStl?.relativePath;
+              return (
+                <button
+                  key={stl.relativePath}
+                  type="button"
+                  onClick={() => setActiveStl(stl)}
+                  aria-pressed={isActive}
+                  className="inline-flex items-center gap-1.5 h-8 px-3 rounded-full text-xs font-medium whitespace-nowrap transition-colors flex-shrink-0"
+                  style={{
+                    background: isActive ? 'var(--ax-amber)' : 'var(--ax-bg-elev)',
+                    color: isActive ? 'var(--ax-amber-fg, white)' : 'var(--ax-fg-muted)',
+                    border: '1px solid var(--ax-border)',
+                  }}
+                >
+                  <Model3DIcon className="h-3.5 w-3.5" />
+                  {stl.name}
+                </button>
+              );
+            })}
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/frontend/src/components/models/ModelViewer3DScene.tsx
+++ b/apps/frontend/src/components/models/ModelViewer3DScene.tsx
@@ -1,0 +1,58 @@
+import { Suspense, useMemo } from 'react';
+import { Canvas, useLoader } from '@react-three/fiber';
+import { OrbitControls, Bounds, Html } from '@react-three/drei';
+import { STLLoader } from 'three/examples/jsm/loaders/STLLoader.js';
+import type { BufferGeometry } from 'three';
+
+/**
+ * The actual react-three-fiber scene. This is the ONLY module that imports
+ * `three` / `@react-three/fiber` / `@react-three/drei`, and it is reached
+ * solely via React.lazy from ModelViewer3DModal — so the (large) three.js
+ * bundle is emitted as a separate async chunk, loaded on first viewer open.
+ */
+
+function StlMesh({ url }: { url: string }) {
+  const loaded = useLoader(STLLoader, url) as BufferGeometry;
+
+  // Center the geometry at the origin and ensure normals exist (STL files
+  // frequently ship without them, which renders the mesh flat/black).
+  const geometry = useMemo(() => {
+    loaded.center();
+    loaded.computeVertexNormals();
+    return loaded;
+  }, [loaded]);
+
+  return (
+    <mesh geometry={geometry}>
+      <meshStandardMaterial color="#b8bcc4" roughness={0.55} metalness={0.1} />
+    </mesh>
+  );
+}
+
+interface ModelViewer3DSceneProps {
+  url: string;
+}
+
+export default function ModelViewer3DScene({ url }: ModelViewer3DSceneProps) {
+  return (
+    <Canvas camera={{ position: [0, 0, 100], fov: 45 }} dpr={[1, 2]}>
+      <color attach="background" args={['#15181f']} />
+      <ambientLight intensity={0.7} />
+      <directionalLight position={[8, 12, 8]} intensity={1.3} />
+      <directionalLight position={[-8, -4, -6]} intensity={0.4} />
+      <Suspense
+        fallback={
+          <Html center>
+            <span style={{ color: '#c8ccd4', fontSize: 13 }}>Loading model…</span>
+          </Html>
+        }
+      >
+        {/* `key` forces a fresh fit when the STL url changes. */}
+        <Bounds key={url} fit clip observe margin={1.2}>
+          <StlMesh url={url} />
+        </Bounds>
+      </Suspense>
+      <OrbitControls makeDefault enablePan enableZoom enableRotate />
+    </Canvas>
+  );
+}

--- a/apps/frontend/src/components/models/PanelTabs.tsx
+++ b/apps/frontend/src/components/models/PanelTabs.tsx
@@ -1,0 +1,75 @@
+export interface PanelTab<T extends string> {
+  value: T;
+  label: string;
+  Icon?: React.ComponentType<{ className?: string }>;
+  count?: number;
+}
+
+interface PanelTabsProps<T extends string> {
+  tabs: PanelTab<T>[];
+  value: T;
+  onChange: (value: T) => void;
+}
+
+/**
+ * Full-width segmented tab control for the model detail panel.
+ *
+ * A self-contained, token-styled segmented control modeled on the pivot
+ * workspace ViewSwitch: the active tab gets the accent fill, inactive tabs are
+ * muted. Uses tablist/tab roles. Kept self-contained (not a card-top bar) so
+ * each tab's content can keep its own card chrome without nesting.
+ */
+export function PanelTabs<T extends string>({
+  tabs,
+  value,
+  onChange,
+}: PanelTabsProps<T>) {
+  return (
+    <div
+      role="tablist"
+      aria-label="Model details"
+      className="flex items-stretch rounded-lg overflow-hidden"
+      style={{
+        border: '1px solid var(--ax-border)',
+        background: 'var(--ax-bg-elev)',
+      }}
+    >
+      {tabs.map(({ value: tabValue, label, Icon, count }, i) => {
+        const isActive = value === tabValue;
+        return (
+          <button
+            key={tabValue}
+            type="button"
+            role="tab"
+            aria-selected={isActive}
+            onClick={() => onChange(tabValue)}
+            className="flex flex-1 items-center justify-center gap-1.5 py-2 text-sm font-medium transition-colors"
+            style={{
+              color: isActive ? 'var(--ax-amber-fg, white)' : 'var(--ax-fg-muted)',
+              background: isActive ? 'var(--ax-amber)' : 'transparent',
+              borderRight:
+                i < tabs.length - 1 ? '1px solid var(--ax-border)' : 'none',
+              cursor: 'pointer',
+            }}
+          >
+            {Icon && <Icon className="h-4 w-4 flex-shrink-0" aria-hidden />}
+            <span className="truncate">{label}</span>
+            {count !== undefined && (
+              <span
+                className="ml-0.5 rounded-full px-1.5 text-xs"
+                style={{
+                  background: isActive
+                    ? 'rgba(255,255,255,0.25)'
+                    : 'var(--ax-bg-sunk)',
+                  color: isActive ? 'inherit' : 'var(--ax-fg-muted)',
+                }}
+              >
+                {count}
+              </span>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/frontend/src/components/pivot/PivotMain.tsx
+++ b/apps/frontend/src/components/pivot/PivotMain.tsx
@@ -21,7 +21,7 @@ import {
 } from '../icons';
 import type { PivotAxis } from '../../hooks/use-model-filters';
 
-const AXIS_ICONS: Record<PivotAxis, React.ElementType> = {
+const AXIS_ICONS: Record<PivotAxis, React.ComponentType<{ className?: string }>> = {
   collections: CollectionsIcon,
   artists: ArtistIcon,
   tags: TagIcon,

--- a/apps/frontend/src/components/pivot/ViewSwitch.tsx
+++ b/apps/frontend/src/components/pivot/ViewSwitch.tsx
@@ -1,7 +1,7 @@
 import { useDisplayPreferences, type ViewMode } from '../../hooks/use-display-preferences';
 import { GridViewIcon, ListViewIcon, GroupViewIcon } from '../icons';
 
-const VIEWS: Array<{ mode: ViewMode; label: string; Icon: React.ElementType }> = [
+const VIEWS: Array<{ mode: ViewMode; label: string; Icon: React.ComponentType<{ className?: string }> }> = [
   { mode: 'grid', label: 'Grid view', Icon: GridViewIcon },
   { mode: 'list', label: 'List view', Icon: ListViewIcon },
   { mode: 'group', label: 'Group view', Icon: GroupViewIcon },

--- a/apps/frontend/src/lib/model-files.test.ts
+++ b/apps/frontend/src/lib/model-files.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import type { FileTreeNode } from '@alexandria/shared';
+import { collectStlFiles, getPrimaryStl } from './model-files';
+
+const MODEL_ID = 'abc-123';
+
+describe('collectStlFiles', () => {
+  it('returns an empty array for an empty tree', () => {
+    expect(collectStlFiles([], MODEL_ID)).toEqual([]);
+  });
+
+  it('finds a top-level STL and builds its URL', () => {
+    const tree: FileTreeNode[] = [
+      { name: 'dragon.stl', type: 'file', fileType: 'stl', sizeBytes: 100, id: 'f1' },
+    ];
+    expect(collectStlFiles(tree, MODEL_ID)).toEqual([
+      {
+        name: 'dragon.stl',
+        relativePath: 'dragon.stl',
+        url: `/api/files/models/${MODEL_ID}/dragon.stl`,
+      },
+    ]);
+  });
+
+  it('filters out non-STL files', () => {
+    const tree: FileTreeNode[] = [
+      { name: 'cover.png', type: 'file', fileType: 'image', id: 'i1' },
+      { name: 'body.stl', type: 'file', fileType: 'stl', id: 's1' },
+      { name: 'readme.md', type: 'file', fileType: 'document', id: 'd1' },
+      { name: 'notes.txt', type: 'file', fileType: 'other', id: 'o1' },
+    ];
+    const result = collectStlFiles(tree, MODEL_ID);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('body.stl');
+  });
+
+  it('reconstructs the full relative path for nested STLs', () => {
+    const tree: FileTreeNode[] = [
+      {
+        name: 'parts',
+        type: 'directory',
+        children: [
+          {
+            name: 'left',
+            type: 'directory',
+            children: [
+              { name: 'arm.stl', type: 'file', fileType: 'stl', id: 's1' },
+            ],
+          },
+          { name: 'base.stl', type: 'file', fileType: 'stl', id: 's2' },
+        ],
+      },
+    ];
+    const result = collectStlFiles(tree, MODEL_ID);
+    expect(result).toEqual([
+      {
+        name: 'arm.stl',
+        relativePath: 'parts/left/arm.stl',
+        url: `/api/files/models/${MODEL_ID}/parts/left/arm.stl`,
+      },
+      {
+        name: 'base.stl',
+        relativePath: 'parts/base.stl',
+        url: `/api/files/models/${MODEL_ID}/parts/base.stl`,
+      },
+    ]);
+  });
+
+  it('preserves depth-first tree order', () => {
+    const tree: FileTreeNode[] = [
+      { name: 'a.stl', type: 'file', fileType: 'stl', id: '1' },
+      {
+        name: 'sub',
+        type: 'directory',
+        children: [{ name: 'b.stl', type: 'file', fileType: 'stl', id: '2' }],
+      },
+      { name: 'c.stl', type: 'file', fileType: 'stl', id: '3' },
+    ];
+    expect(collectStlFiles(tree, MODEL_ID).map((s) => s.name)).toEqual([
+      'a.stl',
+      'b.stl',
+      'c.stl',
+    ]);
+  });
+
+  it('URL-encodes path segments with spaces and special characters', () => {
+    const tree: FileTreeNode[] = [
+      {
+        name: 'pre supports',
+        type: 'directory',
+        children: [
+          { name: 'main body.stl', type: 'file', fileType: 'stl', id: 's1' },
+        ],
+      },
+    ];
+    const result = collectStlFiles(tree, MODEL_ID);
+    expect(result[0].relativePath).toBe('pre supports/main body.stl');
+    expect(result[0].url).toBe(
+      `/api/files/models/${MODEL_ID}/pre%20supports/main%20body.stl`,
+    );
+  });
+
+  it('tolerates directories with no children', () => {
+    const tree: FileTreeNode[] = [{ name: 'empty', type: 'directory' }];
+    expect(collectStlFiles(tree, MODEL_ID)).toEqual([]);
+  });
+});
+
+describe('getPrimaryStl', () => {
+  it('returns null for an empty list', () => {
+    expect(getPrimaryStl([])).toBeNull();
+  });
+
+  it('returns the first STL in the list', () => {
+    const stls = collectStlFiles(
+      [
+        { name: 'first.stl', type: 'file', fileType: 'stl', id: '1' },
+        { name: 'second.stl', type: 'file', fileType: 'stl', id: '2' },
+      ],
+      MODEL_ID,
+    );
+    expect(getPrimaryStl(stls)?.name).toBe('first.stl');
+  });
+});

--- a/apps/frontend/src/lib/model-files.ts
+++ b/apps/frontend/src/lib/model-files.ts
@@ -1,0 +1,63 @@
+import type { FileTreeNode } from '@alexandria/shared';
+
+/**
+ * A loadable reference to a single STL file within a model.
+ *
+ * `FileTreeNode`s don't carry the relative path (the backend builds the tree
+ * by splitting `relativePath` on `/`), so we reconstruct each STL's path by
+ * joining its ancestor directory names + its own name. The resulting `url`
+ * points at the same-origin file route, so the session cookie is sent
+ * automatically by the loader's fetch.
+ */
+export interface StlFileRef {
+  /** File name, e.g. "dragon_base.stl". */
+  name: string;
+  /** Path relative to the model root, e.g. "parts/dragon_base.stl". */
+  relativePath: string;
+  /** Fetchable URL: `/api/files/models/{modelId}/{encoded path}`. */
+  url: string;
+}
+
+/**
+ * Build an STL reference from a model id and the file's path segments
+ * (ancestor directory names + file name). Single source of truth for the file
+ * URL so the file tree and the discovery walk stay in sync.
+ */
+export function makeStlRef(modelId: string, segments: string[]): StlFileRef {
+  return {
+    name: segments[segments.length - 1],
+    relativePath: segments.join('/'),
+    url: `/api/files/models/${modelId}/${segments
+      .map(encodeURIComponent)
+      .join('/')}`,
+  };
+}
+
+/**
+ * Walk a file tree and collect every STL file with its reconstructed relative
+ * path and fetch URL, in depth-first tree order.
+ */
+export function collectStlFiles(
+  tree: FileTreeNode[],
+  modelId: string,
+): StlFileRef[] {
+  const out: StlFileRef[] = [];
+
+  const walk = (nodes: FileTreeNode[], prefix: string[]) => {
+    for (const node of nodes) {
+      if (node.type === 'directory') {
+        walk(node.children ?? [], [...prefix, node.name]);
+      } else if (node.fileType === 'stl') {
+        out.push(makeStlRef(modelId, [...prefix, node.name]));
+      }
+    }
+  };
+
+  walk(tree, []);
+  return out;
+}
+
+/** The "primary" STL is the first one found in tree order, or null if none. */
+export function getPrimaryStl(stls: StlFileRef[]): StlFileRef | null {
+  return stls[0] ?? null;
+}

--- a/apps/frontend/src/pages/ModelDetailPage.tsx
+++ b/apps/frontend/src/pages/ModelDetailPage.tsx
@@ -1,13 +1,14 @@
+import * as React from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { ChevronLeft, AlertTriangle } from 'lucide-react';
 import { getModel, getModelFiles } from '../api/models';
-import { ImageGallery } from '../components/models/ImageGallery';
-import { FileTree } from '../components/models/FileTree';
-import { MetadataPanel } from '../components/models/MetadataPanel';
-import { ModelInfo } from '../components/models/ModelInfo';
-import { CollectionsList } from '../components/models/CollectionsList';
+import { ModelHero } from '../components/models/ModelHero';
+import { ModelDetailPanel } from '../components/models/ModelDetailPanel';
+import { ModelBreadcrumb } from '../components/models/ModelBreadcrumb';
+import { ModelViewer3DModal } from '../components/models/ModelViewer3DModal';
 import { ModelDetailSkeleton } from '../components/models/ModelDetailSkeleton';
+import { collectStlFiles, type StlFileRef } from '../lib/model-files';
 
 export function ModelDetailPage() {
   const { id } = useParams<{ id: string }>();
@@ -31,17 +32,37 @@ export function ModelDetailPage() {
 
   const isLoading = modelLoading || filesLoading;
 
+  // STL files discovered from the file tree (drives the 3D viewer).
+  const stlFiles = React.useMemo(
+    () => (id ? collectStlFiles(fileTree, id) : []),
+    [fileTree, id],
+  );
+
+  const [viewerOpen, setViewerOpen] = React.useState(false);
+  const [activeStl, setActiveStl] = React.useState<StlFileRef | null>(null);
+
+  function openViewer(stl: StlFileRef) {
+    setActiveStl(stl);
+    setViewerOpen(true);
+  }
+
   return (
-    <div className="flex flex-col gap-5 max-w-6xl mx-auto p-6">
-      {/* Back nav */}
-      <div>
+    <div className="flex flex-col gap-4 max-w-[1400px] mx-auto p-6">
+      {/* Header: back link + breadcrumb */}
+      <div className="flex flex-col gap-2">
         <Link
           to="/"
-          className="inline-flex items-center gap-0.5 h-8 px-2 -ml-2 rounded-md text-sm text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
+          className="inline-flex items-center gap-0.5 h-8 px-2 -ml-2 rounded-md text-sm text-muted-foreground hover:text-foreground hover:bg-accent transition-colors self-start"
         >
           <ChevronLeft className="h-4 w-4" />
           Back to Library
         </Link>
+        {model && !isLoading && (
+          <ModelBreadcrumb
+            collection={model.collections[0] ?? null}
+            modelName={model.name}
+          />
+        )}
       </div>
 
       {isLoading && <ModelDetailSkeleton />}
@@ -66,27 +87,28 @@ export function ModelDetailPage() {
 
       {model && !isLoading && (
         <div className="flex flex-col lg:flex-row gap-6">
-          {/* Left column: gallery + file tree */}
-          <div className="flex-1 min-w-0 flex flex-col gap-4">
-            <ImageGallery
-              images={model.images}
-              previewImageFileId={model.previewImageFileId}
-              previewCropX={model.previewCropX}
-              previewCropY={model.previewCropY}
-              previewCropScale={model.previewCropScale}
-              modelId={model.id}
-            />
-            <FileTree tree={fileTree} />
+          {/* Hero column */}
+          <div className="flex-1 min-w-0">
+            <ModelHero model={model} stlFiles={stlFiles} onOpenViewer={openViewer} />
           </div>
 
-          {/* Right column: info, metadata, collections */}
-          <div className="lg:w-80 xl:w-96 flex flex-col gap-4 flex-shrink-0">
-            <ModelInfo model={model} />
-            <MetadataPanel metadata={model.metadata} modelId={model.id} />
-            <CollectionsList collections={model.collections} />
+          {/* Tabbed panel column */}
+          <div className="lg:w-[380px] xl:w-[420px] flex-shrink-0">
+            <ModelDetailPanel
+              model={model}
+              fileTree={fileTree}
+              onOpenStl={openViewer}
+            />
           </div>
         </div>
       )}
+
+      <ModelViewer3DModal
+        open={viewerOpen}
+        onOpenChange={setViewerOpen}
+        stlFiles={stlFiles}
+        initialStl={activeStl}
+      />
     </div>
   );
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -46,6 +46,11 @@ The `runSeed` function is also exported for use as a standalone CLI script (`npm
 │   AppShell: PivotRail + <Outlet>                         │
 │   PivotRail: AxisPicker + AxisFacetBody + UserMenu       │
 │   PivotMain: top bar + context header + results grid     │
+│                                                          │
+│   ModelDetailPage: ModelBreadcrumb + ModelHero +         │
+│     ModelDetailPanel (Info/Collections/Files tabs)       │
+│   ModelViewer3DModal → lazy ModelViewer3DScene (three.js)│
+│   lib/model-files.ts: STL path helpers (pure)           │
 └──────────────────────┬──────────────────────────────────┘
                        │ HTTP (JSON, multipart)
 ┌──────────────────────▼──────────────────────────────────┐
@@ -364,6 +369,49 @@ Routes unchanged from P0: `/models/:id`, `/collections`, `/collections/:id`, `/u
 
 ---
 
+## Frontend: Model Detail Page (P2)
+
+The Model Detail page (`pages/ModelDetailPage.tsx`) was fully redesigned in P2. It fetches both `GET /models/:id` and `GET /models/:id/files` in parallel and composes three top-level regions:
+
+1. **Header** — a back link to the library plus `ModelBreadcrumb`, which renders `Library › <Collection> › <Model name>`. The collection crumb is a live navigation link; the model name is the current-page marker. The collection crumb is omitted when the model belongs to no collections.
+
+2. **Hero column** — the existing `ImageGallery` plus a "View in 3D" button. The button is hidden when the model has no STL files. When the model has multiple STLs the button opens the viewer on the first file in tree order; per-file 3D affordances in the file tree open a specific file.
+
+3. **Tabbed right panel** — `ModelDetailPanel` hosts `PanelTabs` (a full-width segmented control) with three tabs: Info (model name, description, metadata), Collections, and Files (the file tree). The panel is `380–420 px` fixed width alongside the hero column at `lg:` breakpoint and stacked on smaller screens.
+
+### ModelBreadcrumb
+
+`components/models/ModelBreadcrumb.tsx` renders the three-level hierarchy breadcrumb. It accepts the model's primary collection (`CollectionSummary | null`) and the model name. The intermediate collection crumb links to `/collections/:id`. Stylistically it mirrors the pivot workspace `Breadcrumb` but uses real navigation links.
+
+### ModelHero
+
+`components/models/ModelHero.tsx` wraps `ImageGallery` and the "View in 3D" action. It receives `stlFiles: StlFileRef[]` collected from the file tree and calls `onOpenViewer(primaryStl)` when the button is clicked.
+
+### ModelDetailPanel and PanelTabs
+
+`components/models/ModelDetailPanel.tsx` is the tabbed right panel. `components/models/PanelTabs.tsx` is the generic full-width segmented control it uses. `PanelTabs` is typed with a string union for tab values and accepts icon components typed as `React.ComponentType<{ className?: string }>` (see the gotcha note in the Conventions doc).
+
+### 3D Viewer
+
+The 3D viewer is an in-browser STL renderer built on `three` + `@react-three/fiber` + `@react-three/drei`. It is composed of two layers:
+
+- `ModelViewer3DModal` — the dialog shell. Manages the active STL selection, a file switcher strip when the model has multiple STLs, and an error boundary around the scene. It loads the scene module via `React.lazy`.
+- `ModelViewer3DScene` — the actual r3f scene: a `Canvas` with ambient and directional lights, `OrbitControls`, and a `Bounds` wrapper that auto-fits the loaded geometry. This is the **only module that imports `three`** — the rest of the app does not touch three.js.
+
+Because `ModelViewer3DScene` is lazy-loaded, Vite emits three.js as a separate async chunk (~924 KB). The chunk is fetched only when the viewer first opens. Nothing in the critical path is blocked.
+
+### lib/model-files.ts
+
+`lib/model-files.ts` contains three pure helper functions for working with STL files from the file tree:
+
+- `collectStlFiles(tree, modelId)` — walks a `FileTreeNode[]` tree depth-first and returns a `StlFileRef[]` for every STL file. It reconstructs each file's relative path from the tree (since `FileTreeNode` nodes have only a `name`, not a `relativePath`) by accumulating ancestor directory names during the walk.
+- `getPrimaryStl(stls)` — returns the first `StlFileRef` or `null`.
+- `makeStlRef(modelId, segments)` — builds a `StlFileRef` from path segments, including the `/api/files/models/:modelId/:path` URL. This is the single source of truth for STL file URLs in the frontend.
+
+`StlFileRef` is defined in this module: `{ name: string, relativePath: string, url: string }`. It is a frontend-only type and does not exist in shared types.
+
+---
+
 ## API Design
 
 ### Conventions
@@ -482,3 +530,6 @@ The `requireLibrary` preHandler derives `libraryId` from the authenticated sessi
 
 ### D14: Pivot axis is URL state, not query state
 The active pivot axis (`?axis=collections|artists|tags`) is stored in the URL so it survives navigation and is shareable, but it is excluded from the React Query key. The axis controls how the rail and context header look; it does not change the underlying API request. Only the filter values derived from an axis selection (e.g., `collectionId`, `meta_artist`) enter the query key and trigger refetches.
+
+### D15: three.js is isolated in a single lazy-loaded module
+`ModelViewer3DScene` is the only file in the frontend that imports `three`, `@react-three/fiber`, or `@react-three/drei`. All other code reaches it through `ModelViewer3DModal` via `React.lazy`, which causes Vite to emit three.js as a separate async chunk (~924 KB). The chunk is never fetched unless the 3D viewer is opened. This isolation is intentional: adding any static import of three anywhere else in the app would pull the entire bundle into the critical path. If the viewer grows to need additional three.js utilities, they must be added inside `ModelViewer3DScene` or co-located lazy modules — not imported at the app or component level.

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -374,6 +374,16 @@ Color tokens are defined as CSS custom properties in `src/index.css`. shadcn/ui 
 
 `ThemeProvider` must wrap the app root in `main.tsx` for `useTheme` to be available anywhere in the tree.
 
+### three.js and the 3D viewer
+
+three.js must never be imported statically outside `ModelViewer3DScene`. That module is the deliberate isolation boundary: it is reached only via `React.lazy(() => import('./ModelViewer3DScene'))` in `ModelViewer3DModal`, which causes Vite to emit the entire three.js bundle as a separate async chunk. Any static import elsewhere pulls the ~924 KB chunk into the critical path.
+
+If new three.js functionality is needed (e.g., an additional loader or post-processing pass), add it inside `ModelViewer3DScene` or in a co-located module that `ModelViewer3DScene` imports directly. Do not import from `three`, `@react-three/fiber`, or `@react-three/drei` anywhere else in the codebase.
+
+### Icon component props: `React.ComponentType` not `React.ElementType`
+
+Installing `@react-three/fiber` augments the global React JSX namespace with three.js element names. This means `React.ElementType` becomes ambiguous for icon props — TypeScript can no longer distinguish a React component from a three.js primitive. Use `React.ComponentType<{ className?: string }>` instead of `React.ElementType` whenever a prop is intended to receive an icon (or any other React component rendered as JSX). This pattern is in use in `ViewSwitch.tsx`, `PivotMain.tsx`, and `PanelTabs.tsx`.
+
 ---
 
 ## Testing Conventions

--- a/docs/superpowers/specs/2026-05-29-design-system-foundation-design.md
+++ b/docs/superpowers/specs/2026-05-29-design-system-foundation-design.md
@@ -46,16 +46,16 @@ from the start so P5 is mostly UI + invites, not a high-risk query migration.
 shadcn's existing CSS vars at the `--ax-*` vars so all existing components inherit the new design
 with no rewrite, while keeping runtime palette-switching + density.
 
-| Phase | Title | Backend? | Summary |
-|-------|-------|----------|---------|
-| **P0** | Design System Foundation | no | Port tokens, bridge to shadcn, palette/theme/density state, fonts, icon strategy, verification sandbox. **(this spec)** |
-| **P1** | App Shell + Pivot Workspace | thin Library layer | Dark rail + axis picker + main pane/header; Pivot by Collections / Tags / Artists end-to-end; view toggle (grid/list/group), density, thumbnails toggle. Smart axis deferred. |
-| **P2** | Model Detail + 3D Viewer | no | Restyle detail with multi-hierarchy breadcrumb; 3D modal (files already served). |
-| **P3** | Workflow Pages | no | Restyle Upload + global Search. |
-| **P4** | Smart Collections | yes | New entity + rule engine (extends SearchService); Smart pivot axis + composer. |
-| **P5** | Multi-library | yes | Surface the Library layer: All-Libraries home, switcher, `/lib/:id` routing, per-library scoping in UI. |
-| **P6** | Users / Roles / Admin | yes | Multi-user + roles in AuthService; admin pages (libraries, users, bulk edit, auto-tagging). |
-| **P7** | Empty states + polish | no | Empty library, empty collections, final pass. |
+| Phase | Title | Backend? | Status | Summary |
+|-------|-------|----------|--------|---------|
+| **P0** | Design System Foundation | no | Shipped | Port tokens, bridge to shadcn, palette/theme/density state, fonts, icon strategy, verification sandbox. **(this spec)** |
+| **P1** | App Shell + Pivot Workspace | thin Library layer | Shipped | Dark rail + axis picker + main pane/header; Pivot by Collections / Tags / Artists end-to-end; view toggle (grid/list/group), density, thumbnails toggle. Smart axis deferred. |
+| **P2** | Model Detail + 3D Viewer | no | Shipped | Restyle detail with multi-hierarchy breadcrumb; 3D modal (files already served). |
+| **P3** | Workflow Pages | no | Pending | Restyle Upload + global Search. |
+| **P4** | Smart Collections | yes | Pending | New entity + rule engine (extends SearchService); Smart pivot axis + composer. |
+| **P5** | Multi-library | yes | Pending | Surface the Library layer: All-Libraries home, switcher, `/lib/:id` routing, per-library scoping in UI. |
+| **P6** | Users / Roles / Admin | yes | Pending | Multi-user + roles in AuthService; admin pages (libraries, users, bulk edit, auto-tagging). |
+| **P7** | Empty states + polish | no | Pending | Empty library, empty collections, final pass. |
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,6 +64,8 @@
         "@fontsource/inter": "^5.2.8",
         "@fontsource/inter-tight": "^5.2.7",
         "@fontsource/jetbrains-mono": "^5.2.8",
+        "@react-three/drei": "^10.7.7",
+        "@react-three/fiber": "^9.6.1",
         "@tanstack/react-query": "^5.90.21",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -71,7 +73,8 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-router-dom": "^7.13.0",
-        "tailwind-merge": "^3.5.0"
+        "tailwind-merge": "^3.5.0",
+        "three": "^0.184.0"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.9.1",
@@ -79,6 +82,7 @@
         "@testing-library/user-event": "^14.6.1",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
+        "@types/three": "^0.184.1",
         "@vitejs/plugin-react": "^4.3.0",
         "autoprefixer": "^10.4.0",
         "jsdom": "^28.1.0",
@@ -424,7 +428,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
       "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -622,6 +625,12 @@
       "engines": {
         "node": ">=20.19.0"
       }
+    },
+    "node_modules/@dimforge/rapier3d-compat": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
+      "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
+      "license": "Apache-2.0"
     },
     "node_modules/@drizzle-team/brocli": {
       "version": "0.10.2",
@@ -2313,6 +2322,24 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@mediapipe/tasks-vision": {
+      "version": "0.10.17",
+      "resolved": "https://registry.npmjs.org/@mediapipe/tasks-vision/-/tasks-vision-0.10.17.tgz",
+      "integrity": "sha512-CZWV/q6TTe8ta61cZXjfnnHsfWIdFhms03M9T7Cnd5y2mdpylJM0rF1qRq+wsQVRMLz1OYPVEBU9ph2Bx8cxrg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@monogrid/gainmap-js": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@monogrid/gainmap-js/-/gainmap-js-3.4.0.tgz",
+      "integrity": "sha512-2Z0FATFHaoYJ8b+Y4y4Hgfn3FRFwuU5zRrk+9dFWp4uGAdHGqVEdP7HP+gLA3X469KXHmfupJaUbKo1b/aDKIg==",
+      "license": "MIT",
+      "dependencies": {
+        "promise-worker-transferable": "^1.0.4"
+      },
+      "peerDependencies": {
+        "three": ">= 0.159.0"
+      }
+    },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.3.tgz",
@@ -2460,6 +2487,94 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@react-three/drei": {
+      "version": "10.7.7",
+      "resolved": "https://registry.npmjs.org/@react-three/drei/-/drei-10.7.7.tgz",
+      "integrity": "sha512-ff+J5iloR0k4tC++QtD/j9u3w5fzfgFAWDtAGQah9pF2B1YgOq/5JxqY0/aVoQG5r3xSZz0cv5tk2YuBob4xEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.0",
+        "@mediapipe/tasks-vision": "0.10.17",
+        "@monogrid/gainmap-js": "^3.0.6",
+        "@use-gesture/react": "^10.3.1",
+        "camera-controls": "^3.1.0",
+        "cross-env": "^7.0.3",
+        "detect-gpu": "^5.0.56",
+        "glsl-noise": "^0.0.0",
+        "hls.js": "^1.5.17",
+        "maath": "^0.10.8",
+        "meshline": "^3.3.1",
+        "stats-gl": "^2.2.8",
+        "stats.js": "^0.17.0",
+        "suspend-react": "^0.1.3",
+        "three-mesh-bvh": "^0.8.3",
+        "three-stdlib": "^2.35.6",
+        "troika-three-text": "^0.52.4",
+        "tunnel-rat": "^0.1.2",
+        "use-sync-external-store": "^1.4.0",
+        "utility-types": "^3.11.0",
+        "zustand": "^5.0.1"
+      },
+      "peerDependencies": {
+        "@react-three/fiber": "^9.0.0",
+        "react": "^19",
+        "react-dom": "^19",
+        "three": ">=0.159"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-three/fiber": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-9.6.1.tgz",
+      "integrity": "sha512-zF0rsKcVYpcJwbFEnv2HkHX9cvOEgsfQo/X8lwmR2dn13S4qEQJXir9fxf5js2LQFoXqxOY7MDkOkYx2uZ4gSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.17.8",
+        "@types/webxr": "*",
+        "base64-js": "^1.5.1",
+        "buffer": "^6.0.3",
+        "its-fine": "^2.0.0",
+        "react-use-measure": "^2.1.7",
+        "scheduler": "^0.27.0",
+        "suspend-react": "^0.1.3",
+        "use-sync-external-store": "^1.4.0",
+        "zustand": "^5.0.3"
+      },
+      "peerDependencies": {
+        "expo": ">=43.0",
+        "expo-asset": ">=8.4",
+        "expo-file-system": ">=11.0",
+        "expo-gl": ">=11.0",
+        "react": ">=19 <19.3",
+        "react-dom": ">=19 <19.3",
+        "react-native": ">=0.78",
+        "three": ">=0.156"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        },
+        "expo-asset": {
+          "optional": true
+        },
+        "expo-file-system": {
+          "optional": true
+        },
+        "expo-gl": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -2942,6 +3057,12 @@
         "@testing-library/dom": ">=7.21.4"
       }
     },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "license": "MIT"
+    },
     "node_modules/@types/archiver": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@types/archiver/-/archiver-7.0.0.tgz",
@@ -3023,6 +3144,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/draco3d": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@types/draco3d/-/draco3d-1.4.10.tgz",
+      "integrity": "sha512-AX22jp8Y7wwaBgAixaSvkoG4M/+PlAcm3Qs4OW8yT9DM4xUpWKeFhLueTAyZF39pviAdcDdeJoACapiAceqNcw==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -3049,6 +3176,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/offscreencanvas": {
+      "version": "2019.7.3",
+      "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.3.tgz",
+      "integrity": "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==",
+      "license": "MIT"
+    },
     "node_modules/@types/pg": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.16.0.tgz",
@@ -3065,7 +3198,6 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -3079,6 +3211,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/react-reconciler": {
+      "version": "0.28.9",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.28.9.tgz",
+      "integrity": "sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/@types/readdir-glob": {
@@ -3101,6 +3242,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "license": "MIT"
+    },
     "node_modules/@types/tar": {
       "version": "6.1.13",
       "resolved": "https://registry.npmjs.org/@types/tar/-/tar-6.1.13.tgz",
@@ -3122,6 +3269,26 @@
         "node": ">=8"
       }
     },
+    "node_modules/@types/three": {
+      "version": "0.184.1",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.184.1.tgz",
+      "integrity": "sha512-6q4VdiqVsrTRqmk62/BnlcAvIrnDM0zf2ZDVKI5kZiniWrSaOHaQzmbp+BNzoggc/8tgW412pL//wZIxu2PPTA==",
+      "license": "MIT",
+      "dependencies": {
+        "@dimforge/rapier3d-compat": "~0.12.0",
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": ">=0.5.17",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~1.1.1"
+      }
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.24",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
+      "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
+      "license": "MIT"
+    },
     "node_modules/@types/yauzl": {
       "version": "2.10.3",
       "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
@@ -3129,6 +3296,24 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@use-gesture/core": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@use-gesture/core/-/core-10.3.1.tgz",
+      "integrity": "sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw==",
+      "license": "MIT"
+    },
+    "node_modules/@use-gesture/react": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@use-gesture/react/-/react-10.3.1.tgz",
+      "integrity": "sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@use-gesture/core": "10.3.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0"
       }
     },
     "node_modules/@vitejs/plugin-react": {
@@ -3585,7 +3770,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3619,7 +3803,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
       "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "require-from-string": "^2.0.2"
@@ -3702,7 +3885,6 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
       "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3774,6 +3956,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/camera-controls": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/camera-controls/-/camera-controls-3.1.2.tgz",
+      "integrity": "sha512-xkxfpG2ECZ6Ww5/9+kf4mfg1VEYAoe9aDSY+IwF0UEs7qEzwy0aVRfs2grImIECs/PoBtWFrh7RXsQkwG922JA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.0.0",
+        "npm": ">=10.5.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.126.1"
       }
     },
     "node_modules/caniuse-lite": {
@@ -3997,11 +4192,28 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -4016,14 +4228,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/cross-spawn/node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -4099,7 +4309,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {
@@ -4158,6 +4367,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/detect-gpu": {
+      "version": "5.0.70",
+      "resolved": "https://registry.npmjs.org/detect-gpu/-/detect-gpu-5.0.70.tgz",
+      "integrity": "sha512-bqerEP1Ese6nt3rFkwPnGbsUF9a4q+gMmpTVVOEzoCyeCc+y7/RvJnQZJx1JwhgQI5Ntg0Kgat8Uu7XpBqnz1w==",
+      "license": "MIT",
+      "dependencies": {
+        "webgl-constants": "^1.1.1"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -4188,6 +4406,12 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/draco3d": {
+      "version": "1.5.7",
+      "resolved": "https://registry.npmjs.org/draco3d/-/draco3d-1.5.7.tgz",
+      "integrity": "sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/drizzle-kit": {
       "version": "0.30.6",
@@ -4708,6 +4932,12 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -4883,6 +5113,12 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/glsl-noise": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/glsl-noise/-/glsl-noise-0.0.0.tgz",
+      "integrity": "sha512-b/ZCF6amfAUb7dJM/MxRs7AetQEahYzJ8PtgfrmEdtw6uyGOr+ZSGtgjFm6mfsBkxJ4d2W7kg+Nlqzqvn3Bc0w==",
+      "license": "MIT"
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -4902,6 +5138,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/hls.js": {
+      "version": "1.6.16",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.6.16.tgz",
+      "integrity": "sha512-VSIRpLfRwlAAdGL4wiTucx2ScRipo0ed1FBatWkyt832jC4CReKstga6yIhYVwGu9LOBjuX9wzmRMeQdBJtzEA==",
+      "license": "Apache-2.0"
     },
     "node_modules/html-encoding-sniffer": {
       "version": "6.0.0",
@@ -4948,7 +5190,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4964,6 +5205,12 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
     },
     "node_modules/indent-string": {
       "version": "4.0.0",
@@ -5094,6 +5341,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/is-promise": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
+      "license": "MIT"
+    },
     "node_modules/is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -5122,6 +5375,18 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/its-fine": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/its-fine/-/its-fine-2.0.0.tgz",
+      "integrity": "sha512-KLViCmWx94zOvpLwSlsx6yOCeMhZYaxrJV87Po5k/FoZzcPSahvK5qJ7fYhS61sZi5ikmh2S3Hz55A2l3U69ng==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react-reconciler": "^0.28.9"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0"
       }
     },
     "node_modules/jackspeak": {
@@ -5295,6 +5560,15 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
     "node_modules/light-my-request": {
       "version": "6.6.0",
       "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-6.6.0.tgz",
@@ -5440,6 +5714,16 @@
         "lz-string": "bin/bin.js"
       }
     },
+    "node_modules/maath": {
+      "version": "0.10.8",
+      "resolved": "https://registry.npmjs.org/maath/-/maath-0.10.8.tgz",
+      "integrity": "sha512-tRvbDF0Pgqz+9XUa4jjfgAQ8/aPKmQdWXilFu2tMy4GWj4NOsx99HlULO4IeREfbO3a0sA145DZYyvXPkybm0g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/three": ">=0.134.0",
+        "three": ">=0.134.0"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -5466,6 +5750,21 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/meshline": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/meshline/-/meshline-3.3.1.tgz",
+      "integrity": "sha512-/TQj+JdZkeSUOl5Mk2J7eLcYTLiQm2IDzmlSvYm7ov15anEcDJ92GHqqazxTSreeNgfnYu24kiEvvv0WlbCdFQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">=0.137"
+      }
+    },
+    "node_modules/meshoptimizer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-1.1.1.tgz",
+      "integrity": "sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==",
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -5758,7 +6057,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6195,6 +6493,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/potpack": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.2.tgz",
+      "integrity": "sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ==",
+      "license": "ISC"
+    },
     "node_modules/pretty-format": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
@@ -6268,6 +6572,16 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/promise-worker-transferable": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/promise-worker-transferable/-/promise-worker-transferable-1.0.4.tgz",
+      "integrity": "sha512-bN+0ehEnrXfxV2ZQvU2PetO0n4gqBD4ulq3MI1WOPLgr7/Mg9yRQkX5+0v1vagr74ZTsl7XtzlaYDo2EuCeYJw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "is-promise": "^2.1.0",
+        "lie": "^3.0.2"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -6381,6 +6695,21 @@
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-use-measure": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/react-use-measure/-/react-use-measure-2.1.7.tgz",
+      "integrity": "sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.13",
+        "react-dom": ">=16.13"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/read-cache": {
@@ -6801,7 +7130,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -6814,7 +7142,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6913,6 +7240,32 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
       "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+      "license": "MIT"
+    },
+    "node_modules/stats-gl": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/stats-gl/-/stats-gl-2.4.2.tgz",
+      "integrity": "sha512-g5O9B0hm9CvnM36+v7SFl39T7hmAlv541tU81ME8YeSb3i1CIP5/QdDeSB3A0la0bKNHpxpwxOVRo2wFTYEosQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/three": "*",
+        "three": "^0.170.0"
+      },
+      "peerDependencies": {
+        "@types/three": "*",
+        "three": "*"
+      }
+    },
+    "node_modules/stats-gl/node_modules/three": {
+      "version": "0.170.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.170.0.tgz",
+      "integrity": "sha512-FQK+LEpYc0fBD+J8g6oSEyyNzjp+Q7Ks1C568WWaoMRLW+TkNNWmenWeGgJjV105Gd+p/2ql1ZcjYvNiPZBhuQ==",
+      "license": "MIT"
+    },
+    "node_modules/stats.js": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/stats.js/-/stats.js-0.17.0.tgz",
+      "integrity": "sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw==",
       "license": "MIT"
     },
     "node_modules/std-env": {
@@ -7097,6 +7450,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/suspend-react": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/suspend-react/-/suspend-react-0.1.3.tgz",
+      "integrity": "sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=17.0"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -7230,6 +7592,44 @@
       "dependencies": {
         "real-require": "^0.2.0"
       }
+    },
+    "node_modules/three": {
+      "version": "0.184.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.184.0.tgz",
+      "integrity": "sha512-wtTRjG92pM5eUg/KuUnHsqSAlPM296brTOcLgMRqEeylYTh/CdtvKUvCyyCQTzFuStieWxvZb8mVTMvdPyUpxg==",
+      "license": "MIT"
+    },
+    "node_modules/three-mesh-bvh": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/three-mesh-bvh/-/three-mesh-bvh-0.8.3.tgz",
+      "integrity": "sha512-4G5lBaF+g2auKX3P0yqx+MJC6oVt6sB5k+CchS6Ob0qvH0YIhuUk1eYr7ktsIpY+albCqE80/FVQGV190PmiAg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">= 0.159.0"
+      }
+    },
+    "node_modules/three-stdlib": {
+      "version": "2.36.1",
+      "resolved": "https://registry.npmjs.org/three-stdlib/-/three-stdlib-2.36.1.tgz",
+      "integrity": "sha512-XyGQrFmNQ5O/IoKm556ftwKsBg11TIb301MB5dWNicziQBEs2g3gtOYIf7pFiLa0zI2gUwhtCjv9fmjnxKZ1Cg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/draco3d": "^1.4.0",
+        "@types/offscreencanvas": "^2019.6.4",
+        "@types/webxr": "^0.5.2",
+        "draco3d": "^1.4.1",
+        "fflate": "^0.6.9",
+        "potpack": "^1.0.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.128.0"
+      }
+    },
+    "node_modules/three-stdlib/node_modules/fflate": {
+      "version": "0.6.10",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.6.10.tgz",
+      "integrity": "sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg==",
+      "license": "MIT"
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -7373,6 +7773,36 @@
       "engines": {
         "node": ">=20"
       }
+    },
+    "node_modules/troika-three-text": {
+      "version": "0.52.4",
+      "resolved": "https://registry.npmjs.org/troika-three-text/-/troika-three-text-0.52.4.tgz",
+      "integrity": "sha512-V50EwcYGruV5rUZ9F4aNsrytGdKcXKALjEtQXIOBfhVoZU9VAqZNIoGQ3TMiooVqFAbR1w15T+f+8gkzoFzawg==",
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.2",
+        "troika-three-utils": "^0.52.4",
+        "troika-worker-utils": "^0.52.0",
+        "webgl-sdf-generator": "1.1.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.125.0"
+      }
+    },
+    "node_modules/troika-three-utils": {
+      "version": "0.52.4",
+      "resolved": "https://registry.npmjs.org/troika-three-utils/-/troika-three-utils-0.52.4.tgz",
+      "integrity": "sha512-NORAStSVa/BDiG52Mfudk4j1FG4jC4ILutB3foPnfGbOeIs9+G5vZLa0pnmnaftZUGm4UwSoqEpWdqvC7zms3A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">=0.125.0"
+      }
+    },
+    "node_modules/troika-worker-utils": {
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/troika-worker-utils/-/troika-worker-utils-0.52.0.tgz",
+      "integrity": "sha512-W1CpvTHykaPH5brv5VHLfQo9D1OYuo0cSBEUQFFT/nBUzM8iD6Lq2/tgG/f1OelbAS1WtaTPQzE5uM49egnngw==",
+      "license": "MIT"
     },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
@@ -7863,6 +8293,43 @@
         "@esbuild/win32-x64": "0.27.3"
       }
     },
+    "node_modules/tunnel-rat": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tunnel-rat/-/tunnel-rat-0.1.2.tgz",
+      "integrity": "sha512-lR5VHmkPhzdhrM092lI2nACsLO4QubF0/yoOhzX7c+wIpbN1GjHNzCc91QlpxBi+cnx8vVJ+Ur6vL5cEoQPFpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "zustand": "^4.3.2"
+      }
+    },
+    "node_modules/tunnel-rat/node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/turbo": {
       "version": "2.8.10",
       "resolved": "https://registry.npmjs.org/turbo/-/turbo-2.8.10.tgz",
@@ -8026,12 +8493,30 @@
         "browserslist": ">= 4.21.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/utility-types": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.11.0.tgz",
+      "integrity": "sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
     },
     "node_modules/uuid": {
       "version": "11.1.0",
@@ -8740,6 +9225,17 @@
         "node": ">=18"
       }
     },
+    "node_modules/webgl-constants": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/webgl-constants/-/webgl-constants-1.1.1.tgz",
+      "integrity": "sha512-LkBXKjU5r9vAW7Gcu3T5u+5cvSvh5WwINdr0C+9jpzVB41cjQAP5ePArDtk/WHYdVj0GefCgM73BA7FlIiNtdg=="
+    },
+    "node_modules/webgl-sdf-generator": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/webgl-sdf-generator/-/webgl-sdf-generator-1.1.1.tgz",
+      "integrity": "sha512-9Z0JcMTFxeE+b2x1LJTdnaT8rT8aEp7MVxkNwoycNmJWwPdzoXzMh0BjJSh/AEFP+KPYZUli814h8bJZFIZ2jA==",
+      "license": "MIT"
+    },
     "node_modules/webidl-conversions": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
@@ -8974,6 +9470,35 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.14",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.14.tgz",
+      "integrity": "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     },
     "packages/shared": {


### PR DESCRIPTION
## Summary

**P2** of the frontend redesign program (roadmap in `docs/superpowers/specs/2026-05-29-design-system-foundation-design.md`). Fully redesigns the **Model Detail page** and adds an in-browser **3D STL viewer**. Frontend-only — **no backend, API, schema, or shared-type changes**.

Builds on P1 (#46, already merged to `main`), so the diff here is P2-only.

## What changed

**Redesigned Model Detail page** (`pages/ModelDetailPage.tsx`)
- Header with a multi-hierarchy breadcrumb: `Library › Collection › Model` (collection = `collections[0]`, links to `/collections/:id`).
- Hero column: the existing image gallery + a prominent **"View in 3D"** button (hidden when the model has no STL).
- Tabbed right panel: **Info** (model info + metadata) · **Collections** · **Files**.

**3D STL viewer**
- Built on `three` + `@react-three/fiber` + `@react-three/drei`: `Canvas` + `Bounds` + `OrbitControls`, STL loaded via `useLoader(STLLoader, url)`.
- **Lazy-loaded**: `ModelViewer3DScene` is the *only* module importing three.js and is reached solely via `React.lazy`, so three.js builds as a **separate ~924 KB async chunk** (gzip 251 KB) loaded only on first viewer open — the main bundle is unaffected.
- `Suspense` fallback + a class error boundary with retry; STL switcher chips when a model has multiple STLs.
- Reachable from the hero button (primary STL) and from a per-STL **"3D"** affordance on file-tree rows.

**Supporting changes**
- `lib/model-files.ts` — pure helpers (`collectStlFiles` / `getPrimaryStl` / `makeStlRef`) that reconstruct STL relative paths from the file tree (`FileTreeNode` carries no `relativePath`) and build `/api/files/models/{id}/{path}` URLs (same-origin → session cookie sent automatically).
- New components: `ModelBreadcrumb`, `ModelHero`, `ModelDetailPanel`, `PanelTabs` (segmented control modeled on `ViewSwitch`).
- `FileTree.tsx` — migrated literal `text-amber-*`/`text-blue-*` colors to design tokens, threads a path prefix, added `modelId` + `onOpenStl`. `CollectionsList.tsx` token fix. Reshaped `ModelDetailSkeleton`. Added `Model3DIcon`/`ResetViewIcon` to the icon map.
- Icon props typed `React.ComponentType<{ className?: string }>` instead of `React.ElementType` in `ViewSwitch`/`PivotMain`/`PanelTabs`: `@react-three/fiber` augments the global `react` `JSX.IntrinsicElements` with three.js elements, which otherwise collapses `className` to `never` for `ElementType`-typed icons program-wide.

**Docs** — `ARCHITECTURE.md` (detail-page components + 3D viewer + decision log), `CONVENTIONS.md` (three.js bundle-isolation rule + the `ElementType` gotcha), roadmap marked P2 shipped.

## Testing
- `npx vitest run` — **159 passed** (new suites: `model-files`, `ModelBreadcrumb`, `FileTree`, `ModelViewer3DModal`; scene mocked since jsdom has no WebGL).
- `tsc -b` + `vite build` green; confirmed three.js emits as a separate async chunk.
- Reviewer + documentation agents run; reviewer's one actionable item (label the dialog via `DialogTitle`) applied.

## Manual QA not yet done
Live browser verification (orbit/zoom a real STL, multi-STL switching, cookie-auth fetch, palette/dark-mode pass) still needs a running backend + a model with STL files. Steps are in the plan's verification checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)