### PR TITLE
feat(p3): staged upload + global search (Workflow Pages)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ test-files/
 /apps/frontend/.claude/agent-memory/
 .claude/ToDo.md
 /apps/backend/data
+/data

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -11,6 +11,7 @@ import { metadataFieldRoutes, modelMetadataRoute } from './routes/metadata.js';
 import { bulkRoutes } from './routes/bulk.js';
 import { collectionRoutes } from './routes/collections.js';
 import { fileRoutes } from './routes/files.js';
+import { searchRoutes } from './routes/search.js';
 import { startIngestionWorker } from './workers/ingestion.worker.js';
 
 export async function buildApp(): Promise<ReturnType<typeof Fastify>> {
@@ -65,6 +66,7 @@ export async function buildApp(): Promise<ReturnType<typeof Fastify>> {
   await app.register(bulkRoutes, { prefix: '/bulk' });
   await app.register(collectionRoutes, { prefix: '/collections' });
   await app.register(fileRoutes, { prefix: '/files' });
+  await app.register(searchRoutes, { prefix: '/search' });
 
   // Start background workers
   startIngestionWorker();

--- a/apps/backend/src/db/migrations/0008_add_import_sessions.sql
+++ b/apps/backend/src/db/migrations/0008_add_import_sessions.sql
@@ -1,0 +1,28 @@
+-- Add import_sessions table for staged archive upload workflow (scan → review → commit).
+-- An import session is created when an archive is uploaded, tracks the scan and commit
+-- lifecycle, and is deleted (or expired) once a model is committed or the session discarded.
+
+CREATE TABLE "import_sessions" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "user_id" uuid NOT NULL,
+  "library_id" uuid NOT NULL,
+  "original_filename" varchar(512) NOT NULL,
+  "status" varchar(20) DEFAULT 'scanning' NOT NULL,
+  "detected" jsonb,
+  "manifest" jsonb,
+  "staging_path" text,
+  "model_id" uuid,
+  "error" text,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "expires_at" timestamp with time zone
+);--> statement-breakpoint
+ALTER TABLE "import_sessions" ADD CONSTRAINT "import_sessions_user_id_users_id_fk"
+  FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "import_sessions" ADD CONSTRAINT "import_sessions_library_id_libraries_id_fk"
+  FOREIGN KEY ("library_id") REFERENCES "public"."libraries"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "import_sessions" ADD CONSTRAINT "import_sessions_model_id_models_id_fk"
+  FOREIGN KEY ("model_id") REFERENCES "public"."models"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "import_sessions_user_id_idx" ON "import_sessions" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "import_sessions_library_id_idx" ON "import_sessions" USING btree ("library_id");--> statement-breakpoint
+CREATE INDEX "import_sessions_status_idx" ON "import_sessions" USING btree ("status");

--- a/apps/backend/src/db/migrations/meta/_journal.json
+++ b/apps/backend/src/db/migrations/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1772100002000,
       "tag": "0007_add_library_id",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1748591400000,
+      "tag": "0008_add_import_sessions",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/backend/src/db/schema/import-session.ts
+++ b/apps/backend/src/db/schema/import-session.ts
@@ -1,0 +1,44 @@
+import { pgTable, uuid, varchar, text, jsonb, timestamp, index } from 'drizzle-orm/pg-core';
+import type { DetectedImportMetadata } from '@alexandria/shared';
+import { users } from './user.js';
+import { libraries } from './library.js';
+import { models } from './model.js';
+
+/**
+ * A staged archive upload awaiting review/commit.
+ *
+ * An uploaded archive is scanned (extracted + inspected) into a `staging_path`
+ * without being committed. The detected metadata + file manifest are persisted
+ * here so the user can review/edit before committing the session into a model.
+ * Abandoned sessions are reaped via `expires_at`.
+ */
+export const importSessions = pgTable(
+  'import_sessions',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    userId: uuid('user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    libraryId: uuid('library_id')
+      .notNull()
+      .references(() => libraries.id, { onDelete: 'cascade' }),
+    originalFilename: varchar('original_filename', { length: 512 }).notNull(),
+    status: varchar('status', { length: 20 }).notNull().default('scanning'),
+    // Best-effort metadata detected during scan.
+    detected: jsonb('detected').$type<DetectedImportMetadata>(),
+    // The file manifest captured at scan, reused at commit (FileManifest shape).
+    manifest: jsonb('manifest').$type<unknown>(),
+    // Directory of extracted files kept between scan and commit.
+    stagingPath: text('staging_path'),
+    modelId: uuid('model_id').references(() => models.id, { onDelete: 'set null' }),
+    error: text('error'),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+    expiresAt: timestamp('expires_at', { withTimezone: true }),
+  },
+  (table) => [
+    index('import_sessions_user_id_idx').on(table.userId),
+    index('import_sessions_library_id_idx').on(table.libraryId),
+    index('import_sessions_status_idx').on(table.status),
+  ],
+);

--- a/apps/backend/src/db/schema/index.ts
+++ b/apps/backend/src/db/schema/index.ts
@@ -7,3 +7,4 @@ export * from './thumbnail.js';
 export * from './metadata.js';
 export * from './tag.js';
 export * from './collection.js';
+export * from './import-session.js';

--- a/apps/backend/src/routes/import-sessions.test.ts
+++ b/apps/backend/src/routes/import-sessions.test.ts
@@ -23,6 +23,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import type { FastifyInstance } from 'fastify';
+import type { FileType } from '@alexandria/shared';
 import { eq, inArray } from 'drizzle-orm';
 import { buildApp } from '../app.js';
 import { db } from '../db/index.js';
@@ -519,7 +520,7 @@ describe('POST /models/import-sessions/:id/commit', () => {
         {
           filename: 'model.stl',
           relativePath: 'model.stl',
-          fileType: 'stl',
+          fileType: 'stl' as FileType,
           mimeType: 'model/stl',
           sizeBytes: fs.statSync(stlPath).size,
           hash: 'abc123test',

--- a/apps/backend/src/routes/import-sessions.test.ts
+++ b/apps/backend/src/routes/import-sessions.test.ts
@@ -1,0 +1,706 @@
+/**
+ * Integration tests for the staged-import routes in /models (P3).
+ *
+ * Routes under test:
+ *   GET  /models/import-sessions
+ *   GET  /models/import-sessions/:id
+ *   POST /models/import-sessions/:id/commit
+ *   DELETE /models/import-sessions/:id
+ *
+ * Each test uses the real Fastify app (buildApp) + real Postgres.
+ * Session rows are seeded directly via importSessionService (bypassing BullMQ)
+ * so we never actually enqueue jobs.
+ *
+ * Auth is established by POST /auth/login (identical to auth.test.ts pattern).
+ * requireLibrary resolves the user's default library server-side.
+ *
+ * NOTE: The POST /upload/:uploadId/complete endpoint now returns { sessionId }
+ * (not the old { modelId, jobId }). That contract change is verified here.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type { FastifyInstance } from 'fastify';
+import { eq, inArray } from 'drizzle-orm';
+import { buildApp } from '../app.js';
+import { db } from '../db/index.js';
+import {
+  users,
+  libraries,
+  models,
+  importSessions,
+} from '../db/schema/index.js';
+import { importSessionService } from '../services/import-session.service.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+let app: FastifyInstance;
+let sessionCookie: string;
+let otherUserCookie: string;
+
+let testUserId: string;
+let otherUserId: string;
+let testLibraryId: string;
+
+// Session rows created during tests (cleaned up in afterEach)
+let perTestSessionIds: string[] = [];
+// Model rows created during tests (cleaned up in afterEach)
+let perTestModelIds: string[] = [];
+
+const TEST_EMAIL = 'import-route-test@example.com';
+const OTHER_EMAIL = 'import-route-other@example.com';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function login(email: string, password: string): Promise<string> {
+  const res = await app.inject({
+    method: 'POST',
+    url: '/auth/login',
+    payload: { email, password },
+  });
+  const setCookie = res.headers['set-cookie'];
+  const cookieStr = Array.isArray(setCookie) ? setCookie[0] : String(setCookie);
+  return cookieStr.split(';')[0];
+}
+
+/** Create a test import session directly in the DB (no BullMQ) and track it. */
+async function createSession(opts: {
+  userId?: string;
+  libraryId?: string;
+  status?: string;
+  filename?: string;
+}): Promise<string> {
+  const { id } = await importSessionService.create({
+    userId: opts.userId ?? testUserId,
+    libraryId: opts.libraryId ?? testLibraryId,
+    originalFilename: opts.filename ?? 'test.zip',
+  });
+
+  if (opts.status && opts.status !== 'scanning') {
+    await importSessionService.update(id, { status: opts.status as import('@alexandria/shared').ImportSessionStatus });
+  }
+
+  perTestSessionIds.push(id);
+  return id;
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+beforeAll(async () => {
+  app = await buildApp();
+  await app.ready();
+
+  const ts = Date.now();
+
+  // Remove leftover fixtures
+  for (const email of [TEST_EMAIL, OTHER_EMAIL]) {
+    const leftover = await db
+      .select({ id: users.id })
+      .from(users)
+      .where(eq(users.email, email));
+
+    if (leftover.length > 0) {
+      const ids = leftover.map((u) => u.id);
+      await db.delete(importSessions).where(inArray(importSessions.userId, ids));
+      await db.delete(libraries).where(inArray(libraries.userId, ids));
+      await db.delete(users).where(inArray(users.id, ids));
+    }
+  }
+
+  const authService = (
+    app as FastifyInstance & {
+      authService: import('../services/auth.service.js').AuthService;
+    }
+  ).authService;
+
+  // Primary test user
+  await authService.createUser(TEST_EMAIL, 'password123', 'Import Route Test User');
+  const [testUser] = await db
+    .select()
+    .from(users)
+    .where(eq(users.email, TEST_EMAIL))
+    .limit(1);
+  testUserId = testUser.id;
+
+  const [testLibrary] = await db
+    .insert(libraries)
+    .values({
+      name: 'Import Route Test Library',
+      slug: `import-route-lib-${ts}`,
+      userId: testUserId,
+      isDefault: true,
+    })
+    .returning();
+  testLibraryId = testLibrary.id;
+
+  sessionCookie = await login(TEST_EMAIL, 'password123');
+
+  // Secondary user (for auth/ownership tests)
+  await authService.createUser(OTHER_EMAIL, 'password123', 'Import Route Other User');
+  const [otherUser] = await db
+    .select()
+    .from(users)
+    .where(eq(users.email, OTHER_EMAIL))
+    .limit(1);
+  otherUserId = otherUser.id;
+
+  // Other user gets their own default library (requireLibrary will create it automatically)
+  otherUserCookie = await login(OTHER_EMAIL, 'password123');
+});
+
+afterAll(async () => {
+  // Final cleanup
+  const allSessionIds = [...perTestSessionIds].filter(Boolean);
+  if (allSessionIds.length > 0) {
+    await db.delete(importSessions).where(inArray(importSessions.id, allSessionIds));
+  }
+
+  const allModelIds = [...perTestModelIds].filter(Boolean);
+  if (allModelIds.length > 0) {
+    await db.delete(models).where(inArray(models.id, allModelIds));
+  }
+
+  const bothUsers = [testUserId, otherUserId].filter(Boolean);
+  if (bothUsers.length > 0) {
+    await db.delete(importSessions).where(inArray(importSessions.userId, bothUsers));
+    await db.delete(libraries).where(inArray(libraries.userId, bothUsers));
+    await db.delete(users).where(inArray(users.id, bothUsers));
+  }
+
+  await app.close();
+});
+
+afterEach(async () => {
+  // Clean up any sessions or models created during the most recent test
+  if (perTestSessionIds.length > 0) {
+    await db.delete(importSessions).where(inArray(importSessions.id, perTestSessionIds));
+    perTestSessionIds = [];
+  }
+  if (perTestModelIds.length > 0) {
+    await db.delete(models).where(inArray(models.id, perTestModelIds));
+    perTestModelIds = [];
+  }
+});
+
+// ---------------------------------------------------------------------------
+// GET /models/import-sessions
+// ---------------------------------------------------------------------------
+
+describe('GET /models/import-sessions', () => {
+  it('should return 401 when not authenticated', async () => {
+    const res = await app.inject({ method: 'GET', url: '/models/import-sessions' });
+
+    expect(res.statusCode).toBe(401);
+    const body = res.json();
+    expect(body.errors[0].code).toBe('UNAUTHORIZED');
+  });
+
+  it('should return 200 with { data: [], meta: null, errors: null } when no active sessions', async () => {
+    // Ensure the user has no active sessions before this test
+    const res = await app.inject({
+      method: 'GET',
+      url: '/models/import-sessions',
+      headers: { cookie: sessionCookie },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body).toHaveProperty('data');
+    expect(body).toHaveProperty('meta', null);
+    expect(body).toHaveProperty('errors', null);
+    expect(Array.isArray(body.data)).toBe(true);
+  });
+
+  it('should return active sessions in the envelope data array', async () => {
+    const id = await createSession({ status: 'scanning' });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/models/import-sessions',
+      headers: { cookie: sessionCookie },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    const found = body.data.find((s: { id: string }) => s.id === id);
+    expect(found).toBeDefined();
+    expect(found.status).toBe('scanning');
+    expect(found.originalFilename).toBe('test.zip');
+  });
+
+  it('should include sessions in all active statuses', async () => {
+    const statuses = ['scanning', 'ready_for_review', 'committing', 'error'] as const;
+    const createdIds: string[] = [];
+
+    for (const status of statuses) {
+      const id = await createSession({ status });
+      createdIds.push(id);
+    }
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/models/import-sessions',
+      headers: { cookie: sessionCookie },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    const returnedIds = body.data.map((s: { id: string }) => s.id);
+
+    for (const id of createdIds) {
+      expect(returnedIds).toContain(id);
+    }
+  });
+
+  it('should NOT include committed sessions', async () => {
+    const id = await createSession({ status: 'committed' });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/models/import-sessions',
+      headers: { cookie: sessionCookie },
+    });
+
+    const body = res.json();
+    const returnedIds = body.data.map((s: { id: string }) => s.id);
+    expect(returnedIds).not.toContain(id);
+  });
+
+  it('should return ImportSession DTO shape for each session', async () => {
+    const id = await createSession({ status: 'scanning' });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/models/import-sessions',
+      headers: { cookie: sessionCookie },
+    });
+
+    const body = res.json();
+    const session = body.data.find((s: { id: string }) => s.id === id);
+    expect(session).toHaveProperty('id');
+    expect(session).toHaveProperty('originalFilename');
+    expect(session).toHaveProperty('status');
+    expect(session).toHaveProperty('detected');
+    expect(session).toHaveProperty('modelId');
+    expect(session).toHaveProperty('error');
+    expect(session).toHaveProperty('createdAt');
+    // Internal fields must NOT be exposed
+    expect(session).not.toHaveProperty('userId');
+    expect(session).not.toHaveProperty('libraryId');
+    expect(session).not.toHaveProperty('stagingPath');
+  });
+
+  it('should only return sessions for the authenticated user (library isolation)', async () => {
+    // Create a session for the primary user
+    const primaryId = await createSession({ status: 'scanning' });
+
+    // Other user's session (managed via importSessionService directly)
+    const otherUserDb = await db
+      .select()
+      .from(users)
+      .where(eq(users.email, OTHER_EMAIL))
+      .limit(1);
+    const otherLibraries = await db
+      .select()
+      .from(libraries)
+      .where(eq(libraries.userId, otherUserDb[0].id));
+
+    if (otherLibraries.length > 0) {
+      const { id: otherId } = await importSessionService.create({
+        userId: otherUserId,
+        libraryId: otherLibraries[0].id,
+        originalFilename: 'other-user-session.zip',
+      });
+      perTestSessionIds.push(otherId);
+
+      const res = await app.inject({
+        method: 'GET',
+        url: '/models/import-sessions',
+        headers: { cookie: sessionCookie },
+      });
+
+      const body = res.json();
+      const returnedIds = body.data.map((s: { id: string }) => s.id);
+      expect(returnedIds).toContain(primaryId);
+      expect(returnedIds).not.toContain(otherId);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /models/import-sessions/:id
+// ---------------------------------------------------------------------------
+
+describe('GET /models/import-sessions/:id', () => {
+  it('should return 401 when not authenticated', async () => {
+    const id = await createSession({ status: 'scanning' });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/models/import-sessions/${id}`,
+    });
+
+    expect(res.statusCode).toBe(401);
+    expect(res.json().errors[0].code).toBe('UNAUTHORIZED');
+  });
+
+  it('should return 200 with the ImportSession DTO in the envelope', async () => {
+    const id = await createSession({ status: 'ready_for_review' });
+
+    // Update with some detected metadata
+    const detected = {
+      modelCount: 2,
+      fileCount: 10,
+      totalSizeBytes: 3_000_000,
+      artist: 'detected-artist',
+      tagsGuessed: ['dragon'],
+      folderStructure: [],
+    };
+    await importSessionService.update(id, { detected });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/models/import-sessions/${id}`,
+      headers: { cookie: sessionCookie },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body).toHaveProperty('meta', null);
+    expect(body).toHaveProperty('errors', null);
+
+    const session = body.data;
+    expect(session.id).toBe(id);
+    expect(session.status).toBe('ready_for_review');
+    expect(session.detected).not.toBeNull();
+    expect(session.detected.artist).toBe('detected-artist');
+  });
+
+  it('should return 404 NOT_FOUND for an unknown session id', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/models/import-sessions/00000000-0000-0000-0000-000000000000',
+      headers: { cookie: sessionCookie },
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(res.json().errors[0].code).toBe('NOT_FOUND');
+  });
+
+  it('should return 404 NOT_FOUND when the session belongs to another user', async () => {
+    const id = await createSession({ status: 'scanning' });
+
+    // Other user tries to access the primary user's session
+    const res = await app.inject({
+      method: 'GET',
+      url: `/models/import-sessions/${id}`,
+      headers: { cookie: otherUserCookie },
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(res.json().errors[0].code).toBe('NOT_FOUND');
+  });
+
+  it('should return 400 VALIDATION_ERROR for a non-UUID session id', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/models/import-sessions/not-a-uuid',
+      headers: { cookie: sessionCookie },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().errors[0].code).toBe('VALIDATION_ERROR');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /models/import-sessions/:id/commit
+// ---------------------------------------------------------------------------
+
+describe('POST /models/import-sessions/:id/commit', () => {
+  it('should return 401 when not authenticated', async () => {
+    const id = await createSession({ status: 'ready_for_review' });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/models/import-sessions/${id}/commit`,
+      payload: {},
+    });
+
+    expect(res.statusCode).toBe(401);
+    expect(res.json().errors[0].code).toBe('UNAUTHORIZED');
+  });
+
+  it('should return 400 VALIDATION_ERROR when session is not in ready_for_review state', async () => {
+    // Session is still 'scanning' — commit requires 'ready_for_review'
+    const id = await createSession({ status: 'scanning' });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/models/import-sessions/${id}/commit`,
+      headers: { cookie: sessionCookie },
+      payload: {},
+    });
+
+    expect(res.statusCode).toBe(400);
+    const body = res.json();
+    expect(body.errors[0].code).toBe('VALIDATION_ERROR');
+  });
+
+  it('should return 404 when committing a session that belongs to another user', async () => {
+    // Session owned by primary user, accessed by other user
+    const id = await createSession({ status: 'ready_for_review' });
+    // Need staged data so the commit doesn't fail on missing manifest — but
+    // the ownership check happens first, so 404 is expected before any manifest check.
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/models/import-sessions/${id}/commit`,
+      headers: { cookie: otherUserCookie },
+      payload: {},
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(res.json().errors[0].code).toBe('NOT_FOUND');
+  });
+
+  it('should return 400 for a non-UUID session id', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/models/import-sessions/not-a-uuid/commit',
+      headers: { cookie: sessionCookie },
+      payload: {},
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().errors[0].code).toBe('VALIDATION_ERROR');
+  });
+
+  it('should accept an empty batchMetadata body (optional field)', async () => {
+    // The body schema treats batchMetadata as optional; an empty object is valid.
+    // We still get a 400 from the service (wrong status), not a 400 from body validation.
+    const id = await createSession({ status: 'scanning' });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/models/import-sessions/${id}/commit`,
+      headers: { cookie: sessionCookie },
+      payload: {},
+    });
+
+    // 400 comes from the service (wrong status), which proves body validation passed.
+    expect(res.statusCode).toBe(400);
+    const body = res.json();
+    // The error is about session state, not body shape
+    expect(body.errors[0].code).toBe('VALIDATION_ERROR');
+    expect(body.errors[0].message).toMatch(/not ready to commit/i);
+  });
+
+  it('should return 202 with { data: { modelId, jobId }, meta: null, errors: null } on success', async () => {
+    // The commit endpoint requires a 'ready_for_review' session + a manifest
+    // stored in it. We create a real temp staging directory with a real file so
+    // the BullMQ commit worker (running in the same process) doesn't ENOENT.
+    const stagingDir = fs.mkdtempSync(path.join(os.tmpdir(), 'alex-commit-test-'));
+    const stlPath = path.join(stagingDir, 'model.stl');
+    fs.writeFileSync(stlPath, 'solid model\nendsolid model\n');
+
+    const id = await createSession({ status: 'scanning' });
+
+    const manifest = {
+      entries: [
+        {
+          filename: 'model.stl',
+          relativePath: 'model.stl',
+          fileType: 'stl',
+          mimeType: 'model/stl',
+          sizeBytes: fs.statSync(stlPath).size,
+          hash: 'abc123test',
+        },
+      ],
+      totalSizeBytes: fs.statSync(stlPath).size,
+    };
+
+    await importSessionService.update(id, {
+      status: 'ready_for_review',
+      manifest,
+      stagingPath: stagingDir,
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/models/import-sessions/${id}/commit`,
+      headers: { cookie: sessionCookie },
+      payload: {},
+    });
+
+    // The route enqueues a BullMQ job (real Redis is running) and returns 202
+    expect(res.statusCode).toBe(202);
+    const body = res.json();
+    expect(body).toHaveProperty('meta', null);
+    expect(body).toHaveProperty('errors', null);
+    expect(body.data).toHaveProperty('modelId');
+    expect(body.data).toHaveProperty('jobId');
+    expect(typeof body.data.modelId).toBe('string');
+    expect(typeof body.data.jobId).toBe('string');
+
+    // Track the created model for cleanup
+    perTestModelIds.push(body.data.modelId);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DELETE /models/import-sessions/:id
+// ---------------------------------------------------------------------------
+
+describe('DELETE /models/import-sessions/:id', () => {
+  it('should return 401 when not authenticated', async () => {
+    const id = await createSession({ status: 'scanning' });
+
+    const res = await app.inject({
+      method: 'DELETE',
+      url: `/models/import-sessions/${id}`,
+    });
+
+    expect(res.statusCode).toBe(401);
+    expect(res.json().errors[0].code).toBe('UNAUTHORIZED');
+  });
+
+  it('should return 200 with { data: null, meta: null, errors: null } on success', async () => {
+    const id = await createSession({ status: 'ready_for_review' });
+    // Remove from tracking since we're deleting it explicitly
+    perTestSessionIds = perTestSessionIds.filter((sid) => sid !== id);
+
+    const res = await app.inject({
+      method: 'DELETE',
+      url: `/models/import-sessions/${id}`,
+      headers: { cookie: sessionCookie },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body).toEqual({ data: null, meta: null, errors: null });
+  });
+
+  it('should remove the session from the database after deletion', async () => {
+    const id = await createSession({ status: 'scanning' });
+    perTestSessionIds = perTestSessionIds.filter((sid) => sid !== id);
+
+    await app.inject({
+      method: 'DELETE',
+      url: `/models/import-sessions/${id}`,
+      headers: { cookie: sessionCookie },
+    });
+
+    const row = await importSessionService.getRow(id);
+    expect(row).toBeUndefined();
+  });
+
+  it('should return 404 when trying to delete another user\'s session', async () => {
+    const id = await createSession({ status: 'scanning' });
+
+    const res = await app.inject({
+      method: 'DELETE',
+      url: `/models/import-sessions/${id}`,
+      headers: { cookie: otherUserCookie },
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(res.json().errors[0].code).toBe('NOT_FOUND');
+
+    // The session must still exist (not deleted by the wrong user)
+    const row = await importSessionService.getRow(id);
+    expect(row).toBeDefined();
+  });
+
+  it('should return 400 VALIDATION_ERROR for a non-UUID session id', async () => {
+    const res = await app.inject({
+      method: 'DELETE',
+      url: '/models/import-sessions/not-a-uuid',
+      headers: { cookie: sessionCookie },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().errors[0].code).toBe('VALIDATION_ERROR');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Upload complete endpoint — sessionId contract (P3 change)
+// ---------------------------------------------------------------------------
+
+describe('POST /models/upload/:uploadId/complete — response shape', () => {
+  it('should return { data: { sessionId }, ... } not { data: { modelId, jobId } }', async () => {
+    // Build a minimal valid zip file so the assembleFile size check passes.
+    // The zip end-of-central-directory (EOCD) record is 22 bytes; an empty zip
+    // consists of just this record. yauzl will open it as a valid empty archive.
+    const eocd = Buffer.from([
+      0x50, 0x4b, 0x05, 0x06, // EOCD signature
+      0x00, 0x00,              // disk number
+      0x00, 0x00,              // disk with central dir start
+      0x00, 0x00,              // entries on this disk
+      0x00, 0x00,              // total entries
+      0x00, 0x00, 0x00, 0x00, // central dir size
+      0x00, 0x00, 0x00, 0x00, // central dir offset
+      0x00, 0x00,              // comment length
+    ]);
+
+    // Step 1: Init an upload session with the exact file size
+    const initRes = await app.inject({
+      method: 'POST',
+      url: '/models/upload/init',
+      headers: { cookie: sessionCookie },
+      payload: {
+        filename: 'contract-test.zip',
+        totalSize: eocd.length,
+        totalChunks: 1,
+      },
+    });
+
+    expect(initRes.statusCode).toBe(201);
+    const { uploadId } = initRes.json().data;
+
+    // Step 2: Send the single chunk
+    const chunkRes = await app.inject({
+      method: 'PUT',
+      url: `/models/upload/${uploadId}/chunk/0`,
+      headers: {
+        cookie: sessionCookie,
+        'content-type': 'application/octet-stream',
+      },
+      payload: eocd,
+    });
+
+    expect(chunkRes.statusCode).toBe(200);
+
+    // Step 3: Call complete — the new P3 contract returns { sessionId }.
+    const completeRes = await app.inject({
+      method: 'POST',
+      url: `/models/upload/${uploadId}/complete`,
+      headers: { cookie: sessionCookie },
+    });
+
+    // The route returns 202 with { data: { sessionId } }.
+    expect(completeRes.statusCode).toBe(202);
+    const completeBody = completeRes.json();
+
+    expect(completeBody).toHaveProperty('meta', null);
+    expect(completeBody).toHaveProperty('errors', null);
+
+    // New P3 contract: data has sessionId, NOT modelId/jobId
+    expect(completeBody.data).toHaveProperty('sessionId');
+    expect(typeof completeBody.data.sessionId).toBe('string');
+    expect(completeBody.data).not.toHaveProperty('modelId');
+    expect(completeBody.data).not.toHaveProperty('jobId');
+
+    // Track session for cleanup
+    perTestSessionIds.push(completeBody.data.sessionId);
+  });
+});

--- a/apps/backend/src/routes/models.ts
+++ b/apps/backend/src/routes/models.ts
@@ -5,7 +5,12 @@ import os from 'node:os';
 import path from 'node:path';
 import type { FastifyInstance } from 'fastify';
 import type { Readable } from 'node:stream';
-import type { ImportConfig, ModelSearchParams, UpdateModelRequest } from '@alexandria/shared';
+import type {
+  ImportConfig,
+  ModelSearchParams,
+  UpdateModelRequest,
+  BatchUploadMetadata,
+} from '@alexandria/shared';
 import {
   importConfigSchema,
   modelSearchParamsSchema,
@@ -13,12 +18,15 @@ import {
   uploadInitSchema,
   chunkIndexParamsSchema,
   uploadCompleteParamsSchema,
+  commitImportSessionSchema,
+  importSessionIdParamsSchema,
 } from '@alexandria/shared';
 import { requireAuth } from '../middleware/auth.js';
 import { requireLibrary } from '../middleware/library.js';
 import { validate } from '../middleware/validate.js';
 import { detectArchiveExtension } from '../utils/archive.js';
 import { ingestionService } from '../services/ingestion.service.js';
+import { importSessionService } from '../services/import-session.service.js';
 import { modelService } from '../services/model.service.js';
 import { searchService } from '../services/search.service.js';
 import { presenterService } from '../services/presenter.service.js';
@@ -146,13 +154,13 @@ export async function modelRoutes(app: FastifyInstance): Promise<void> {
       const userId = request.user!.id;
 
       const { tempFilePath, originalFilename } = await uploadService.assembleFile(uploadId, userId);
-      const { modelId, jobId } = await ingestionService.handleUpload(
+      const { sessionId } = await ingestionService.handleScan(
         { tempFilePath, originalFilename },
         userId,
         request.libraryId!,
       );
 
-      return reply.status(202).send({ data: { modelId, jobId }, meta: null, errors: null });
+      return reply.status(202).send({ data: { sessionId }, meta: null, errors: null });
     },
   );
 
@@ -186,13 +194,80 @@ export async function modelRoutes(app: FastifyInstance): Promise<void> {
       }
 
       const userId = request.user!.id;
-      const { modelId, jobId } = await ingestionService.handleUpload(
+      const { sessionId } = await ingestionService.handleScan(
         { tempFilePath, originalFilename },
         userId,
         request.libraryId!,
       );
 
+      return reply.status(202).send({ data: { sessionId }, meta: null, errors: null });
+    },
+  );
+
+  // --- Staged import sessions (scan → review → commit) ---
+
+  // GET /import-sessions — list the current user's active sessions (the queue)
+  app.get(
+    '/import-sessions',
+    { preHandler: [requireAuth, requireLibrary] },
+    async (request, reply) => {
+      const sessions = await importSessionService.listActive(request.user!.id, request.libraryId!);
+      return reply.status(200).send({ data: sessions, meta: null, errors: null });
+    },
+  );
+
+  // GET /import-sessions/:id — poll a single session (status + detected metadata)
+  app.get(
+    '/import-sessions/:id',
+    { preHandler: [requireAuth] },
+    async (request, reply) => {
+      const parseResult = importSessionIdParamsSchema.safeParse(request.params);
+      if (!parseResult.success) {
+        throw validationError(parseResult.error.issues[0]?.message ?? 'Validation failed');
+      }
+      const row = await importSessionService.getOwnedRow(parseResult.data.id, request.user!.id);
+      return reply.status(200).send({ data: importSessionService.toDto(row), meta: null, errors: null });
+    },
+  );
+
+  // POST /import-sessions/:id/commit — apply batch metadata and create the model
+  app.post(
+    '/import-sessions/:id/commit',
+    { preHandler: [requireAuth, requireLibrary] },
+    async (request, reply) => {
+      const paramsResult = importSessionIdParamsSchema.safeParse(request.params);
+      if (!paramsResult.success) {
+        throw validationError(paramsResult.error.issues[0]?.message ?? 'Validation failed');
+      }
+      const bodyResult = commitImportSessionSchema.safeParse(request.body ?? {});
+      if (!bodyResult.success) {
+        const firstIssue = bodyResult.error.issues[0];
+        throw validationError(firstIssue?.message ?? 'Validation failed', firstIssue?.path.join('.'));
+      }
+
+      const batchMetadata = bodyResult.data.batchMetadata as BatchUploadMetadata | undefined;
+      const { modelId, jobId } = await ingestionService.handleCommit(
+        paramsResult.data.id,
+        batchMetadata,
+        request.user!.id,
+        request.libraryId!,
+      );
+
       return reply.status(202).send({ data: { modelId, jobId }, meta: null, errors: null });
+    },
+  );
+
+  // DELETE /import-sessions/:id — discard a session and its staged files
+  app.delete(
+    '/import-sessions/:id',
+    { preHandler: [requireAuth] },
+    async (request, reply) => {
+      const parseResult = importSessionIdParamsSchema.safeParse(request.params);
+      if (!parseResult.success) {
+        throw validationError(parseResult.error.issues[0]?.message ?? 'Validation failed');
+      }
+      await ingestionService.discardSession(parseResult.data.id, request.user!.id);
+      return reply.status(200).send({ data: null, meta: null, errors: null });
     },
   );
 

--- a/apps/backend/src/routes/search.test.ts
+++ b/apps/backend/src/routes/search.test.ts
@@ -1,0 +1,486 @@
+/**
+ * Integration tests for GET /search (globalSearchParamsSchema + searchRoutes).
+ *
+ * Tests hit the real Fastify app (buildApp) against the real test database.
+ * Auth is established via POST /auth/login cookie exactly as auth.test.ts does.
+ * requireLibrary injects libraryId server-side — no library header needed.
+ *
+ * Coverage:
+ * - Happy-path: hits in all four buckets (models, collections, artists, tags).
+ * - Envelope shape: { data, meta, errors }.
+ * - Validation: empty q → 400 VALIDATION_ERROR.
+ * - Auth guard: no cookie → 401 UNAUTHORIZED.
+ * - Library isolation: models/collections from another library do not appear.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import { eq, inArray } from 'drizzle-orm';
+import { buildApp } from '../app.js';
+import { db } from '../db/index.js';
+import {
+  users,
+  libraries,
+  models,
+  tags,
+  modelTags,
+  collections,
+  collectionModels,
+  metadataFieldDefinitions,
+  modelMetadata,
+} from '../db/schema/index.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+let app: FastifyInstance;
+let sessionCookie: string;
+
+let testUserId: string;
+let testLibraryId: string;
+
+const modelIds: string[] = [];
+const tagIds: Record<string, string> = {};
+let collectionId: string;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Log in as the test user and return the signed session cookie string. */
+async function login(email: string, password: string): Promise<string> {
+  const res = await app.inject({
+    method: 'POST',
+    url: '/auth/login',
+    payload: { email, password },
+  });
+  const setCookie = res.headers['set-cookie'];
+  const cookieStr = Array.isArray(setCookie) ? setCookie[0] : String(setCookie);
+  return cookieStr.split(';')[0];
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+beforeAll(async () => {
+  app = await buildApp();
+  await app.ready();
+
+  const ts = Date.now();
+
+  // ------------------------------------------------------------------
+  // Remove leftover fixtures from a previous failed run
+  // ------------------------------------------------------------------
+  const leftoverUsers = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(eq(users.email, 'search-route-test@example.com'));
+
+  if (leftoverUsers.length > 0) {
+    const ids = leftoverUsers.map((u) => u.id);
+    await db.delete(collections).where(inArray(collections.userId, ids));
+    await db.delete(models).where(inArray(models.userId, ids));
+    await db.delete(libraries).where(inArray(libraries.userId, ids));
+    await db.delete(users).where(eq(users.email, 'search-route-test@example.com'));
+  }
+
+  // ------------------------------------------------------------------
+  // Create user via authService so the password is properly hashed
+  // ------------------------------------------------------------------
+  const authService = (
+    app as FastifyInstance & {
+      authService: import('../services/auth.service.js').AuthService;
+    }
+  ).authService;
+
+  await authService.createUser(
+    'search-route-test@example.com',
+    'password123',
+    'Search Route Test User',
+  );
+
+  const [testUser] = await db
+    .select()
+    .from(users)
+    .where(eq(users.email, 'search-route-test@example.com'))
+    .limit(1);
+
+  testUserId = testUser.id;
+
+  // ------------------------------------------------------------------
+  // Create the default library (requireLibrary will use this)
+  // ------------------------------------------------------------------
+  const [testLibrary] = await db
+    .insert(libraries)
+    .values({
+      name: 'Search Route Test Library',
+      slug: `search-route-test-library-${ts}`,
+      userId: testUserId,
+      isDefault: true,
+    })
+    .returning();
+
+  testLibraryId = testLibrary.id;
+
+  // ------------------------------------------------------------------
+  // Resolve field definition IDs from seed
+  // ------------------------------------------------------------------
+  const fieldDefs = await db
+    .select({ id: metadataFieldDefinitions.id, slug: metadataFieldDefinitions.slug })
+    .from(metadataFieldDefinitions)
+    .where(eq(metadataFieldDefinitions.isDefault, true));
+
+  const fieldDefIds: Record<string, string> = {};
+  for (const fd of fieldDefs) {
+    fieldDefIds[fd.slug] = fd.id;
+  }
+
+  // ------------------------------------------------------------------
+  // Create models
+  //   [0] "Route Dragon Model"  — status: ready, artist: route-sculptor
+  //   [1] "Route Fantasy Model" — status: ready
+  // ------------------------------------------------------------------
+  const modelDefs = [
+    {
+      name: 'Route Dragon Model',
+      description: 'A full-text-matchable dragon model for route tests',
+      status: 'ready' as const,
+    },
+    {
+      name: 'Route Fantasy Model',
+      description: 'A fantasy model for route tests',
+      status: 'ready' as const,
+    },
+  ];
+
+  for (let i = 0; i < modelDefs.length; i++) {
+    const def = modelDefs[i];
+    const [m] = await db
+      .insert(models)
+      .values({
+        name: def.name,
+        slug: `route-test-${def.name.toLowerCase().replace(/\s+/g, '-')}-${ts}-${i}`,
+        description: def.description,
+        userId: testUserId,
+        libraryId: testLibraryId,
+        sourceType: 'zip_upload',
+        status: def.status,
+        totalSizeBytes: 1_000_000,
+        fileCount: 1,
+      })
+      .returning();
+
+    modelIds.push(m.id);
+  }
+
+  // ------------------------------------------------------------------
+  // Create a tag that contains "dragon" in its name
+  // ------------------------------------------------------------------
+  const [dragonTag] = await db
+    .insert(tags)
+    .values({ name: `Dragon-route-${ts}`, slug: `dragon-route-${ts}` })
+    .returning();
+
+  tagIds['dragon'] = dragonTag.id;
+
+  await db
+    .insert(modelTags)
+    .values([{ modelId: modelIds[0], tagId: tagIds['dragon'] }]);
+
+  // ------------------------------------------------------------------
+  // Assign artist metadata to model[0]
+  // ------------------------------------------------------------------
+  const artistFieldId = fieldDefIds['artist'];
+  if (artistFieldId) {
+    await db.insert(modelMetadata).values([
+      { modelId: modelIds[0], fieldDefinitionId: artistFieldId, value: 'route-sculptor' },
+    ]);
+  }
+
+  // ------------------------------------------------------------------
+  // Create a collection that contains "dragon" in the name
+  // ------------------------------------------------------------------
+  const [col] = await db
+    .insert(collections)
+    .values({
+      name: 'Route Dragon Collection',
+      slug: `route-dragon-col-${ts}`,
+      userId: testUserId,
+      libraryId: testLibraryId,
+    })
+    .returning();
+
+  collectionId = col.id;
+
+  await db.insert(collectionModels).values([{ collectionId, modelId: modelIds[0] }]);
+
+  // ------------------------------------------------------------------
+  // Log in to get a session cookie
+  // ------------------------------------------------------------------
+  sessionCookie = await login('search-route-test@example.com', 'password123');
+});
+
+afterAll(async () => {
+  // FK-ordered cleanup
+  const allModelIds = [...modelIds].filter(Boolean);
+  if (allModelIds.length > 0) {
+    await db.delete(models).where(inArray(models.id, allModelIds));
+  }
+
+  const tagIdValues = Object.values(tagIds);
+  if (tagIdValues.length > 0) {
+    await db.delete(tags).where(inArray(tags.id, tagIdValues));
+  }
+
+  if (collectionId) {
+    await db.delete(collections).where(eq(collections.id, collectionId));
+  }
+
+  if (testLibraryId) {
+    await db.delete(libraries).where(eq(libraries.id, testLibraryId));
+  }
+
+  if (testUserId) {
+    await db.delete(users).where(eq(users.id, testUserId));
+  }
+
+  await app.close();
+});
+
+// ---------------------------------------------------------------------------
+// describe: auth guard
+// ---------------------------------------------------------------------------
+
+describe('GET /search — auth guard', () => {
+  it('should return 401 UNAUTHORIZED when no session cookie is present', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/search?q=dragon',
+    });
+
+    expect(res.statusCode).toBe(401);
+    const body = res.json();
+    expect(body.data).toBeNull();
+    expect(body.errors).toHaveLength(1);
+    expect(body.errors[0].code).toBe('UNAUTHORIZED');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// describe: input validation
+// ---------------------------------------------------------------------------
+
+describe('GET /search — input validation', () => {
+  it('should return 400 VALIDATION_ERROR when q is missing', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/search',
+      headers: { cookie: sessionCookie },
+    });
+
+    expect(res.statusCode).toBe(400);
+    const body = res.json();
+    expect(body.data).toBeNull();
+    expect(body.errors).toHaveLength(1);
+    expect(body.errors[0].code).toBe('VALIDATION_ERROR');
+  });
+
+  it('should return 400 VALIDATION_ERROR when q is empty string', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/search?q=',
+      headers: { cookie: sessionCookie },
+    });
+
+    expect(res.statusCode).toBe(400);
+    const body = res.json();
+    expect(body.errors[0].code).toBe('VALIDATION_ERROR');
+  });
+
+  it('should return 400 VALIDATION_ERROR when q is only whitespace', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/search?q=%20%20',
+      headers: { cookie: sessionCookie },
+    });
+
+    expect(res.statusCode).toBe(400);
+    const body = res.json();
+    expect(body.errors[0].code).toBe('VALIDATION_ERROR');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// describe: response envelope
+// ---------------------------------------------------------------------------
+
+describe('GET /search — response envelope', () => {
+  it('should return { data, meta: null, errors: null } on success', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/search?q=dragon',
+      headers: { cookie: sessionCookie },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+
+    expect(body).toHaveProperty('data');
+    expect(body).toHaveProperty('meta', null);
+    expect(body).toHaveProperty('errors', null);
+  });
+
+  it('should return GlobalSearchResult shape in data', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/search?q=dragon',
+      headers: { cookie: sessionCookie },
+    });
+
+    const body = res.json();
+    const data = body.data;
+
+    expect(data).toHaveProperty('q');
+    expect(data).toHaveProperty('models');
+    expect(data).toHaveProperty('collections');
+    expect(data).toHaveProperty('artists');
+    expect(data).toHaveProperty('tags');
+
+    // models bucket shape
+    expect(data.models).toHaveProperty('items');
+    expect(data.models).toHaveProperty('total');
+    expect(Array.isArray(data.models.items)).toBe(true);
+    expect(typeof data.models.total).toBe('number');
+
+    // other buckets are arrays
+    expect(Array.isArray(data.collections)).toBe(true);
+    expect(Array.isArray(data.artists)).toBe(true);
+    expect(Array.isArray(data.tags)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// describe: result content — all four buckets
+// ---------------------------------------------------------------------------
+
+describe('GET /search — result content', () => {
+  it('should include matching model in models.items', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/search?q=Route+Dragon+Model',
+      headers: { cookie: sessionCookie },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const { data } = res.json();
+
+    const hit = data.models.items.find((m: { id: string }) => m.id === modelIds[0]);
+    expect(hit).toBeDefined();
+    expect(hit.name).toBe('Route Dragon Model');
+  });
+
+  it('should include matching collection in collections array', async () => {
+    // "Route Dragon Collection" contains "dragon"
+    const res = await app.inject({
+      method: 'GET',
+      url: '/search?q=dragon',
+      headers: { cookie: sessionCookie },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const { data } = res.json();
+
+    const hit = data.collections.find((c: { id: string }) => c.id === collectionId);
+    expect(hit).toBeDefined();
+    expect(hit.name).toBe('Route Dragon Collection');
+    expect(typeof hit.modelCount).toBe('number');
+    expect(typeof hit.slug).toBe('string');
+  });
+
+  it('should include matching artist in artists array', async () => {
+    // artist value "route-sculptor" contains "sculptor"
+    const res = await app.inject({
+      method: 'GET',
+      url: '/search?q=sculptor',
+      headers: { cookie: sessionCookie },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const { data } = res.json();
+
+    const hit = data.artists.find((a: { name: string }) => a.name === 'route-sculptor');
+    expect(hit).toBeDefined();
+    expect(typeof hit.modelCount).toBe('number');
+  });
+
+  it('should include matching tag in tags array', async () => {
+    // Tag name starts with "Dragon-route-" so it contains "dragon"
+    const res = await app.inject({
+      method: 'GET',
+      url: '/search?q=dragon',
+      headers: { cookie: sessionCookie },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const { data } = res.json();
+
+    const hit = data.tags.find((t: { name: string }) =>
+      t.name.toLowerCase().startsWith('dragon-route'),
+    );
+    expect(hit).toBeDefined();
+    expect(typeof hit.modelCount).toBe('number');
+  });
+
+  it('should return empty buckets for a query that matches nothing', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/search?q=xyzzy-zzt-nothing-matches',
+      headers: { cookie: sessionCookie },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const { data } = res.json();
+
+    expect(data.models.items).toHaveLength(0);
+    expect(data.models.total).toBe(0);
+    expect(data.collections).toHaveLength(0);
+    expect(data.artists).toHaveLength(0);
+    expect(data.tags).toHaveLength(0);
+  });
+
+  it('should echo the query in data.q', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/search?q=dragon',
+      headers: { cookie: sessionCookie },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const { data } = res.json();
+    expect(data.q).toBe('dragon');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// describe: limit param
+// ---------------------------------------------------------------------------
+
+describe('GET /search — limit param', () => {
+  it('should cap items per bucket when limit=1 is supplied', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/search?q=dragon&limit=1',
+      headers: { cookie: sessionCookie },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const { data } = res.json();
+
+    expect(data.models.items.length).toBeLessThanOrEqual(1);
+    expect(data.collections.length).toBeLessThanOrEqual(1);
+    expect(data.artists.length).toBeLessThanOrEqual(1);
+    expect(data.tags.length).toBeLessThanOrEqual(1);
+  });
+});

--- a/apps/backend/src/routes/search.ts
+++ b/apps/backend/src/routes/search.ts
@@ -1,0 +1,27 @@
+import type { FastifyInstance } from 'fastify';
+import type { GlobalSearchParams } from '@alexandria/shared';
+import { globalSearchParamsSchema } from '@alexandria/shared';
+import { requireAuth } from '../middleware/auth.js';
+import { requireLibrary } from '../middleware/library.js';
+import { searchService } from '../services/search.service.js';
+import { validationError } from '../utils/errors.js';
+
+export async function searchRoutes(app: FastifyInstance): Promise<void> {
+  // GET /search — cross-entity search (models, collections, artists, tags)
+  app.get(
+    '/',
+    { preHandler: [requireAuth, requireLibrary] },
+    async (request, reply) => {
+      const parseResult = globalSearchParamsSchema.safeParse(request.query);
+      if (!parseResult.success) {
+        const firstIssue = parseResult.error.issues[0];
+        throw validationError(firstIssue?.message ?? 'Validation failed', firstIssue?.path.join('.'));
+      }
+
+      const params = parseResult.data as GlobalSearchParams;
+      const result = await searchService.searchAll(params, request.user!.id, request.libraryId!);
+
+      return reply.status(200).send({ data: result, meta: null, errors: null });
+    },
+  );
+}

--- a/apps/backend/src/services/collection.service.ts
+++ b/apps/backend/src/services/collection.service.ts
@@ -84,6 +84,38 @@ export class CollectionService {
   }
 
   /**
+   * Verify that a collection exists, belongs to the given user, and is in the
+   * given library. Throws NOT_FOUND if any check fails — same error shape
+   * regardless of which check failed so callers cannot enumerate other users'
+   * collection IDs.
+   *
+   * Used by handleCommit to gate cross-tenant collection writes before
+   * the commit job is enqueued (so the caller gets a 4xx rather than a
+   * silent non-fatal failure inside the worker).
+   */
+  async requireOwnedCollection(
+    collectionId: string,
+    userId: string,
+    libraryId: string,
+  ): Promise<void> {
+    const [row] = await db
+      .select({ id: collections.id })
+      .from(collections)
+      .where(
+        and(
+          eq(collections.id, collectionId),
+          eq(collections.userId, userId),
+          eq(collections.libraryId, libraryId),
+        ),
+      )
+      .limit(1);
+
+    if (!row) {
+      throw notFound('Collection not found');
+    }
+  }
+
+  /**
    * Add a single model to a collection. Idempotent.
    * Preserved for folder import backward compatibility.
    */

--- a/apps/backend/src/services/import-session.service.test.ts
+++ b/apps/backend/src/services/import-session.service.test.ts
@@ -1,0 +1,576 @@
+/**
+ * Integration tests for ImportSessionService (P3 staged upload).
+ *
+ * Tests hit the real Postgres test database. All fixture rows are inserted
+ * in beforeAll and cleaned up in afterAll. No mocking — every DB call is real.
+ *
+ * Coverage:
+ * - create()     — inserts a row with status='scanning' and returns the id.
+ * - getRow()     — retrieves the raw row; returns undefined for unknown id.
+ * - getOwnedRow() — throws NOT_FOUND for unknown id or wrong user.
+ * - listActive() — returns only active-status sessions for the given user+library.
+ * - update()     — updates status, detected, manifest, stagingPath, modelId, error.
+ * - toDto()      — shape (id, originalFilename, status, detected, modelId, error, createdAt ISO).
+ * - delete()     — removes the row.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
+import { eq, inArray } from 'drizzle-orm';
+import { db } from '../db/index.js';
+import { users, libraries, importSessions } from '../db/schema/index.js';
+import { importSessionService, ImportSessionService } from './import-session.service.js';
+import type { DetectedImportMetadata } from '@alexandria/shared';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+let testUserId: string;
+let otherUserId: string;
+let testLibraryId: string;
+let otherLibraryId: string;
+
+const SESSION_EMAIL = 'import-session-test@example.com';
+const OTHER_EMAIL = 'import-session-other@example.com';
+
+// IDs created per-test (for tests that need per-test isolation)
+let perTestSessionIds: string[] = [];
+
+beforeAll(async () => {
+  const ts = Date.now();
+
+  // ------------------------------------------------------------------
+  // Remove any leftovers from a previous failed run
+  // ------------------------------------------------------------------
+  for (const email of [SESSION_EMAIL, OTHER_EMAIL]) {
+    const leftover = await db
+      .select({ id: users.id })
+      .from(users)
+      .where(eq(users.email, email));
+
+    if (leftover.length > 0) {
+      const ids = leftover.map((u) => u.id);
+      await db.delete(importSessions).where(inArray(importSessions.userId, ids));
+      await db.delete(libraries).where(inArray(libraries.userId, ids));
+      await db.delete(users).where(inArray(users.id, ids));
+    }
+  }
+
+  // ------------------------------------------------------------------
+  // Create primary test user + library
+  // ------------------------------------------------------------------
+  const [testUser] = await db
+    .insert(users)
+    .values({
+      email: SESSION_EMAIL,
+      displayName: 'Import Session Test User',
+      passwordHash: 'not-a-real-hash',
+      role: 'user',
+    })
+    .returning();
+
+  testUserId = testUser.id;
+
+  const [testLibrary] = await db
+    .insert(libraries)
+    .values({
+      name: 'Import Session Test Library',
+      slug: `import-session-lib-${ts}`,
+      userId: testUserId,
+      isDefault: true,
+    })
+    .returning();
+
+  testLibraryId = testLibrary.id;
+
+  // ------------------------------------------------------------------
+  // Create secondary user + library (for ownership checks)
+  // ------------------------------------------------------------------
+  const [otherUser] = await db
+    .insert(users)
+    .values({
+      email: OTHER_EMAIL,
+      displayName: 'Import Session Other User',
+      passwordHash: 'not-a-real-hash',
+      role: 'user',
+    })
+    .returning();
+
+  otherUserId = otherUser.id;
+
+  const [otherLibrary] = await db
+    .insert(libraries)
+    .values({
+      name: 'Import Session Other Library',
+      slug: `import-session-other-lib-${ts}`,
+      userId: otherUserId,
+      isDefault: true,
+    })
+    .returning();
+
+  otherLibraryId = otherLibrary.id;
+});
+
+afterAll(async () => {
+  // Clean up any stray sessions created during tests
+  if (perTestSessionIds.length > 0) {
+    await db.delete(importSessions).where(inArray(importSessions.id, perTestSessionIds));
+  }
+
+  // Delete all sessions for both users, then libraries, then users.
+  const bothUsers = [testUserId, otherUserId].filter(Boolean);
+  if (bothUsers.length > 0) {
+    await db.delete(importSessions).where(inArray(importSessions.userId, bothUsers));
+    await db.delete(libraries).where(inArray(libraries.userId, bothUsers));
+    await db.delete(users).where(inArray(users.id, bothUsers));
+  }
+});
+
+/** Track a session id so afterEach / afterAll can clean it up. */
+function track(id: string): string {
+  perTestSessionIds.push(id);
+  return id;
+}
+
+afterEach(async () => {
+  // Clean up any sessions created during the most recent test
+  if (perTestSessionIds.length > 0) {
+    await db.delete(importSessions).where(inArray(importSessions.id, perTestSessionIds));
+    perTestSessionIds = [];
+  }
+});
+
+// ---------------------------------------------------------------------------
+// describe: create()
+// ---------------------------------------------------------------------------
+
+describe('ImportSessionService.create()', () => {
+  it('should create a session row with status scanning and return its id', async () => {
+    const { id } = await importSessionService.create({
+      userId: testUserId,
+      libraryId: testLibraryId,
+      originalFilename: 'my-model.zip',
+    });
+    track(id);
+
+    expect(typeof id).toBe('string');
+    expect(id.length).toBeGreaterThan(0);
+
+    // Verify the actual DB row
+    const row = await importSessionService.getRow(id);
+    expect(row).toBeDefined();
+    expect(row!.userId).toBe(testUserId);
+    expect(row!.libraryId).toBe(testLibraryId);
+    expect(row!.originalFilename).toBe('my-model.zip');
+    expect(row!.status).toBe('scanning');
+    expect(row!.detected).toBeNull();
+    expect(row!.modelId).toBeNull();
+    expect(row!.error).toBeNull();
+  });
+
+  it('should set expiresAt to ~24 hours in the future', async () => {
+    const before = Date.now();
+    const { id } = await importSessionService.create({
+      userId: testUserId,
+      libraryId: testLibraryId,
+      originalFilename: 'test.zip',
+    });
+    track(id);
+
+    const row = await importSessionService.getRow(id);
+    expect(row!.expiresAt).toBeDefined();
+
+    const expiresMs = row!.expiresAt!.getTime();
+    const twentyThreeHoursMs = 23 * 60 * 60 * 1000;
+    const twentyFiveHoursMs = 25 * 60 * 60 * 1000;
+
+    expect(expiresMs).toBeGreaterThan(before + twentyThreeHoursMs);
+    expect(expiresMs).toBeLessThan(before + twentyFiveHoursMs);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// describe: getRow()
+// ---------------------------------------------------------------------------
+
+describe('ImportSessionService.getRow()', () => {
+  it('should return the row when the id exists', async () => {
+    const { id } = await importSessionService.create({
+      userId: testUserId,
+      libraryId: testLibraryId,
+      originalFilename: 'dragon.zip',
+    });
+    track(id);
+
+    const row = await importSessionService.getRow(id);
+    expect(row).toBeDefined();
+    expect(row!.id).toBe(id);
+  });
+
+  it('should return undefined for an unknown id', async () => {
+    const row = await importSessionService.getRow('00000000-0000-0000-0000-000000000000');
+    expect(row).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// describe: getOwnedRow()
+// ---------------------------------------------------------------------------
+
+describe('ImportSessionService.getOwnedRow()', () => {
+  it('should return the row when id and userId match', async () => {
+    const { id } = await importSessionService.create({
+      userId: testUserId,
+      libraryId: testLibraryId,
+      originalFilename: 'owned.zip',
+    });
+    track(id);
+
+    const row = await importSessionService.getOwnedRow(id, testUserId);
+    expect(row.id).toBe(id);
+    expect(row.userId).toBe(testUserId);
+  });
+
+  it('should throw NOT_FOUND when the session id does not exist', async () => {
+    await expect(
+      importSessionService.getOwnedRow('00000000-0000-0000-0000-000000000000', testUserId),
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+
+  it('should throw NOT_FOUND when the session belongs to a different user', async () => {
+    // Create session as the primary user
+    const { id } = await importSessionService.create({
+      userId: testUserId,
+      libraryId: testLibraryId,
+      originalFilename: 'private.zip',
+    });
+    track(id);
+
+    // Attempt to get it as the OTHER user
+    await expect(
+      importSessionService.getOwnedRow(id, otherUserId),
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// describe: listActive()
+// ---------------------------------------------------------------------------
+
+describe('ImportSessionService.listActive()', () => {
+  it('should return only active sessions for the given user and library', async () => {
+    // Insert one session in each of the active statuses
+    const activeStatuses = ['scanning', 'ready_for_review', 'committing', 'error'] as const;
+    const insertedIds: string[] = [];
+
+    for (const status of activeStatuses) {
+      const { id } = await importSessionService.create({
+        userId: testUserId,
+        libraryId: testLibraryId,
+        originalFilename: `${status}.zip`,
+      });
+      track(id);
+      insertedIds.push(id);
+
+      if (status !== 'scanning') {
+        // update to the target status
+        await importSessionService.update(id, { status });
+      }
+    }
+
+    const list = await importSessionService.listActive(testUserId, testLibraryId);
+    const listIds = list.map((s) => s.id);
+
+    for (const id of insertedIds) {
+      expect(listIds).toContain(id);
+    }
+  });
+
+  it('should NOT return committed sessions in the active list', async () => {
+    const { id } = await importSessionService.create({
+      userId: testUserId,
+      libraryId: testLibraryId,
+      originalFilename: 'committed.zip',
+    });
+    track(id);
+
+    await importSessionService.update(id, { status: 'committed' });
+
+    const list = await importSessionService.listActive(testUserId, testLibraryId);
+    const listIds = list.map((s) => s.id);
+    expect(listIds).not.toContain(id);
+  });
+
+  it('should NOT return sessions belonging to a different user', async () => {
+    // Session for the OTHER user in the OTHER library
+    const { id } = await importSessionService.create({
+      userId: otherUserId,
+      libraryId: otherLibraryId,
+      originalFilename: 'other-user.zip',
+    });
+    track(id);
+
+    const list = await importSessionService.listActive(testUserId, testLibraryId);
+    const listIds = list.map((s) => s.id);
+    expect(listIds).not.toContain(id);
+  });
+
+  it('should NOT return sessions from a different library for the same user', async () => {
+    // We need a second library for the same test user to test this
+    const ts = Date.now();
+    const [lib2] = await db
+      .insert(libraries)
+      .values({
+        name: 'Second Library',
+        slug: `import-session-lib2-${ts}`,
+        userId: testUserId,
+        isDefault: false,
+      })
+      .returning();
+
+    try {
+      const { id } = await importSessionService.create({
+        userId: testUserId,
+        libraryId: lib2.id,
+        originalFilename: 'wrong-library.zip',
+      });
+      track(id);
+
+      const list = await importSessionService.listActive(testUserId, testLibraryId);
+      const listIds = list.map((s) => s.id);
+      expect(listIds).not.toContain(id);
+    } finally {
+      await db.delete(libraries).where(eq(libraries.id, lib2.id));
+    }
+  });
+
+  it('should return sessions in descending createdAt order', async () => {
+    const id1 = track(
+      (
+        await importSessionService.create({
+          userId: testUserId,
+          libraryId: testLibraryId,
+          originalFilename: 'first.zip',
+        })
+      ).id,
+    );
+
+    const id2 = track(
+      (
+        await importSessionService.create({
+          userId: testUserId,
+          libraryId: testLibraryId,
+          originalFilename: 'second.zip',
+        })
+      ).id,
+    );
+
+    const list = await importSessionService.listActive(testUserId, testLibraryId);
+    const listIds = list.map((s) => s.id);
+
+    const idx1 = listIds.indexOf(id1);
+    const idx2 = listIds.indexOf(id2);
+    expect(idx1).toBeGreaterThanOrEqual(0);
+    expect(idx2).toBeGreaterThanOrEqual(0);
+    // id2 was created later so it should appear before id1 (desc order)
+    expect(idx2).toBeLessThan(idx1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// describe: update()
+// ---------------------------------------------------------------------------
+
+describe('ImportSessionService.update()', () => {
+  it('should update the status field', async () => {
+    const { id } = await importSessionService.create({
+      userId: testUserId,
+      libraryId: testLibraryId,
+      originalFilename: 'update-status.zip',
+    });
+    track(id);
+
+    await importSessionService.update(id, { status: 'ready_for_review' });
+
+    const row = await importSessionService.getRow(id);
+    expect(row!.status).toBe('ready_for_review');
+  });
+
+  it('should store detected metadata as JSON', async () => {
+    const { id } = await importSessionService.create({
+      userId: testUserId,
+      libraryId: testLibraryId,
+      originalFilename: 'update-detected.zip',
+    });
+    track(id);
+
+    const detected: DetectedImportMetadata = {
+      modelCount: 3,
+      fileCount: 12,
+      totalSizeBytes: 5_000_000,
+      artist: 'test-artist',
+      tagsGuessed: ['dragon', 'fantasy'],
+      folderStructure: [
+        { name: 'models', type: 'folder', children: [{ name: 'dragon.stl', type: 'file', fileType: 'stl' }] },
+      ],
+    };
+
+    await importSessionService.update(id, { status: 'ready_for_review', detected });
+
+    const row = await importSessionService.getRow(id);
+    expect(row!.status).toBe('ready_for_review');
+
+    const storedDetected = row!.detected as DetectedImportMetadata;
+    expect(storedDetected.modelCount).toBe(3);
+    expect(storedDetected.fileCount).toBe(12);
+    expect(storedDetected.artist).toBe('test-artist');
+    expect(storedDetected.tagsGuessed).toEqual(['dragon', 'fantasy']);
+    expect(storedDetected.folderStructure).toHaveLength(1);
+  });
+
+  it('should update stagingPath field', async () => {
+    const { id } = await importSessionService.create({
+      userId: testUserId,
+      libraryId: testLibraryId,
+      originalFilename: 'staging.zip',
+    });
+    track(id);
+
+    await importSessionService.update(id, { stagingPath: '/tmp/staging/session-xyz' });
+
+    const row = await importSessionService.getRow(id);
+    expect(row!.stagingPath).toBe('/tmp/staging/session-xyz');
+  });
+
+  it('should update error field', async () => {
+    const { id } = await importSessionService.create({
+      userId: testUserId,
+      libraryId: testLibraryId,
+      originalFilename: 'error.zip',
+    });
+    track(id);
+
+    await importSessionService.update(id, { status: 'error', error: 'Archive is corrupt' });
+
+    const row = await importSessionService.getRow(id);
+    expect(row!.status).toBe('error');
+    expect(row!.error).toBe('Archive is corrupt');
+  });
+
+  it('should update updatedAt on each call', async () => {
+    const { id } = await importSessionService.create({
+      userId: testUserId,
+      libraryId: testLibraryId,
+      originalFilename: 'updated-at.zip',
+    });
+    track(id);
+
+    const before = await importSessionService.getRow(id);
+    const updatedAtBefore = before!.updatedAt.getTime();
+
+    // Ensure at least 1ms passes
+    await new Promise((r) => setTimeout(r, 5));
+    await importSessionService.update(id, { status: 'ready_for_review' });
+
+    const after = await importSessionService.getRow(id);
+    const updatedAtAfter = after!.updatedAt.getTime();
+
+    expect(updatedAtAfter).toBeGreaterThanOrEqual(updatedAtBefore);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// describe: toDto()
+// ---------------------------------------------------------------------------
+
+describe('ImportSessionService.toDto()', () => {
+  it('should map a raw row to an ImportSession DTO with correct shape', async () => {
+    const { id } = await importSessionService.create({
+      userId: testUserId,
+      libraryId: testLibraryId,
+      originalFilename: 'dto-test.zip',
+    });
+    track(id);
+
+    const row = await importSessionService.getRow(id);
+    const service = new ImportSessionService();
+    const dto = service.toDto(row!);
+
+    expect(dto).toHaveProperty('id', id);
+    expect(dto).toHaveProperty('originalFilename', 'dto-test.zip');
+    expect(dto).toHaveProperty('status', 'scanning');
+    expect(dto).toHaveProperty('detected', null);
+    expect(dto).toHaveProperty('modelId', null);
+    expect(dto).toHaveProperty('error', null);
+    expect(dto).toHaveProperty('createdAt');
+
+    // createdAt must be an ISO-8601 string
+    expect(typeof dto.createdAt).toBe('string');
+    expect(new Date(dto.createdAt).toISOString()).toBe(dto.createdAt);
+
+    // DTO must NOT expose internal fields like userId, libraryId, stagingPath, manifest
+    expect(dto).not.toHaveProperty('userId');
+    expect(dto).not.toHaveProperty('libraryId');
+    expect(dto).not.toHaveProperty('stagingPath');
+    expect(dto).not.toHaveProperty('manifest');
+  });
+
+  it('should include detected metadata in the DTO when populated', async () => {
+    const { id } = await importSessionService.create({
+      userId: testUserId,
+      libraryId: testLibraryId,
+      originalFilename: 'dto-detected.zip',
+    });
+    track(id);
+
+    const detected: DetectedImportMetadata = {
+      modelCount: 1,
+      fileCount: 5,
+      totalSizeBytes: 1_000_000,
+      artist: null,
+      tagsGuessed: [],
+      folderStructure: [],
+    };
+
+    await importSessionService.update(id, { status: 'ready_for_review', detected });
+
+    const row = await importSessionService.getRow(id);
+    const service = new ImportSessionService();
+    const dto = service.toDto(row!);
+
+    expect(dto.status).toBe('ready_for_review');
+    expect(dto.detected).not.toBeNull();
+    expect(dto.detected!.modelCount).toBe(1);
+    expect(dto.detected!.fileCount).toBe(5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// describe: delete()
+// ---------------------------------------------------------------------------
+
+describe('ImportSessionService.delete()', () => {
+  it('should remove the session row from the database', async () => {
+    const { id } = await importSessionService.create({
+      userId: testUserId,
+      libraryId: testLibraryId,
+      originalFilename: 'to-delete.zip',
+    });
+    // Don't track — we're deleting it explicitly in the test
+
+    // Confirm it exists
+    const before = await importSessionService.getRow(id);
+    expect(before).toBeDefined();
+
+    await importSessionService.delete(id);
+
+    const after = await importSessionService.getRow(id);
+    expect(after).toBeUndefined();
+  });
+
+  it('should be idempotent — deleting a non-existent session does not throw', async () => {
+    await expect(
+      importSessionService.delete('00000000-0000-0000-0000-000000000000'),
+    ).resolves.not.toThrow();
+  });
+});

--- a/apps/backend/src/services/import-session.service.ts
+++ b/apps/backend/src/services/import-session.service.ts
@@ -1,0 +1,111 @@
+import { and, desc, eq, inArray } from 'drizzle-orm';
+import type {
+  ImportSession,
+  ImportSessionStatus,
+  DetectedImportMetadata,
+} from '@alexandria/shared';
+import type { FileManifest } from './file-processing.service.js';
+import { db } from '../db/index.js';
+import { importSessions } from '../db/schema/index.js';
+import { notFound } from '../utils/errors.js';
+import { createLogger } from '../utils/logger.js';
+
+const logger = createLogger('ImportSessionService');
+
+/** How long an un-committed session is kept before it is eligible for cleanup. */
+const SESSION_TTL_MS = 24 * 60 * 60 * 1000;
+
+/** Statuses that still represent live, user-actionable sessions (the queue). */
+const ACTIVE_STATUSES: ImportSessionStatus[] = [
+  'scanning',
+  'ready_for_review',
+  'committing',
+  'error',
+];
+
+type ImportSessionRow = typeof importSessions.$inferSelect;
+
+export class ImportSessionService {
+  async create(input: {
+    userId: string;
+    libraryId: string;
+    originalFilename: string;
+  }): Promise<{ id: string }> {
+    const [row] = await db
+      .insert(importSessions)
+      .values({
+        userId: input.userId,
+        libraryId: input.libraryId,
+        originalFilename: input.originalFilename,
+        status: 'scanning',
+        expiresAt: new Date(Date.now() + SESSION_TTL_MS),
+      })
+      .returning({ id: importSessions.id });
+    return row;
+  }
+
+  async getRow(id: string): Promise<ImportSessionRow | undefined> {
+    const [row] = await db.select().from(importSessions).where(eq(importSessions.id, id)).limit(1);
+    return row;
+  }
+
+  /** Fetch a row, asserting it exists and belongs to the user. */
+  async getOwnedRow(id: string, userId: string): Promise<ImportSessionRow> {
+    const row = await this.getRow(id);
+    if (!row || row.userId !== userId) {
+      throw notFound('Import session not found');
+    }
+    return row;
+  }
+
+  async listActive(userId: string, libraryId: string): Promise<ImportSession[]> {
+    const rows = await db
+      .select()
+      .from(importSessions)
+      .where(
+        and(
+          eq(importSessions.userId, userId),
+          eq(importSessions.libraryId, libraryId),
+          inArray(importSessions.status, ACTIVE_STATUSES),
+        ),
+      )
+      .orderBy(desc(importSessions.createdAt));
+    return rows.map((r) => this.toDto(r));
+  }
+
+  async update(
+    id: string,
+    fields: Partial<{
+      status: ImportSessionStatus;
+      detected: DetectedImportMetadata | null;
+      manifest: FileManifest | null;
+      stagingPath: string | null;
+      modelId: string | null;
+      error: string | null;
+    }>,
+  ): Promise<void> {
+    await db
+      .update(importSessions)
+      .set({ ...fields, updatedAt: new Date() })
+      .where(eq(importSessions.id, id));
+  }
+
+  async delete(id: string): Promise<void> {
+    await db.delete(importSessions).where(eq(importSessions.id, id));
+    logger.info({ sessionId: id }, 'Import session deleted');
+  }
+
+  toDto(row: ImportSessionRow): ImportSession {
+    return {
+      id: row.id,
+      originalFilename: row.originalFilename,
+      status: row.status as ImportSessionStatus,
+      detected: (row.detected as DetectedImportMetadata | null) ?? null,
+      modelId: row.modelId,
+      error: row.error,
+      createdAt: row.createdAt.toISOString(),
+    };
+  }
+}
+
+export const importSessionService = new ImportSessionService();

--- a/apps/backend/src/services/ingestion.service.ts
+++ b/apps/backend/src/services/ingestion.service.ts
@@ -161,6 +161,13 @@ export class IngestionService {
       throw validationError('Import session belongs to a different library');
     }
 
+    // B1: validate collectionId ownership synchronously here, before enqueuing,
+    // so an unauthorized or non-existent collectionId returns a 4xx to the
+    // caller rather than silently failing inside the non-fatal worker catch.
+    if (batchMetadata?.collectionId) {
+      await collectionService.requireOwnedCollection(batchMetadata.collectionId, userId, libraryId);
+    }
+
     const name = stripArchiveExtension(session.originalFilename);
     const slug = generateSlug(name);
     const { id: modelId } = await modelService.createModel({

--- a/apps/backend/src/services/ingestion.service.ts
+++ b/apps/backend/src/services/ingestion.service.ts
@@ -1,9 +1,20 @@
 import fsPromises from 'node:fs/promises';
 import path from 'node:path';
 import type { Job } from 'bullmq';
-import type { ImportConfig } from '@alexandria/shared';
-import { jobService, type IngestionJobPayload, type FolderImportJobPayload } from './job.service.js';
-import { fileProcessingService } from './file-processing.service.js';
+import type {
+  ImportConfig,
+  BatchUploadMetadata,
+  DetectedImportMetadata,
+  DetectedFolderNode,
+} from '@alexandria/shared';
+import {
+  jobService,
+  type IngestionJobPayload,
+  type FolderImportJobPayload,
+  type CommitJobPayload,
+} from './job.service.js';
+import { fileProcessingService, type FileManifest } from './file-processing.service.js';
+import { importSessionService } from './import-session.service.js';
 import { thumbnailService } from './thumbnail.service.js';
 import { modelService } from './model.service.js';
 import { metadataService } from './metadata.service.js';
@@ -17,6 +28,14 @@ import { createLogger } from '../utils/logger.js';
 import { AppError, validationError } from '../utils/errors.js';
 
 const logger = createLogger('IngestionService');
+
+/** File extensions treated as 3D model files when counting sub-models. */
+const MODEL_FILE_EXTENSIONS = new Set(['stl', 'obj', '3mf', 'step', 'stp', 'ply']);
+/** Path tokens too generic to ever be a useful auto-tag. */
+const TAG_STOPWORDS = new Set([
+  'stl', 'obj', 'zip', 'rar', 'files', 'file', 'model', 'models', 'the', 'and',
+  'supported', 'unsupported', 'presupported', 'lys', 'renders', 'render', 'images',
+]);
 
 export class IngestionService {
   async handleUpload(
@@ -54,6 +73,395 @@ export class IngestionService {
 
     logger.info({ service: 'IngestionService', modelId, jobId, libraryId }, 'Upload accepted, ingestion job enqueued');
     return { modelId, jobId };
+  }
+
+  // -------------------------------------------------------------------------
+  // Staged upload: scan → review → commit
+  // -------------------------------------------------------------------------
+
+  /**
+   * Accept an uploaded archive and enqueue a scan. Creates an import session
+   * (not a model) — the archive is extracted + inspected without being committed.
+   */
+  async handleScan(
+    file: { tempFilePath: string; originalFilename: string },
+    userId: string,
+    libraryId: string,
+  ): Promise<{ sessionId: string }> {
+    const { id: sessionId } = await importSessionService.create({
+      userId,
+      libraryId,
+      originalFilename: file.originalFilename,
+    });
+
+    try {
+      await jobService.enqueueScanJob({
+        sessionId,
+        tempFilePath: file.tempFilePath,
+        originalFilename: file.originalFilename,
+        userId,
+        libraryId,
+      });
+    } catch (err) {
+      logger.error({ sessionId, error: String(err) }, 'Failed to enqueue scan job');
+      await importSessionService.update(sessionId, { status: 'error', error: 'Failed to start scan' });
+      throw err;
+    }
+
+    logger.info({ service: 'IngestionService', sessionId, libraryId }, 'Upload accepted, scan job enqueued');
+    return { sessionId };
+  }
+
+  /** Worker entry: extract the archive, detect metadata, mark ready for review. */
+  async processScanJob(
+    sessionId: string,
+    tempFilePath: string,
+    originalFilename: string,
+    libraryId: string,
+  ): Promise<void> {
+    const extractDir = `${tempFilePath}_extracted`;
+    try {
+      const manifest = await fileProcessingService.processArchive(tempFilePath, extractDir);
+      const detected = await this.detectImportMetadata(manifest, originalFilename, libraryId);
+      await importSessionService.update(sessionId, {
+        status: 'ready_for_review',
+        manifest,
+        detected,
+        stagingPath: extractDir,
+      });
+      logger.info({ sessionId, fileCount: manifest.entries.length }, 'Scan complete — ready for review');
+    } catch (err) {
+      logger.error({ sessionId, error: String(err) }, 'Scan failed');
+      await importSessionService.update(sessionId, {
+        status: 'error',
+        error: err instanceof Error ? err.message : 'Could not process this archive',
+      });
+      await fsPromises.rm(extractDir, { recursive: true, force: true }).catch(() => {});
+    } finally {
+      // The uploaded archive is no longer needed once extracted (or on failure).
+      await fsPromises.rm(tempFilePath, { force: true }).catch(() => {});
+    }
+  }
+
+  /**
+   * Promote a reviewed session into a real model. Creates the model row up front
+   * (so the client can poll status), then enqueues the commit job.
+   */
+  async handleCommit(
+    sessionId: string,
+    batchMetadata: BatchUploadMetadata | undefined,
+    userId: string,
+    libraryId: string,
+  ): Promise<{ modelId: string; jobId: string }> {
+    const session = await importSessionService.getOwnedRow(sessionId, userId);
+    if (session.status !== 'ready_for_review') {
+      throw validationError(`Import session is not ready to commit (status: ${session.status})`);
+    }
+    if (session.libraryId !== libraryId) {
+      throw validationError('Import session belongs to a different library');
+    }
+
+    const name = stripArchiveExtension(session.originalFilename);
+    const slug = generateSlug(name);
+    const { id: modelId } = await modelService.createModel({
+      name,
+      slug,
+      userId,
+      libraryId,
+      sourceType: 'archive_upload',
+      status: 'processing',
+      originalFilename: session.originalFilename,
+    });
+    await importSessionService.update(sessionId, { status: 'committing', modelId });
+
+    let jobId: string;
+    try {
+      jobId = await jobService.enqueueCommitJob({ sessionId, modelId, userId, libraryId, batchMetadata });
+    } catch (err) {
+      logger.error({ sessionId, modelId, error: String(err) }, 'Failed to enqueue commit job');
+      await modelService.updateModelStatus(modelId, 'error');
+      await importSessionService.update(sessionId, { status: 'error', error: 'Failed to start commit' });
+      throw err;
+    }
+
+    logger.info({ service: 'IngestionService', sessionId, modelId, jobId }, 'Commit accepted, job enqueued');
+    return { modelId, jobId };
+  }
+
+  /** Worker entry: copy staged files to storage, finalize the model, apply metadata. */
+  async processCommitJob(job: Job<CommitJobPayload>): Promise<void> {
+    const { sessionId, modelId, userId, libraryId, batchMetadata } = job.data;
+
+    const session = await importSessionService.getRow(sessionId);
+    if (!session) {
+      logger.error({ sessionId }, 'Commit job: session not found');
+      return;
+    }
+    const manifest = session.manifest as FileManifest | null;
+    const stagingPath = session.stagingPath;
+    if (!manifest || !stagingPath) {
+      await modelService.updateModelStatus(modelId, 'error');
+      await importSessionService.update(sessionId, { status: 'error', error: 'Missing scanned data' });
+      return;
+    }
+
+    try {
+      await job.updateProgress(10);
+      await fileProcessingService.copyManifestToStorage(stagingPath, modelId, manifest, storageService);
+      await job.updateProgress(50);
+
+      const modelFileInputs = manifest.entries.map((entry) => ({
+        filename: entry.filename,
+        relativePath: entry.relativePath,
+        fileType: entry.fileType,
+        mimeType: entry.mimeType,
+        sizeBytes: entry.sizeBytes,
+        storagePath: `models/${modelId}/${entry.relativePath}`,
+        hash: entry.hash,
+      }));
+
+      const createdFiles = await modelService.createModelFiles(modelId, modelFileInputs);
+      await job.updateProgress(75);
+      await this.generateAndStoreThumbnails(modelId, modelFileInputs, createdFiles, stagingPath);
+
+      await modelService.updateModelStatus(modelId, 'ready', {
+        totalSizeBytes: manifest.totalSizeBytes,
+        fileCount: manifest.entries.length,
+      });
+      await job.updateProgress(100);
+
+      // Apply user-reviewed metadata after the model is ready — non-fatal.
+      await this.applyBatchMetadata(modelId, userId, libraryId, batchMetadata);
+
+      await importSessionService.update(sessionId, { status: 'committed' });
+      logger.info({ sessionId, modelId }, 'Commit complete — model is ready');
+    } catch (err) {
+      logger.error({ sessionId, modelId, error: String(err) }, 'Commit failed');
+      const maxAttempts = job.opts.attempts ?? 1;
+      if (job.attemptsMade >= maxAttempts - 1) {
+        await modelService.updateModelStatus(modelId, 'error');
+        await importSessionService.update(sessionId, {
+          status: 'error',
+          error: err instanceof Error ? err.message : 'Commit failed',
+        });
+      }
+      throw err;
+    } finally {
+      const maxAttempts = job.opts.attempts ?? 1;
+      const isFinalAttempt = job.attemptsMade >= maxAttempts - 1;
+      if (!job.failedReason || isFinalAttempt) {
+        await fsPromises.rm(stagingPath, { recursive: true, force: true }).catch(() => {});
+      }
+    }
+  }
+
+  /** Discard a session that has not been committed, removing staged files. */
+  async discardSession(sessionId: string, userId: string): Promise<void> {
+    const session = await importSessionService.getOwnedRow(sessionId, userId);
+    if (session.stagingPath) {
+      await fsPromises.rm(session.stagingPath, { recursive: true, force: true }).catch(() => {});
+    }
+    await importSessionService.delete(sessionId);
+  }
+
+  /** Apply reviewed batch metadata to a committed model. Failures are non-fatal. */
+  private async applyBatchMetadata(
+    modelId: string,
+    userId: string,
+    libraryId: string,
+    batchMetadata: BatchUploadMetadata | undefined,
+  ): Promise<void> {
+    if (!batchMetadata) return;
+    try {
+      const metadata: Record<string, string | string[]> = {};
+      if (batchMetadata.artist) metadata.artist = batchMetadata.artist;
+      if (batchMetadata.tags && batchMetadata.tags.length > 0) metadata.tags = batchMetadata.tags;
+      const opts = batchMetadata.options;
+      if (opts?.markPreSupported) metadata['pre-supported'] = 'true';
+      if (opts?.markNsfw) metadata.nsfw = 'true';
+      if (Object.keys(metadata).length > 0) {
+        await metadataService.setModelMetadata(modelId, metadata);
+      }
+
+      if (batchMetadata.collectionId) {
+        await collectionService.addModelToCollection(batchMetadata.collectionId, modelId);
+      } else if (batchMetadata.newCollectionName) {
+        const collection = await collectionService.findOrCreateByName(
+          batchMetadata.newCollectionName,
+          userId,
+          libraryId,
+        );
+        await collectionService.addModelToCollection(collection.id, modelId);
+      }
+    } catch (err) {
+      logger.warn(
+        { modelId, error: String(err) },
+        'Failed to apply batch metadata (non-fatal) — model remains ready',
+      );
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Scan-phase detection helpers (all best-effort)
+  // -------------------------------------------------------------------------
+
+  private async detectImportMetadata(
+    manifest: FileManifest,
+    originalFilename: string,
+    libraryId: string,
+  ): Promise<DetectedImportMetadata> {
+    const entries = manifest.entries;
+    const folderStructure = this.buildFolderStructure(entries);
+
+    const topLevelModelDirs = new Set<string>();
+    let looseModelFiles = 0;
+    for (const e of entries) {
+      if (!this.isModelFile(e.filename)) continue;
+      const segs = e.relativePath.split('/').filter(Boolean);
+      if (segs.length > 1) topLevelModelDirs.add(segs[0]);
+      else looseModelFiles++;
+    }
+    const modelCount = Math.max(1, topLevelModelDirs.size + (looseModelFiles > 0 ? 1 : 0));
+
+    const [artist, tagsGuessed] = await Promise.all([
+      this.guessArtist(entries, originalFilename, libraryId),
+      this.guessTags(entries, libraryId),
+    ]);
+
+    return {
+      modelCount,
+      fileCount: entries.length,
+      totalSizeBytes: manifest.totalSizeBytes,
+      artist,
+      tagsGuessed,
+      folderStructure,
+    };
+  }
+
+  private isModelFile(filename: string): boolean {
+    const ext = filename.split('.').pop()?.toLowerCase() ?? '';
+    return MODEL_FILE_EXTENSIONS.has(ext);
+  }
+
+  /** Build a compact folder tree (depth/breadth capped) for the review preview. */
+  private buildFolderStructure(
+    entries: FileManifest['entries'],
+    maxDepth = 3,
+    maxChildren = 12,
+  ): DetectedFolderNode[] {
+    interface MutableNode {
+      name: string;
+      type: 'folder' | 'file';
+      fileType?: DetectedFolderNode['fileType'];
+      children: Map<string, MutableNode>;
+    }
+    const root = new Map<string, MutableNode>();
+
+    for (const entry of entries) {
+      const segs = entry.relativePath.split('/').filter(Boolean);
+      if (segs.length === 0) continue;
+      let level = root;
+      for (let i = 0; i < segs.length && i < maxDepth; i++) {
+        const isLeaf = i === segs.length - 1;
+        const name = segs[i];
+        let node = level.get(name);
+        if (!node) {
+          node = {
+            name,
+            type: isLeaf ? 'file' : 'folder',
+            fileType: isLeaf ? entry.fileType : undefined,
+            children: new Map(),
+          };
+          level.set(name, node);
+        }
+        level = node.children;
+      }
+    }
+
+    const toNodes = (level: Map<string, MutableNode>): DetectedFolderNode[] => {
+      return [...level.values()]
+        .sort((a, b) => (a.type === b.type ? a.name.localeCompare(b.name) : a.type === 'folder' ? -1 : 1))
+        .slice(0, maxChildren)
+        .map((n) => {
+          const node: DetectedFolderNode = { name: n.name, type: n.type };
+          if (n.fileType) node.fileType = n.fileType;
+          if (n.children.size > 0) node.children = toNodes(n.children);
+          return node;
+        });
+    };
+
+    return toNodes(root);
+  }
+
+  private async guessArtist(
+    entries: FileManifest['entries'],
+    originalFilename: string,
+    libraryId: string,
+  ): Promise<string | null> {
+    // Candidate names: the top-level folder, and the archive filename stem.
+    const candidates: string[] = [];
+    const firstWithDir = entries.find((e) => e.relativePath.includes('/'));
+    if (firstWithDir) candidates.push(firstWithDir.relativePath.split('/')[0]);
+    candidates.push(stripArchiveExtension(originalFilename));
+
+    let existing: string[] = [];
+    try {
+      existing = (await metadataService.listFieldValues('artist', libraryId)).map((v) => v.value);
+    } catch {
+      existing = [];
+    }
+    const existingLower = new Map(existing.map((v) => [v.toLowerCase(), v]));
+
+    for (const candidate of candidates) {
+      const humanized = this.humanize(candidate);
+      const match = existingLower.get(humanized.toLowerCase());
+      if (match) return match;
+    }
+    // No existing artist matched — offer a humanized guess if it looks name-like.
+    const guess = this.humanize(candidates[0] ?? '');
+    return /[a-z]/i.test(guess) ? guess : null;
+  }
+
+  private async guessTags(
+    entries: FileManifest['entries'],
+    libraryId: string,
+  ): Promise<string[]> {
+    let existing: string[] = [];
+    try {
+      existing = (await metadataService.listFieldValues('tags', libraryId)).map((v) => v.value);
+    } catch {
+      existing = [];
+    }
+    if (existing.length === 0) return [];
+    const existingLower = new Map(existing.map((v) => [v.toLowerCase(), v]));
+
+    const tokens = new Set<string>();
+    for (const e of entries) {
+      for (const seg of e.relativePath.split(/[/\\]/)) {
+        for (const token of seg.toLowerCase().split(/[\s._-]+/)) {
+          if (token.length >= 3 && !TAG_STOPWORDS.has(token) && !/^\d+$/.test(token)) {
+            tokens.add(token);
+          }
+        }
+      }
+    }
+
+    const matched: string[] = [];
+    for (const token of tokens) {
+      const canonical = existingLower.get(token);
+      if (canonical && !matched.includes(canonical)) {
+        matched.push(canonical);
+        if (matched.length >= 8) break;
+      }
+    }
+    return matched;
+  }
+
+  private humanize(raw: string): string {
+    return raw
+      .replace(/[._-]+/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim();
   }
 
   async processIngestionJob(

--- a/apps/backend/src/services/job.service.ts
+++ b/apps/backend/src/services/job.service.ts
@@ -1,5 +1,5 @@
 import { Queue } from 'bullmq';
-import type { ImportStrategy } from '@alexandria/shared';
+import type { ImportStrategy, BatchUploadMetadata } from '@alexandria/shared';
 import { config } from '../config/index.js';
 import { parseRedisUrl } from '../utils/redis.js';
 
@@ -21,12 +21,34 @@ export interface FolderImportJobPayload {
   libraryId: string;
 }
 
+/** Scan phase of a staged upload: extract + detect, no commit. */
+export interface ScanJobPayload {
+  sessionId: string;
+  tempFilePath: string;
+  originalFilename: string;
+  userId: string;
+  libraryId: string;
+}
+
+/** Commit phase of a staged upload: persist files + apply batch metadata. */
+export interface CommitJobPayload {
+  sessionId: string;
+  modelId: string;
+  userId: string;
+  libraryId: string;
+  batchMetadata?: BatchUploadMetadata;
+}
+
 const INGESTION_QUEUE = 'ingestion';
 const IMPORT_QUEUE = 'folder-import';
+const IMPORT_SCAN_QUEUE = 'import-scan';
+const IMPORT_COMMIT_QUEUE = 'import-commit';
 
 export class JobService {
   private readonly ingestionQueue: Queue;
   private readonly importQueue: Queue;
+  private readonly importScanQueue: Queue;
+  private readonly importCommitQueue: Queue;
 
   constructor() {
     const connection = parseRedisUrl(config.redisUrl);
@@ -40,6 +62,12 @@ export class JobService {
 
     this.ingestionQueue = new Queue(INGESTION_QUEUE, { connection, defaultJobOptions });
     this.importQueue = new Queue(IMPORT_QUEUE, { connection, defaultJobOptions });
+    // Scan runs once (no retry — a corrupt archive won't fix itself); commit retries.
+    this.importScanQueue = new Queue(IMPORT_SCAN_QUEUE, {
+      connection,
+      defaultJobOptions: { attempts: 1 },
+    });
+    this.importCommitQueue = new Queue(IMPORT_COMMIT_QUEUE, { connection, defaultJobOptions });
   }
 
   async enqueueIngestionJob(payload: IngestionJobPayload): Promise<string> {
@@ -49,6 +77,16 @@ export class JobService {
 
   async enqueueFolderImportJob(payload: FolderImportJobPayload): Promise<string> {
     const job = await this.importQueue.add('import', payload);
+    return job.id!;
+  }
+
+  async enqueueScanJob(payload: ScanJobPayload): Promise<string> {
+    const job = await this.importScanQueue.add('scan', payload);
+    return job.id!;
+  }
+
+  async enqueueCommitJob(payload: CommitJobPayload): Promise<string> {
+    const job = await this.importCommitQueue.add('commit', payload);
     return job.id!;
   }
 
@@ -73,6 +111,14 @@ export class JobService {
 
   get folderImportQueueName(): string {
     return IMPORT_QUEUE;
+  }
+
+  get importScanQueueName(): string {
+    return IMPORT_SCAN_QUEUE;
+  }
+
+  get importCommitQueueName(): string {
+    return IMPORT_COMMIT_QUEUE;
   }
 }
 

--- a/apps/backend/src/services/job.service.ts
+++ b/apps/backend/src/services/job.service.ts
@@ -62,12 +62,18 @@ export class JobService {
 
     this.ingestionQueue = new Queue(INGESTION_QUEUE, { connection, defaultJobOptions });
     this.importQueue = new Queue(IMPORT_QUEUE, { connection, defaultJobOptions });
-    // Scan runs once (no retry — a corrupt archive won't fix itself); commit retries.
+    // Scan runs once — a corrupt archive won't fix itself on retry.
     this.importScanQueue = new Queue(IMPORT_SCAN_QUEUE, {
       connection,
       defaultJobOptions: { attempts: 1 },
     });
-    this.importCommitQueue = new Queue(IMPORT_COMMIT_QUEUE, { connection, defaultJobOptions });
+    // Commit also runs once — retrying processCommitJob re-runs createModelFiles,
+    // which produces duplicate ModelFile rows and double-counts totalSizeBytes.
+    // Idempotent retry support is deferred; for now, attempts: 1 prevents duplication.
+    this.importCommitQueue = new Queue(IMPORT_COMMIT_QUEUE, {
+      connection,
+      defaultJobOptions: { attempts: 1 },
+    });
   }
 
   async enqueueIngestionJob(payload: IngestionJobPayload): Promise<string> {

--- a/apps/backend/src/services/search.service.searchAll.test.ts
+++ b/apps/backend/src/services/search.service.searchAll.test.ts
@@ -1,0 +1,510 @@
+/**
+ * Tests for searchService.searchAll() — the P3 cross-entity global search.
+ *
+ * Seeding strategy mirrors search.service.test.ts exactly: one user, one
+ * library, a handful of models with tags + artist metadata + a collection.
+ * We assert hits in all four result buckets (models, collections, artists,
+ * tags) and verify library isolation (a second library's data never leaks).
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { eq, inArray } from 'drizzle-orm';
+import { db } from '../db/index.js';
+import {
+  users,
+  libraries,
+  models,
+  tags,
+  modelTags,
+  collections,
+  collectionModels,
+  metadataFieldDefinitions,
+  modelMetadata,
+} from '../db/schema/index.js';
+import { searchService } from './search.service.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+let testUserId: string;
+let testLibraryId: string;
+let otherLibraryId: string;
+
+const modelIds: string[] = [];
+const tagIds: Record<string, string> = {};
+let collectionId: string;
+let otherModelId: string;
+
+const fieldDefIds: Record<string, string> = {};
+
+beforeAll(async () => {
+  const ts = Date.now();
+
+  // -------------------------------------------------------------------------
+  // Clean up any leftover fixtures from a previous failed run
+  // -------------------------------------------------------------------------
+  const leftoverUsers = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(eq(users.email, 'searchall-test@example.com'));
+
+  if (leftoverUsers.length > 0) {
+    const ids = leftoverUsers.map((u) => u.id);
+    await db.delete(collections).where(inArray(collections.userId, ids));
+    await db.delete(models).where(inArray(models.userId, ids));
+    await db.delete(libraries).where(inArray(libraries.userId, ids));
+    await db.delete(users).where(eq(users.email, 'searchall-test@example.com'));
+  }
+
+  // Clean up orphaned test tags from previous runs
+  await db.delete(tags).where(inArray(tags.name, [`Dragon-${ts}`, `Fantasy-${ts}`]));
+
+  // -------------------------------------------------------------------------
+  // Create the test user
+  // -------------------------------------------------------------------------
+  const [testUser] = await db
+    .insert(users)
+    .values({
+      email: 'searchall-test@example.com',
+      displayName: 'SearchAll Test User',
+      passwordHash: 'not-a-real-hash',
+      role: 'user',
+    })
+    .returning();
+
+  testUserId = testUser.id;
+
+  // -------------------------------------------------------------------------
+  // Primary test library
+  // -------------------------------------------------------------------------
+  const [testLibrary] = await db
+    .insert(libraries)
+    .values({
+      name: 'SearchAll Test Library',
+      slug: `searchall-test-library-${ts}`,
+      userId: testUserId,
+      isDefault: true,
+    })
+    .returning();
+
+  testLibraryId = testLibrary.id;
+
+  // -------------------------------------------------------------------------
+  // Secondary library (isolation)
+  // -------------------------------------------------------------------------
+  const [otherLibrary] = await db
+    .insert(libraries)
+    .values({
+      name: 'SearchAll Other Library',
+      slug: `searchall-other-library-${ts}`,
+      userId: testUserId,
+      isDefault: false,
+    })
+    .returning();
+
+  otherLibraryId = otherLibrary.id;
+
+  // -------------------------------------------------------------------------
+  // Resolve field definition IDs (artist, tags come from seed data)
+  // -------------------------------------------------------------------------
+  const fieldDefs = await db
+    .select({ id: metadataFieldDefinitions.id, slug: metadataFieldDefinitions.slug })
+    .from(metadataFieldDefinitions)
+    .where(eq(metadataFieldDefinitions.isDefault, true));
+
+  for (const fd of fieldDefs) {
+    fieldDefIds[fd.slug] = fd.id;
+  }
+
+  // -------------------------------------------------------------------------
+  // Create models in the primary library:
+  //   [0] "Dragon Bust Alpha"    — status: ready, artist: sculptor-sa, tag: Dragon-<ts>
+  //   [1] "Fantasy Set Beta"     — status: ready, tag: Fantasy-<ts>
+  //   [2] "Mech Warrior Gamma"   — status: ready (no tags, no artist)
+  // -------------------------------------------------------------------------
+  const modelDefs = [
+    {
+      name: 'Dragon Bust Alpha',
+      description: 'A fierce dragon bust model',
+      status: 'ready' as const,
+      totalSizeBytes: 1_000_000,
+    },
+    {
+      name: 'Fantasy Set Beta',
+      description: 'Fantasy warrior collection',
+      status: 'ready' as const,
+      totalSizeBytes: 2_000_000,
+    },
+    {
+      name: 'Mech Warrior Gamma',
+      description: 'Futuristic mechanical warrior',
+      status: 'ready' as const,
+      totalSizeBytes: 3_000_000,
+    },
+  ];
+
+  for (let i = 0; i < modelDefs.length; i++) {
+    const def = modelDefs[i];
+    const [m] = await db
+      .insert(models)
+      .values({
+        name: def.name,
+        slug: `searchall-test-${def.name.toLowerCase().replace(/\s+/g, '-')}-${ts}-${i}`,
+        description: def.description,
+        userId: testUserId,
+        libraryId: testLibraryId,
+        sourceType: 'zip_upload',
+        status: def.status,
+        totalSizeBytes: def.totalSizeBytes,
+        fileCount: 1,
+      })
+      .returning();
+
+    modelIds.push(m.id);
+  }
+
+  // -------------------------------------------------------------------------
+  // Create tags (unique per test run to avoid cross-test contamination)
+  // -------------------------------------------------------------------------
+  const tagDefs = [
+    { name: `Dragon-${ts}`, slug: `dragon-searchall-${ts}` },
+    { name: `Fantasy-${ts}`, slug: `fantasy-searchall-${ts}` },
+  ];
+
+  for (const tagDef of tagDefs) {
+    const [tag] = await db.insert(tags).values(tagDef).returning();
+    // Key by the prefix part before the timestamp
+    const key = tagDef.name.split('-')[0].toLowerCase(); // 'dragon' or 'fantasy'
+    tagIds[key] = tag.id;
+  }
+
+  // Assign tags to models
+  await db.insert(modelTags).values([
+    { modelId: modelIds[0], tagId: tagIds['dragon'] },
+    { modelId: modelIds[1], tagId: tagIds['fantasy'] },
+  ]);
+
+  // -------------------------------------------------------------------------
+  // Assign artist metadata to model[0]
+  // -------------------------------------------------------------------------
+  const artistFieldId = fieldDefIds['artist'];
+  if (artistFieldId) {
+    await db.insert(modelMetadata).values([
+      { modelId: modelIds[0], fieldDefinitionId: artistFieldId, value: 'sculptor-sa' },
+    ]);
+  }
+
+  // -------------------------------------------------------------------------
+  // Create a collection containing model[0]
+  // -------------------------------------------------------------------------
+  const [testCollection] = await db
+    .insert(collections)
+    .values({
+      name: 'Dragon Busts SA',
+      slug: `dragon-busts-sa-${ts}`,
+      userId: testUserId,
+      libraryId: testLibraryId,
+    })
+    .returning();
+
+  collectionId = testCollection.id;
+
+  await db.insert(collectionModels).values([{ collectionId, modelId: modelIds[0] }]);
+
+  // -------------------------------------------------------------------------
+  // Create a model in the OTHER library that must never appear in primary results
+  // -------------------------------------------------------------------------
+  const [mOther] = await db
+    .insert(models)
+    .values({
+      name: 'Dragon Other Library Model',
+      slug: `searchall-other-dragon-${ts}`,
+      description: 'Dragon model in the other library — must not leak',
+      userId: testUserId,
+      libraryId: otherLibraryId,
+      sourceType: 'zip_upload',
+      status: 'ready',
+      totalSizeBytes: 500_000,
+      fileCount: 1,
+    })
+    .returning();
+
+  otherModelId = mOther.id;
+});
+
+afterAll(async () => {
+  // FK-ordered cleanup: models first (cascades to model_tags, model_metadata,
+  // collection_models), then tags, collections, libraries, user.
+  const allModelIds = [...modelIds, otherModelId].filter(Boolean);
+  if (allModelIds.length > 0) {
+    await db.delete(models).where(inArray(models.id, allModelIds));
+  }
+
+  const tagIdValues = Object.values(tagIds);
+  if (tagIdValues.length > 0) {
+    await db.delete(tags).where(inArray(tags.id, tagIdValues));
+  }
+
+  if (collectionId) {
+    await db.delete(collections).where(eq(collections.id, collectionId));
+  }
+
+  if (testLibraryId) {
+    await db.delete(libraries).where(eq(libraries.id, testLibraryId));
+  }
+
+  if (otherLibraryId) {
+    await db.delete(libraries).where(eq(libraries.id, otherLibraryId));
+  }
+
+  if (testUserId) {
+    await db.delete(users).where(eq(users.id, testUserId));
+  }
+});
+
+// ---------------------------------------------------------------------------
+// describe: result shape
+// ---------------------------------------------------------------------------
+
+describe('searchAll — result shape', () => {
+  it('should return a GlobalSearchResult with q, models, collections, artists, tags keys', async () => {
+    const result = await searchService.searchAll({ q: 'dragon' }, testUserId, testLibraryId);
+
+    expect(result).toHaveProperty('q', 'dragon');
+    expect(result).toHaveProperty('models');
+    expect(result).toHaveProperty('collections');
+    expect(result).toHaveProperty('artists');
+    expect(result).toHaveProperty('tags');
+
+    // models bucket is { items: ModelCard[], total: number }
+    expect(Array.isArray(result.models.items)).toBe(true);
+    expect(typeof result.models.total).toBe('number');
+
+    // Other buckets are arrays
+    expect(Array.isArray(result.collections)).toBe(true);
+    expect(Array.isArray(result.artists)).toBe(true);
+    expect(Array.isArray(result.tags)).toBe(true);
+  });
+
+  it('should echo the trimmed query back in the q field', async () => {
+    const result = await searchService.searchAll({ q: '  dragon  ' }, testUserId, testLibraryId);
+    expect(result.q).toBe('dragon');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// describe: models bucket
+// ---------------------------------------------------------------------------
+
+describe('searchAll — models bucket', () => {
+  it('should include models matching the query in the models.items array', async () => {
+    const result = await searchService.searchAll({ q: 'Dragon Bust Alpha' }, testUserId, testLibraryId);
+
+    const ourMatch = result.models.items.find((m) => m.id === modelIds[0]);
+    expect(ourMatch).toBeDefined();
+    expect(ourMatch!.name).toBe('Dragon Bust Alpha');
+  });
+
+  it('should report models.total as the full match count (not capped by limit)', async () => {
+    const result = await searchService.searchAll(
+      { q: 'dragon', limit: 1 },
+      testUserId,
+      testLibraryId,
+    );
+    // total reflects all DB matches even when limit restricts items length
+    expect(result.models.total).toBeGreaterThanOrEqual(1);
+    expect(result.models.items.length).toBeLessThanOrEqual(1);
+  });
+
+  it('should return an empty models bucket when query matches nothing', async () => {
+    const result = await searchService.searchAll(
+      { q: 'xyzzy-zzt-nothing-matches' },
+      testUserId,
+      testLibraryId,
+    );
+
+    expect(result.models.items).toHaveLength(0);
+    expect(result.models.total).toBe(0);
+  });
+
+  it('should include ModelCard shape fields (id, name, slug, status, createdAt)', async () => {
+    const result = await searchService.searchAll({ q: 'Dragon Bust Alpha' }, testUserId, testLibraryId);
+
+    const card = result.models.items.find((m) => m.id === modelIds[0]);
+    expect(card).toBeDefined();
+    expect(card).toHaveProperty('id');
+    expect(card).toHaveProperty('name');
+    expect(card).toHaveProperty('slug');
+    expect(card).toHaveProperty('status');
+    expect(card).toHaveProperty('createdAt');
+    expect(card).toHaveProperty('metadata');
+    expect(Array.isArray(card!.metadata)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// describe: collections bucket
+// ---------------------------------------------------------------------------
+
+describe('searchAll — collections bucket', () => {
+  it('should include a collection whose name contains the query needle', async () => {
+    // "Dragon Busts SA" contains "dragon"
+    const result = await searchService.searchAll({ q: 'Dragon' }, testUserId, testLibraryId);
+
+    const hit = result.collections.find((c) => c.id === collectionId);
+    expect(hit).toBeDefined();
+    expect(hit!.name).toBe('Dragon Busts SA');
+    expect(typeof hit!.id).toBe('string');
+    expect(typeof hit!.slug).toBe('string');
+    expect(typeof hit!.modelCount).toBe('number');
+  });
+
+  it('should NOT include collections whose names do not match the query', async () => {
+    // Query "warrior" — "Dragon Busts SA" does not contain "warrior"
+    const result = await searchService.searchAll({ q: 'warrior' }, testUserId, testLibraryId);
+
+    const hit = result.collections.find((c) => c.id === collectionId);
+    expect(hit).toBeUndefined();
+  });
+
+  it('should return an empty collections array when query matches no collections', async () => {
+    const result = await searchService.searchAll(
+      { q: 'xyzzy-zzt-nothing-matches' },
+      testUserId,
+      testLibraryId,
+    );
+    expect(result.collections).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// describe: artists bucket
+// ---------------------------------------------------------------------------
+
+describe('searchAll — artists bucket', () => {
+  it('should include an artist whose value contains the query needle', async () => {
+    // model[0] has artist "sculptor-sa"; query "sculptor" should surface it
+    const result = await searchService.searchAll({ q: 'sculptor' }, testUserId, testLibraryId);
+
+    const hit = result.artists.find((a) => a.name === 'sculptor-sa');
+    expect(hit).toBeDefined();
+    expect(typeof hit!.modelCount).toBe('number');
+    expect(hit!.modelCount).toBeGreaterThanOrEqual(1);
+  });
+
+  it('should NOT include artists that do not match the query needle', async () => {
+    // Query "dragon" — no artist value contains "dragon" in the test set
+    // (artist is "sculptor-sa")
+    const result = await searchService.searchAll({ q: 'dragon' }, testUserId, testLibraryId);
+
+    const hit = result.artists.find((a) => a.name === 'sculptor-sa');
+    // artist "sculptor-sa" should NOT appear because it doesn't contain "dragon"
+    expect(hit).toBeUndefined();
+  });
+
+  it('should return an empty artists array when query matches no artists', async () => {
+    const result = await searchService.searchAll(
+      { q: 'xyzzy-zzt-nothing-matches' },
+      testUserId,
+      testLibraryId,
+    );
+    expect(result.artists).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// describe: tags bucket
+// ---------------------------------------------------------------------------
+
+describe('searchAll — tags bucket', () => {
+  it('should include a tag whose name contains the query needle', async () => {
+    // Tag `Dragon-<ts>` contains the prefix "Dragon"
+    const ts = tagIds['dragon'];
+    expect(ts).toBeDefined(); // sanity: tag was created
+
+    const result = await searchService.searchAll({ q: 'Dragon' }, testUserId, testLibraryId);
+
+    // Look for a tag that starts with "Dragon" (our timestamped tag name)
+    const hit = result.tags.find((t) => t.name.toLowerCase().startsWith('dragon'));
+    expect(hit).toBeDefined();
+    expect(typeof hit!.modelCount).toBe('number');
+    expect(hit!.modelCount).toBeGreaterThanOrEqual(1);
+  });
+
+  it('should NOT include tags that do not match the query needle', async () => {
+    // Query "sculptor" — no tag name contains "sculptor"
+    const result = await searchService.searchAll({ q: 'sculptor' }, testUserId, testLibraryId);
+
+    const dragonTag = result.tags.find((t) => t.name.toLowerCase().startsWith('dragon'));
+    expect(dragonTag).toBeUndefined();
+  });
+
+  it('should return an empty tags array when query matches no tags', async () => {
+    const result = await searchService.searchAll(
+      { q: 'xyzzy-zzt-nothing-matches' },
+      testUserId,
+      testLibraryId,
+    );
+    expect(result.tags).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// describe: library isolation
+// ---------------------------------------------------------------------------
+
+describe('searchAll — library isolation', () => {
+  it('should not include models from a different library in the models bucket', async () => {
+    // "Dragon Other Library Model" lives in otherLibraryId, not testLibraryId
+    const result = await searchService.searchAll({ q: 'dragon' }, testUserId, testLibraryId);
+
+    const leaked = result.models.items.find((m) => m.id === otherModelId);
+    expect(leaked).toBeUndefined();
+  });
+
+  it('should include the other-library model when searching THAT library', async () => {
+    const result = await searchService.searchAll({ q: 'dragon' }, testUserId, otherLibraryId);
+
+    const found = result.models.items.find((m) => m.id === otherModelId);
+    expect(found).toBeDefined();
+
+    // Primary library models must NOT appear in the other library's results
+    for (const id of modelIds) {
+      const leaked = result.models.items.find((m) => m.id === id);
+      expect(leaked).toBeUndefined();
+    }
+  });
+
+  it('should not include primary-library collections when searching the other library', async () => {
+    // "Dragon Busts SA" belongs to testLibraryId, not otherLibraryId
+    const result = await searchService.searchAll({ q: 'dragon' }, testUserId, otherLibraryId);
+
+    const leaked = result.collections.find((c) => c.id === collectionId);
+    expect(leaked).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// describe: limit param
+// ---------------------------------------------------------------------------
+
+describe('searchAll — limit param', () => {
+  it('should cap the models.items length at the specified limit', async () => {
+    // Use a broad query that has multiple hits; restrict to limit=1
+    const result = await searchService.searchAll(
+      { q: 'dragon', limit: 1 },
+      testUserId,
+      testLibraryId,
+    );
+
+    expect(result.models.items.length).toBeLessThanOrEqual(1);
+  });
+
+  it('should apply the default limit (6) when not specified', async () => {
+    // With only 3 test models total, items.length must be ≤ 6 (but >= our hits)
+    const result = await searchService.searchAll({ q: 'dragon' }, testUserId, testLibraryId);
+
+    expect(result.models.items.length).toBeLessThanOrEqual(6);
+  });
+});

--- a/apps/backend/src/services/search.service.ts
+++ b/apps/backend/src/services/search.service.ts
@@ -2,10 +2,14 @@ import { and, asc, desc, eq, sql, SQL } from 'drizzle-orm';
 import type {
   ModelSearchParams,
   ModelCard,
+  GlobalSearchParams,
+  GlobalSearchResult,
 } from '@alexandria/shared';
 import { db } from '../db/index.js';
 import { models } from '../db/schema/index.js';
 import { presenterService } from './presenter.service.js';
+import { collectionService } from './collection.service.js';
+import { metadataService } from './metadata.service.js';
 import { validationError } from '../utils/errors.js';
 import { createLogger } from '../utils/logger.js';
 
@@ -13,6 +17,7 @@ const logger = createLogger('SearchService');
 
 const DEFAULT_PAGE_SIZE = 50;
 const MAX_PAGE_SIZE = 200;
+const DEFAULT_GLOBAL_LIMIT = 6;
 
 // ---------------------------------------------------------------------------
 // Public interfaces
@@ -20,6 +25,11 @@ const MAX_PAGE_SIZE = 200;
 
 export interface ISearchService {
   searchModels(params: ModelSearchParams, libraryId: string): Promise<SearchResult>;
+  searchAll(
+    params: GlobalSearchParams,
+    userId: string,
+    libraryId: string,
+  ): Promise<GlobalSearchResult>;
 }
 
 export interface SearchResult {
@@ -322,6 +332,71 @@ export class PostgresSearchService implements ISearchService {
       cursor: nextCursor,
       pageSize,
     };
+  }
+
+  /**
+   * Cross-entity search: models (full-text), plus collections, artists, and
+   * tags matched by name. Each type is scored/sorted independently — models by
+   * full-text relevance, the rest by usage count. Library-scoped throughout.
+   */
+  async searchAll(
+    params: GlobalSearchParams,
+    userId: string,
+    libraryId: string,
+  ): Promise<GlobalSearchResult> {
+    const limit = params.limit ?? DEFAULT_GLOBAL_LIMIT;
+    const q = params.q.trim();
+    const needle = q.toLowerCase();
+
+    const modelResult = await this.searchModels({ q, pageSize: limit }, libraryId);
+
+    return {
+      q,
+      models: { items: modelResult.models, total: modelResult.total },
+      collections: await this.searchCollections(needle, userId, libraryId, limit),
+      artists: await this.searchArtists(needle, libraryId, limit),
+      tags: await this.searchTags(needle, libraryId, limit),
+    };
+  }
+
+  private async searchCollections(
+    needle: string,
+    userId: string,
+    libraryId: string,
+    limit: number,
+  ): Promise<GlobalSearchResult['collections']> {
+    // Collections have no tsvector; match by name. The set is small, so we
+    // filter in memory rather than maintaining a separate index.
+    const collections = await collectionService.listCollections(userId, libraryId).catch(() => []);
+    return collections
+      .filter((c) => c.name.toLowerCase().includes(needle))
+      .sort((a, b) => b.modelCount - a.modelCount)
+      .slice(0, limit)
+      .map((c) => ({ id: c.id, name: c.name, slug: c.slug, modelCount: c.modelCount }));
+  }
+
+  private async searchArtists(
+    needle: string,
+    libraryId: string,
+    limit: number,
+  ): Promise<GlobalSearchResult['artists']> {
+    const values = await metadataService.listFieldValues('artist', libraryId).catch(() => []);
+    return values
+      .filter((v) => v.value.toLowerCase().includes(needle))
+      .slice(0, limit)
+      .map((v) => ({ name: v.value, modelCount: v.modelCount }));
+  }
+
+  private async searchTags(
+    needle: string,
+    libraryId: string,
+    limit: number,
+  ): Promise<GlobalSearchResult['tags']> {
+    const values = await metadataService.listFieldValues('tags', libraryId).catch(() => []);
+    return values
+      .filter((v) => v.value.toLowerCase().includes(needle))
+      .slice(0, limit)
+      .map((v) => ({ name: v.value, modelCount: v.modelCount }));
   }
 }
 

--- a/apps/backend/src/workers/ingestion.worker.ts
+++ b/apps/backend/src/workers/ingestion.worker.ts
@@ -2,7 +2,13 @@ import { Worker, type Job } from 'bullmq';
 import { config } from '../config/index.js';
 import { ingestionService } from '../services/ingestion.service.js';
 import { modelService } from '../services/model.service.js';
-import { jobService, type IngestionJobPayload, type FolderImportJobPayload } from '../services/job.service.js';
+import {
+  jobService,
+  type IngestionJobPayload,
+  type FolderImportJobPayload,
+  type ScanJobPayload,
+  type CommitJobPayload,
+} from '../services/job.service.js';
 import { parseRedisUrl } from '../utils/redis.js';
 import { createLogger } from '../utils/logger.js';
 
@@ -11,6 +17,8 @@ const logger = createLogger('IngestionWorker');
 
 let ingestionWorker: Worker | null = null;
 let importWorker: Worker | null = null;
+let importScanWorker: Worker | null = null;
+let importCommitWorker: Worker | null = null;
 
 export function startIngestionWorker(): void {
   const connection = parseRedisUrl(config.redisUrl);
@@ -77,11 +85,59 @@ export function startIngestionWorker(): void {
       'Folder import job failed',
     );
   });
+
+  // Staged-upload scan worker: extract + detect, mark ready for review.
+  importScanWorker = new Worker(
+    jobService.importScanQueueName,
+    async (job: Job<ScanJobPayload>) => {
+      const { sessionId, tempFilePath, originalFilename, libraryId } = job.data;
+      logger.info({ jobId: job.id, sessionId }, 'Scan job started');
+      await ingestionService.processScanJob(sessionId, tempFilePath, originalFilename, libraryId);
+      logger.info({ jobId: job.id, sessionId }, 'Scan job completed');
+    },
+    {
+      connection,
+      concurrency: 2,
+    },
+  );
+
+  importScanWorker.on('failed', (job, err) => {
+    logger.error(
+      { jobId: job?.id, sessionId: job?.data?.sessionId, error: err.message },
+      'Scan job failed',
+    );
+  });
+
+  // Staged-upload commit worker: persist files + apply batch metadata.
+  importCommitWorker = new Worker(
+    jobService.importCommitQueueName,
+    async (job: Job<CommitJobPayload>) => {
+      logger.info(
+        { jobId: job.id, sessionId: job.data.sessionId, modelId: job.data.modelId },
+        'Commit job started',
+      );
+      await ingestionService.processCommitJob(job);
+      logger.info({ jobId: job.id, sessionId: job.data.sessionId }, 'Commit job completed');
+    },
+    {
+      connection,
+      concurrency: 2,
+    },
+  );
+
+  importCommitWorker.on('failed', (job, err) => {
+    logger.error(
+      { jobId: job?.id, sessionId: job?.data?.sessionId, error: err.message },
+      'Commit job failed',
+    );
+  });
 }
 
 export function stopIngestionWorker(): Promise<void> {
   return Promise.all([
     ingestionWorker ? ingestionWorker.close() : Promise.resolve(),
     importWorker ? importWorker.close() : Promise.resolve(),
+    importScanWorker ? importScanWorker.close() : Promise.resolve(),
+    importCommitWorker ? importCommitWorker.close() : Promise.resolve(),
   ]).then(() => {});
 }

--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import { CollectionsPage } from './pages/CollectionsPage';
 import { CollectionDetailPage } from './pages/CollectionDetailPage';
 import { SettingsPage } from './pages/SettingsPage';
 import { UploadPage } from './pages/UploadPage';
+import { SearchPage } from './pages/SearchPage';
 import { DesignSystemPage } from './pages/DesignSystemPage';
 
 function ProtectedRoute({ children }: { children: React.ReactNode }) {
@@ -47,6 +48,7 @@ export default function App() {
         <Route path="collections/:id" element={<CollectionDetailPage />} />
         <Route path="upload" element={<UploadPage />} />
         <Route path="settings" element={<SettingsPage />} />
+        <Route path="search" element={<SearchPage />} />
       </Route>
       {import.meta.env.DEV && (
         <Route path="/design-system" element={<DesignSystemPage />} />

--- a/apps/frontend/src/api/models.ts
+++ b/apps/frontend/src/api/models.ts
@@ -10,6 +10,7 @@ import type {
   ImportSession,
   BatchUploadMetadata,
   ScanUploadResponse,
+  UploadInitResponse,
 } from '@alexandria/shared';
 import { get, post, patch, del, putRaw } from './client';
 import { buildQueryString } from '../lib/query';
@@ -67,7 +68,7 @@ export async function scanUpload(
   const totalChunks = Math.max(1, Math.ceil(file.size / CHUNK_SIZE));
 
   // 1. Initiate chunked upload session
-  const initResponse = await post<{ uploadId: string; expiresAt: string }>(
+  const initResponse = await post<UploadInitResponse>(
     '/models/upload/init',
     { filename: file.name, totalSize: file.size, totalChunks },
   );

--- a/apps/frontend/src/api/models.ts
+++ b/apps/frontend/src/api/models.ts
@@ -7,6 +7,9 @@ import type {
   ModelSearchParams,
   UpdateModelRequest,
   ImportConfig,
+  ImportSession,
+  BatchUploadMetadata,
+  ScanUploadResponse,
 } from '@alexandria/shared';
 import { get, post, patch, del, putRaw } from './client';
 import { buildQueryString } from '../lib/query';
@@ -52,10 +55,15 @@ export async function deleteModel(id: string): Promise<void> {
 const CHUNK_SIZE = 10 * 1024 * 1024; // 10MB
 const MAX_CHUNK_RETRIES = 3;
 
-export async function uploadModel(
+/**
+ * Upload an archive file using chunked upload. Creates an import session
+ * (status: scanning) instead of immediately creating a model.
+ * Returns { sessionId } — poll the session to track scan progress.
+ */
+export async function scanUpload(
   file: File,
   onProgress?: (pct: number) => void
-): Promise<{ modelId: string }> {
+): Promise<ScanUploadResponse> {
   const totalChunks = Math.max(1, Math.ceil(file.size / CHUNK_SIZE));
 
   // 1. Initiate chunked upload session
@@ -89,7 +97,6 @@ export async function uploadModel(
         break;
       } catch (err) {
         lastError = err;
-        // Exponential backoff: 1s, 2s, 4s
         if (attempt < MAX_CHUNK_RETRIES - 1) {
           await new Promise((r) => setTimeout(r, 1000 * Math.pow(2, attempt)));
         }
@@ -100,14 +107,39 @@ export async function uploadModel(
 
   onProgress?.(95);
 
-  // 3. Complete — assemble and start ingestion
-  const completeResponse = await post<{ modelId: string; jobId: string }>(
+  // 3. Complete — assemble and start scan; returns { sessionId }
+  const completeResponse = await post<ScanUploadResponse>(
     `/models/upload/${uploadId}/complete`,
   );
 
   onProgress?.(100);
 
-  return { modelId: completeResponse.data.modelId };
+  return completeResponse.data;
+}
+
+export async function listImportSessions(): Promise<ImportSession[]> {
+  const response = await get<ImportSession[]>('/models/import-sessions');
+  return response.data;
+}
+
+export async function getImportSession(id: string): Promise<ImportSession> {
+  const response = await get<ImportSession>(`/models/import-sessions/${id}`);
+  return response.data;
+}
+
+export async function commitImportSession(
+  id: string,
+  batchMetadata?: BatchUploadMetadata
+): Promise<{ modelId: string; jobId: string }> {
+  const response = await post<{ modelId: string; jobId: string }>(
+    `/models/import-sessions/${id}/commit`,
+    batchMetadata ? { batchMetadata } : undefined
+  );
+  return response.data;
+}
+
+export async function discardImportSession(id: string): Promise<void> {
+  await del(`/models/import-sessions/${id}`);
 }
 
 export async function importFolder(config: ImportConfig): Promise<{ modelId: string }> {

--- a/apps/frontend/src/api/search.ts
+++ b/apps/frontend/src/api/search.ts
@@ -1,0 +1,9 @@
+import type { GlobalSearchParams, GlobalSearchResult } from '@alexandria/shared';
+import { get } from './client';
+import { buildQueryString } from '../lib/query';
+
+export async function globalSearch(params: GlobalSearchParams): Promise<GlobalSearchResult> {
+  const qs = buildQueryString(params as unknown as Record<string, unknown>);
+  const response = await get<GlobalSearchResult>(`/search${qs}`);
+  return response.data;
+}

--- a/apps/frontend/src/components/command/CommandPalette.tsx
+++ b/apps/frontend/src/components/command/CommandPalette.tsx
@@ -1,0 +1,287 @@
+import { useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Search, Package, Folder, ArrowRight } from 'lucide-react';
+import { Dialog, DialogContent } from '../ui/dialog';
+import { useCommandPalette } from '../../hooks/use-command-palette';
+import { useGlobalSearch } from '../../hooks/use-global-search';
+
+function useDebounce<T>(value: T, delay: number): T {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const id = setTimeout(() => setDebounced(value), delay);
+    return () => clearTimeout(id);
+  }, [value, delay]);
+  return debounced;
+}
+
+export function CommandPalette() {
+  const { isOpen, close } = useCommandPalette();
+  const navigate = useNavigate();
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const [inputValue, setInputValue] = useState('');
+  const debouncedQ = useDebounce(inputValue, 200);
+
+  const { data } = useGlobalSearch(debouncedQ, 4);
+
+  // Build a flat list of selectable items for keyboard nav
+  const items: Array<{ type: 'search' | 'model' | 'collection'; label: string; sub?: string; action: () => void }> = [];
+
+  if (debouncedQ.trim().length > 0) {
+    items.push({
+      type: 'search',
+      label: `Search everything for "${debouncedQ}"`,
+      action: () => {
+        navigate(`/search?q=${encodeURIComponent(debouncedQ)}`);
+        close();
+      },
+    });
+  }
+
+  if (data) {
+    for (const model of data.models.items.slice(0, 4)) {
+      items.push({
+        type: 'model',
+        label: model.name,
+        sub: `${model.fileCount} ${model.fileCount === 1 ? 'file' : 'files'}`,
+        action: () => {
+          navigate(`/models/${model.id}`);
+          close();
+        },
+      });
+    }
+    for (const col of data.collections.slice(0, 3)) {
+      items.push({
+        type: 'collection',
+        label: col.name,
+        sub: `${col.modelCount} ${col.modelCount === 1 ? 'model' : 'models'}`,
+        action: () => {
+          navigate(`/collections/${col.id}`);
+          close();
+        },
+      });
+    }
+  }
+
+  const [selectedIndex, setSelectedIndex] = useState(0);
+
+  // Reset selection when items change
+  useEffect(() => {
+    setSelectedIndex(0);
+  }, [debouncedQ]);
+
+  // Focus the input when dialog opens
+  useEffect(() => {
+    if (isOpen) {
+      setInputValue('');
+      setSelectedIndex(0);
+      requestAnimationFrame(() => inputRef.current?.focus());
+    }
+  }, [isOpen]);
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setSelectedIndex((i) => Math.min(i + 1, items.length - 1));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setSelectedIndex((i) => Math.max(i - 1, 0));
+    } else if (e.key === 'Enter' && items.length > 0) {
+      e.preventDefault();
+      items[selectedIndex]?.action();
+    }
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => { if (!open) close(); }}>
+      <DialogContent
+        className="p-0 gap-0 overflow-hidden"
+        style={{
+          maxWidth: 560,
+          background: 'var(--ax-bg)',
+          border: '1px solid var(--ax-border)',
+          borderRadius: 14,
+        }}
+        onKeyDown={handleKeyDown}
+      >
+        {/* Search input */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 10,
+            padding: '14px 16px',
+            borderBottom: items.length > 0 ? '1px solid var(--ax-border)' : 'none',
+          }}
+        >
+          <Search size={16} style={{ color: 'var(--ax-fg-muted)', flexShrink: 0 }} />
+          <input
+            ref={inputRef}
+            type="text"
+            placeholder="Search models, collections…"
+            value={inputValue}
+            onChange={(e) => setInputValue(e.target.value)}
+            style={{
+              flex: 1,
+              background: 'none',
+              border: 'none',
+              outline: 'none',
+              fontSize: 15,
+              color: 'var(--ax-fg)',
+              fontFamily: 'inherit',
+            }}
+            aria-label="Command palette search"
+            aria-autocomplete="list"
+            aria-expanded={items.length > 0}
+          />
+          {inputValue && (
+            <button
+              type="button"
+              onClick={() => setInputValue('')}
+              style={{
+                background: 'none',
+                border: 'none',
+                cursor: 'pointer',
+                color: 'var(--ax-fg-muted)',
+                padding: 2,
+                fontFamily: 'inherit',
+                fontSize: 12,
+              }}
+              aria-label="Clear search"
+            >
+              esc
+            </button>
+          )}
+        </div>
+
+        {/* Results list */}
+        {items.length > 0 && (
+          <div
+            role="listbox"
+            aria-label="Search results"
+            style={{ maxHeight: 340, overflowY: 'auto', padding: '6px 0' }}
+          >
+            {items.map((item, i) => (
+              <div
+                key={`${item.type}-${item.label}`}
+                role="option"
+                aria-selected={i === selectedIndex}
+                onClick={item.action}
+                onMouseEnter={() => setSelectedIndex(i)}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 10,
+                  padding: '9px 16px',
+                  cursor: 'pointer',
+                  background: i === selectedIndex ? 'var(--ax-bg-elev)' : 'transparent',
+                  transition: 'background 0.1s',
+                }}
+              >
+                {/* Type icon */}
+                <span
+                  style={{
+                    width: 28,
+                    height: 28,
+                    borderRadius: 7,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    flexShrink: 0,
+                    background:
+                      item.type === 'search'
+                        ? 'var(--ax-bg-sunk)'
+                        : item.type === 'collection'
+                        ? 'var(--ax-amber-tint)'
+                        : 'var(--ax-bg-sunk)',
+                    color:
+                      item.type === 'collection'
+                        ? 'var(--ax-amber-tint-fg)'
+                        : 'var(--ax-fg-muted)',
+                  }}
+                >
+                  {item.type === 'search' && <Search size={13} />}
+                  {item.type === 'model' && <Package size={13} />}
+                  {item.type === 'collection' && <Folder size={13} />}
+                </span>
+
+                {/* Labels */}
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div
+                    style={{
+                      fontSize: 13.5,
+                      fontWeight: item.type === 'search' ? 500 : 600,
+                      color:
+                        item.type === 'search'
+                          ? 'var(--ax-fg-muted)'
+                          : 'var(--ax-fg)',
+                      whiteSpace: 'nowrap',
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                    }}
+                  >
+                    {item.label}
+                  </div>
+                  {item.sub && (
+                    <div className="ax-mono" style={{ fontSize: 11, color: 'var(--ax-fg-muted)' }}>
+                      {item.sub}
+                    </div>
+                  )}
+                </div>
+
+                {i === selectedIndex && (
+                  <ArrowRight size={12} style={{ color: 'var(--ax-fg-muted)', flexShrink: 0 }} />
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* Empty state for typed query with no results yet */}
+        {inputValue.trim().length > 0 && items.length === 0 && (
+          <div
+            style={{
+              padding: '32px 16px',
+              textAlign: 'center',
+              fontSize: 13,
+              color: 'var(--ax-fg-muted)',
+            }}
+          >
+            No results for "{inputValue}"
+          </div>
+        )}
+
+        {/* Prompt when empty */}
+        {inputValue.trim().length === 0 && (
+          <div
+            style={{
+              padding: '28px 16px',
+              textAlign: 'center',
+              fontSize: 13,
+              color: 'var(--ax-fg-muted)',
+            }}
+          >
+            Type to search models, collections, artists, and tags
+          </div>
+        )}
+
+        {/* Keyboard hint footer */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 12,
+            padding: '8px 16px',
+            borderTop: '1px solid var(--ax-border)',
+            fontSize: 11,
+            color: 'var(--ax-fg-muted)',
+          }}
+        >
+          <span>↑↓ navigate</span>
+          <span>↵ select</span>
+          <span>esc close</span>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/frontend/src/components/layout/AppShell.tsx
+++ b/apps/frontend/src/components/layout/AppShell.tsx
@@ -1,13 +1,18 @@
 import { Outlet } from 'react-router-dom';
 import { PivotRail } from '../pivot/PivotRail';
+import { CommandPaletteProvider } from '../../hooks/use-command-palette';
+import { CommandPalette } from '../command/CommandPalette';
 
 export function AppShell() {
   return (
-    <div className="flex h-screen overflow-hidden bg-background">
-      <PivotRail />
-      <main className="flex-1 min-w-0 overflow-auto">
-        <Outlet />
-      </main>
-    </div>
+    <CommandPaletteProvider>
+      <div className="flex h-screen overflow-hidden bg-background">
+        <PivotRail />
+        <main className="flex-1 min-w-0 overflow-auto">
+          <Outlet />
+        </main>
+      </div>
+      <CommandPalette />
+    </CommandPaletteProvider>
   );
 }

--- a/apps/frontend/src/components/pivot/PivotMain.tsx
+++ b/apps/frontend/src/components/pivot/PivotMain.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { Loader2 } from 'lucide-react';
 import { useModelFilters } from '../../hooks/use-model-filters';
 import { useModelResults } from '../../hooks/use-model-results';
@@ -64,6 +64,7 @@ function deriveContextTitle(
  * full pivot workspace page.
  */
 export function PivotMain() {
+  const navigate = useNavigate();
   const { filters, toApiParams, setQ, axis, activeAxisValue, hasActiveFilters } =
     useModelFilters();
   const { view, showThumbnails } = useDisplayPreferences();
@@ -117,29 +118,37 @@ export function PivotMain() {
 
         {/* Right: search + upload */}
         <div className="flex items-center gap-2 flex-shrink-0">
-          {/* Search input */}
-          <label className="relative flex items-center">
-            <span className="sr-only">Search models</span>
-            <SearchIcon
-              className="absolute left-2.5 h-3.5 w-3.5 pointer-events-none"
-              style={{ color: 'var(--ax-fg-muted)' }}
-              aria-hidden
-            />
-            <input
-              type="search"
-              placeholder="Search…"
-              value={filters.q}
-              onChange={(e) => setQ(e.target.value)}
-              aria-label="Search models"
-              className="h-8 rounded-lg pl-8 pr-3 text-sm outline-none transition-colors"
-              style={{
-                width: 200,
-                background: 'var(--ax-bg-elev)',
-                border: '1px solid var(--ax-border)',
-                color: 'var(--ax-fg)',
-              }}
-            />
-          </label>
+          {/* Search input — Enter navigates to the global search page */}
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              const val = filters.q.trim();
+              if (val) navigate(`/search?q=${encodeURIComponent(val)}`);
+            }}
+          >
+            <label className="relative flex items-center">
+              <span className="sr-only">Search models</span>
+              <SearchIcon
+                className="absolute left-2.5 h-3.5 w-3.5 pointer-events-none"
+                style={{ color: 'var(--ax-fg-muted)' }}
+                aria-hidden
+              />
+              <input
+                type="search"
+                placeholder="Search…"
+                value={filters.q}
+                onChange={(e) => setQ(e.target.value)}
+                aria-label="Search models"
+                className="h-8 rounded-lg pl-8 pr-3 text-sm outline-none transition-colors"
+                style={{
+                  width: 200,
+                  background: 'var(--ax-bg-elev)',
+                  border: '1px solid var(--ax-border)',
+                  color: 'var(--ax-fg)',
+                }}
+              />
+            </label>
+          </form>
 
           {/* Upload action */}
           <Link

--- a/apps/frontend/src/components/search/ArtistResultCard.tsx
+++ b/apps/frontend/src/components/search/ArtistResultCard.tsx
@@ -1,0 +1,91 @@
+import { useNavigate } from 'react-router-dom';
+import type { SearchArtistHit } from '@alexandria/shared';
+
+// A deterministic palette per artist name for the gradient avatar
+const GRADIENTS: [string, string][] = [
+  ['#f59e0b', '#d97706'],
+  ['#0d9488', '#0f766e'],
+  ['#6366f1', '#4f46e5'],
+  ['#ec4899', '#db2777'],
+  ['#10b981', '#059669'],
+  ['#3b82f6', '#2563eb'],
+];
+
+function getGradient(name: string): [string, string] {
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) {
+    hash = (hash << 5) - hash + name.charCodeAt(i);
+    hash |= 0;
+  }
+  return GRADIENTS[Math.abs(hash) % GRADIENTS.length];
+}
+
+function initials(name: string): string {
+  return name
+    .split(' ')
+    .map((w) => w[0])
+    .join('')
+    .slice(0, 2)
+    .toUpperCase();
+}
+
+interface ArtistResultCardProps {
+  artist: SearchArtistHit;
+}
+
+export function ArtistResultCard({ artist }: ArtistResultCardProps) {
+  const navigate = useNavigate();
+  const [from, to] = getGradient(artist.name);
+
+  function handleClick() {
+    navigate(`/?meta_artist=${encodeURIComponent(artist.name)}`);
+  }
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={handleClick}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          handleClick();
+        }
+      }}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 12,
+        padding: 12,
+        borderRadius: 10,
+        background: 'var(--ax-bg-elev)',
+        border: '1px solid var(--ax-border)',
+        cursor: 'pointer',
+      }}
+    >
+      <div
+        style={{
+          width: 38,
+          height: 38,
+          borderRadius: '50%',
+          background: `linear-gradient(135deg, ${from}, ${to})`,
+          color: 'white',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontSize: 13,
+          fontWeight: 700,
+          flexShrink: 0,
+        }}
+      >
+        {initials(artist.name)}
+      </div>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ fontSize: 13, fontWeight: 600 }}>{artist.name}</div>
+        <div className="ax-mono" style={{ fontSize: 11, color: 'var(--ax-fg-muted)' }}>
+          {artist.modelCount} {artist.modelCount === 1 ? 'model' : 'models'}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/search/CollectionResultRow.tsx
+++ b/apps/frontend/src/components/search/CollectionResultRow.tsx
@@ -1,0 +1,58 @@
+import { useNavigate } from 'react-router-dom';
+import { Folder, ArrowRight } from 'lucide-react';
+import type { SearchCollectionHit } from '@alexandria/shared';
+
+interface CollectionResultRowProps {
+  collection: SearchCollectionHit;
+}
+
+export function CollectionResultRow({ collection }: CollectionResultRowProps) {
+  const navigate = useNavigate();
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={() => navigate(`/collections/${collection.id}`)}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          navigate(`/collections/${collection.id}`);
+        }
+      }}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 12,
+        padding: '10px 14px',
+        background: 'var(--ax-bg-elev)',
+        border: '1px solid var(--ax-border)',
+        borderRadius: 10,
+        cursor: 'pointer',
+      }}
+    >
+      <span
+        style={{
+          width: 32,
+          height: 32,
+          borderRadius: 8,
+          background: 'var(--ax-amber-tint)',
+          color: 'var(--ax-amber-tint-fg)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          flexShrink: 0,
+        }}
+      >
+        <Folder size={14} />
+      </span>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ fontSize: 13.5, fontWeight: 600 }}>{collection.name}</div>
+        <div className="ax-mono" style={{ fontSize: 11.5, color: 'var(--ax-fg-muted)' }}>
+          {collection.modelCount} {collection.modelCount === 1 ? 'model' : 'models'}
+        </div>
+      </div>
+      <ArrowRight size={14} style={{ color: 'var(--ax-fg-muted)', flexShrink: 0 }} />
+    </div>
+  );
+}

--- a/apps/frontend/src/components/search/SearchRail.tsx
+++ b/apps/frontend/src/components/search/SearchRail.tsx
@@ -1,0 +1,237 @@
+import { BookOpen, ChevronDown } from 'lucide-react';
+import type { GlobalSearchResult } from '@alexandria/shared';
+
+type ResultTypeFilter = 'all' | 'models' | 'collections' | 'artists' | 'tags';
+
+interface SearchRailProps {
+  result: GlobalSearchResult | undefined;
+  activeType: ResultTypeFilter;
+  onTypeChange: (type: ResultTypeFilter) => void;
+}
+
+interface RailRowProps {
+  label: string;
+  count: number;
+  active?: boolean;
+  onClick?: () => void;
+}
+
+function RailRow({ label, count, active, onClick }: RailRowProps) {
+  return (
+    <div
+      role={onClick ? 'button' : undefined}
+      tabIndex={onClick ? 0 : undefined}
+      onClick={onClick}
+      onKeyDown={onClick ? (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onClick(); } } : undefined}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 8,
+        padding: '6px 8px',
+        borderRadius: 6,
+        cursor: onClick ? 'pointer' : 'default',
+        background: active ? 'var(--ax-rail-active)' : 'transparent',
+        color: active ? 'white' : 'var(--ax-rail-fg-muted)',
+        fontSize: 12.5,
+      }}
+    >
+      <span style={{ flex: 1 }}>{label}</span>
+      <span className="ax-mono" style={{ fontSize: 11 }}>{count}</span>
+    </div>
+  );
+}
+
+function RailSectionHeader({ title }: { title: string }) {
+  return (
+    <div
+      className="ax-mono"
+      style={{
+        padding: '8px 8px 4px',
+        fontSize: 10.5,
+        fontWeight: 700,
+        letterSpacing: '0.08em',
+        textTransform: 'uppercase',
+        color: 'var(--ax-rail-fg-muted)',
+        opacity: 0.6,
+      }}
+    >
+      {title}
+    </div>
+  );
+}
+
+export function SearchRail({ result, activeType, onTypeChange }: SearchRailProps) {
+  const totalModels = result?.models.total ?? 0;
+  const totalCollections = result?.collections.length ?? 0;
+  const totalArtists = result?.artists.length ?? 0;
+  const totalTags = result?.tags.length ?? 0;
+  const grandTotal = totalModels + totalCollections + totalArtists + totalTags;
+
+  return (
+    <aside
+      style={{
+        width: 220,
+        background: 'var(--ax-rail)',
+        color: 'var(--ax-rail-fg)',
+        borderRight: '1px solid var(--ax-rail-border)',
+        flexShrink: 0,
+        display: 'flex',
+        flexDirection: 'column',
+      }}
+    >
+      {/* Brand header */}
+      <div
+        style={{
+          padding: '14px 16px 12px',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 8,
+          borderBottom: '1px solid var(--ax-rail-border)',
+        }}
+      >
+        <BookOpen size={16} style={{ color: 'var(--ax-amber)', flexShrink: 0 }} />
+        <span style={{ fontWeight: 600, fontSize: 14, color: 'var(--ax-rail-fg)' }}>
+          Search
+        </span>
+      </div>
+
+      <div style={{ flex: 1, overflowY: 'auto', padding: '12px 8px' }}>
+        {/* Result type filter */}
+        <RailSectionHeader title="Result type" />
+        <div style={{ padding: '4px 0 14px' }}>
+          <RailRow
+            label="All results"
+            count={grandTotal}
+            active={activeType === 'all'}
+            onClick={() => onTypeChange('all')}
+          />
+          <RailRow
+            label="Models"
+            count={totalModels}
+            active={activeType === 'models'}
+            onClick={() => onTypeChange('models')}
+          />
+          <RailRow
+            label="Collections"
+            count={totalCollections}
+            active={activeType === 'collections'}
+            onClick={() => onTypeChange('collections')}
+          />
+          <RailRow
+            label="Artists"
+            count={totalArtists}
+            active={activeType === 'artists'}
+            onClick={() => onTypeChange('artists')}
+          />
+          <RailRow
+            label="Tags"
+            count={totalTags}
+            active={activeType === 'tags'}
+            onClick={() => onTypeChange('tags')}
+          />
+        </div>
+
+        {/* Library section — cosmetic, single library */}
+        <RailSectionHeader title="Library" />
+        <div style={{ padding: '4px 0 14px' }}>
+          {/*
+           * Multi-library switching is a later phase (P5).
+           * Render a single cosmetic library entry that is non-interactive.
+           */}
+          <button
+            type="button"
+            aria-disabled="true"
+            title="Library switching coming soon"
+            tabIndex={-1}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 8,
+              width: '100%',
+              padding: '6px 8px',
+              borderRadius: 6,
+              background: 'var(--ax-rail-elev)',
+              border: '1px solid var(--ax-rail-border)',
+              color: 'var(--ax-rail-fg-muted)',
+              fontFamily: 'inherit',
+              fontSize: 12.5,
+              cursor: 'not-allowed',
+              opacity: 0.75,
+            }}
+          >
+            <div
+              style={{
+                width: 20,
+                height: 20,
+                borderRadius: 5,
+                background: 'linear-gradient(135deg, var(--ax-amber) 0%, var(--ax-amber-deep, #b45309) 100%)',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                fontSize: 10,
+                fontWeight: 700,
+                color: 'white',
+                flexShrink: 0,
+              }}
+            >
+              L
+            </div>
+            <span style={{ flex: 1, textAlign: 'left' }}>Library</span>
+            <ChevronDown size={12} style={{ color: 'var(--ax-rail-fg-muted)' }} />
+          </button>
+        </div>
+
+        {/* Visual-only filter toggles */}
+        <RailSectionHeader title="Filter results" />
+        <div style={{ padding: '4px 0 0' }}>
+          <RailToggle label="Has 3D files" />
+          <RailToggle label="Has images" />
+          <RailToggle label="Pre-supported only" />
+        </div>
+      </div>
+    </aside>
+  );
+}
+
+function RailToggle({ label, active = false }: { label: string; active?: boolean }) {
+  return (
+    <label
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 8,
+        padding: '6px 8px',
+        borderRadius: 6,
+        cursor: 'default',
+        fontSize: 12.5,
+        color: 'var(--ax-rail-fg-muted)',
+      }}
+    >
+      <span
+        style={{
+          width: 24,
+          height: 14,
+          borderRadius: 999,
+          background: active ? 'var(--ax-amber)' : 'var(--ax-rail-elev)',
+          border: `1px solid ${active ? 'var(--ax-amber)' : 'var(--ax-rail-border)'}`,
+          position: 'relative',
+          flexShrink: 0,
+        }}
+      >
+        <span
+          style={{
+            position: 'absolute',
+            top: 1,
+            left: active ? 11 : 1,
+            width: 10,
+            height: 10,
+            borderRadius: '50%',
+            background: 'white',
+            transition: 'left .12s',
+          }}
+        />
+      </span>
+      <span>{label}</span>
+    </label>
+  );
+}

--- a/apps/frontend/src/components/search/SearchSection.tsx
+++ b/apps/frontend/src/components/search/SearchSection.tsx
@@ -1,0 +1,51 @@
+import { useState } from 'react';
+import { ChevronDown, ChevronUp } from 'lucide-react';
+
+interface SearchSectionProps {
+  title: string;
+  count: number;
+  icon: React.ReactNode;
+  note?: string;
+  children: React.ReactNode;
+}
+
+export function SearchSection({ title, count, icon, note, children }: SearchSectionProps) {
+  const [open, setOpen] = useState(true);
+
+  return (
+    <section style={{ marginTop: 20 }}>
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="flex items-center gap-2 w-full text-left"
+        style={{
+          background: 'none',
+          border: 'none',
+          cursor: 'pointer',
+          padding: '4px 0',
+          marginBottom: open ? 10 : 0,
+          color: 'inherit',
+          fontFamily: 'inherit',
+        }}
+      >
+        {icon}
+        <h2 style={{ margin: 0, fontSize: 16, fontWeight: 700 }}>{title}</h2>
+        <span
+          className="ax-mono"
+          style={{ fontSize: 12, color: 'var(--ax-fg-muted)' }}
+        >
+          {count}
+        </span>
+        {note && (
+          <span style={{ marginLeft: 8, fontSize: 11.5, color: 'var(--ax-fg-subtle)', fontStyle: 'italic' }}>
+            {note}
+          </span>
+        )}
+        <span style={{ marginLeft: 'auto', color: 'var(--ax-fg-muted)' }}>
+          {open ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+        </span>
+      </button>
+      {open && children}
+    </section>
+  );
+}

--- a/apps/frontend/src/components/search/TagResultPill.tsx
+++ b/apps/frontend/src/components/search/TagResultPill.tsx
@@ -1,0 +1,42 @@
+import { useNavigate } from 'react-router-dom';
+import { Hash } from 'lucide-react';
+import type { SearchTagHit } from '@alexandria/shared';
+
+interface TagResultPillProps {
+  tag: SearchTagHit;
+}
+
+export function TagResultPill({ tag }: TagResultPillProps) {
+  const navigate = useNavigate();
+
+  function handleClick() {
+    navigate(`/?tags=${encodeURIComponent(tag.name)}`);
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 6,
+        padding: '8px 14px',
+        borderRadius: 999,
+        background: 'var(--ax-amber-tint)',
+        color: 'var(--ax-amber-tint-fg)',
+        border: 'none',
+        cursor: 'pointer',
+        fontFamily: 'inherit',
+        fontSize: 13,
+        fontWeight: 500,
+      }}
+    >
+      <Hash size={11} />
+      {tag.name}
+      <span className="ax-mono" style={{ marginLeft: 4, fontSize: 11, opacity: 0.7 }}>
+        {tag.modelCount}
+      </span>
+    </button>
+  );
+}

--- a/apps/frontend/src/components/upload/BatchMetadataForm.tsx
+++ b/apps/frontend/src/components/upload/BatchMetadataForm.tsx
@@ -1,0 +1,322 @@
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Loader2, X, FolderOpen, User, Tag } from 'lucide-react';
+import type { DetectedImportMetadata, BatchUploadMetadata } from '@alexandria/shared';
+import { getCollections } from '../../api/collections';
+import { useCommitSession } from '../../hooks/use-import-sessions';
+import { Button } from '../ui/button';
+import { Input } from '../ui/input';
+import { Label } from '../ui/label';
+import { Checkbox } from '../ui/checkbox';
+
+interface BatchMetadataFormProps {
+  sessionId: string;
+  detected: DetectedImportMetadata;
+  onCommitted: (modelId: string) => void;
+}
+
+interface FormState {
+  collectionId: string;
+  newCollectionName: string;
+  artist: string;
+  tags: string[];
+  tagInput: string;
+  markPreSupported: boolean;
+  autoThumbnails: boolean;
+  markNsfw: boolean;
+  skipDuplicatesByHash: boolean;
+}
+
+export function BatchMetadataForm({ sessionId, detected, onCommitted }: BatchMetadataFormProps) {
+  const [form, setForm] = useState<FormState>({
+    collectionId: '',
+    newCollectionName: '',
+    artist: detected.artist ?? '',
+    tags: [...detected.tagsGuessed],
+    tagInput: '',
+    markPreSupported: false,
+    autoThumbnails: true,
+    markNsfw: false,
+    skipDuplicatesByHash: true,
+  });
+
+  const { data: collectionsResponse } = useQuery({
+    queryKey: ['collections'],
+    queryFn: () => getCollections({ depth: 1 }),
+    staleTime: 30_000,
+  });
+  const collections = collectionsResponse?.data ?? [];
+
+  const commitMutation = useCommitSession();
+
+  function addTag(tag: string) {
+    const t = tag.trim();
+    if (t && !form.tags.includes(t)) {
+      setForm((f) => ({ ...f, tags: [...f.tags, t], tagInput: '' }));
+    } else {
+      setForm((f) => ({ ...f, tagInput: '' }));
+    }
+  }
+
+  function removeTag(tag: string) {
+    setForm((f) => ({ ...f, tags: f.tags.filter((t) => t !== tag) }));
+  }
+
+  async function handleSubmit() {
+    const batchMetadata: BatchUploadMetadata = {
+      ...(form.collectionId && form.collectionId !== '__new__' ? { collectionId: form.collectionId } : {}),
+      ...(form.newCollectionName.trim() ? { newCollectionName: form.newCollectionName.trim() } : {}),
+      ...(form.artist.trim() ? { artist: form.artist.trim() } : {}),
+      ...(form.tags.length > 0 ? { tags: form.tags } : {}),
+      options: {
+        markPreSupported: form.markPreSupported,
+        autoThumbnails: form.autoThumbnails,
+        markNsfw: form.markNsfw,
+        skipDuplicatesByHash: form.skipDuplicatesByHash,
+      },
+    };
+
+    try {
+      const result = await commitMutation.mutateAsync({ id: sessionId, batchMetadata });
+      onCommitted(result.modelId);
+    } catch {
+      // Error surfaces via commitMutation.error
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Destination collection */}
+      <FormSection label="Destination collection">
+        <select
+          value={form.collectionId}
+          onChange={(e) =>
+            setForm((f) => ({
+              ...f,
+              collectionId: e.target.value,
+              newCollectionName: e.target.value !== '__new__' ? '' : f.newCollectionName,
+            }))
+          }
+          className="w-full rounded-lg px-3 py-2 text-[13px]"
+          style={{
+            background: 'var(--ax-bg-elev)',
+            border: '1px solid var(--ax-border)',
+            color: 'var(--ax-fg)',
+            fontFamily: 'inherit',
+          }}
+        >
+          <option value="">— None —</option>
+          {collections.map((c) => (
+            <option key={c.id} value={c.id}>
+              {c.name}
+            </option>
+          ))}
+          <option value="__new__">+ New collection…</option>
+        </select>
+        {form.collectionId === '__new__' && (
+          <div className="flex items-center gap-2 mt-2">
+            <FolderOpen className="h-4 w-4 flex-shrink-0" style={{ color: 'var(--ax-amber)' }} />
+            <Input
+              placeholder="New collection name"
+              value={form.newCollectionName}
+              onChange={(e) => setForm((f) => ({ ...f, newCollectionName: e.target.value }))}
+              className="text-[13px]"
+            />
+          </div>
+        )}
+      </FormSection>
+
+      {/* Artist */}
+      <FormSection
+        label={
+          <span>
+            Artist
+            {detected.artist && (
+              <span
+                className="ml-2 font-normal text-[11px]"
+                style={{ color: 'var(--ax-fg-subtle)' }}
+              >
+                auto-detected
+              </span>
+            )}
+          </span>
+        }
+      >
+        <div className="flex items-center gap-2">
+          <User className="h-4 w-4 flex-shrink-0" style={{ color: 'var(--ax-fg-muted)' }} />
+          <Input
+            value={form.artist}
+            onChange={(e) => setForm((f) => ({ ...f, artist: e.target.value }))}
+            placeholder="Artist name (optional)"
+            className="text-[13px]"
+          />
+        </div>
+      </FormSection>
+
+      {/* Tags */}
+      <FormSection label="Tags to apply to all">
+        <div
+          className="flex flex-wrap gap-1.5 p-2.5 rounded-lg min-h-[40px]"
+          style={{
+            background: 'var(--ax-bg-elev)',
+            border: '1px solid var(--ax-border)',
+          }}
+        >
+          {form.tags.map((tag) => (
+            <span
+              key={tag}
+              className="ax-chip ax-chip-amber flex items-center gap-1"
+              style={{ height: 22 }}
+            >
+              <Tag className="w-2.5 h-2.5" />
+              {tag}
+              <button
+                type="button"
+                onClick={() => removeTag(tag)}
+                className="ml-0.5 hover:opacity-70"
+                aria-label={`Remove tag ${tag}`}
+              >
+                <X className="w-2.5 h-2.5" />
+              </button>
+            </span>
+          ))}
+          <input
+            value={form.tagInput}
+            onChange={(e) => setForm((f) => ({ ...f, tagInput: e.target.value }))}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ',') {
+                e.preventDefault();
+                addTag(form.tagInput);
+              }
+            }}
+            placeholder={form.tags.length === 0 ? 'Type a tag and press Enter…' : '+ tag'}
+            className="bg-transparent text-[12px] outline-none flex-1 min-w-[80px] placeholder:text-[var(--ax-fg-muted)]"
+            style={{ color: 'var(--ax-fg)', fontFamily: 'inherit' }}
+          />
+        </div>
+        <p className="text-[11.5px] mt-1.5" style={{ color: 'var(--ax-fg-muted)' }}>
+          Inferred from filenames + folder paths. Press Enter or comma to add.
+        </p>
+      </FormSection>
+
+      {/* Options */}
+      <FormSection label="Options">
+        <div className="flex flex-col gap-1">
+          <OptionCheck
+            id="pre-supported"
+            label="Mark all as pre-supported"
+            checked={form.markPreSupported}
+            onChange={(v) => setForm((f) => ({ ...f, markPreSupported: v }))}
+          />
+          <OptionCheck
+            id="auto-thumbnails"
+            label="Auto-generate thumbnails"
+            checked={form.autoThumbnails}
+            onChange={(v) => setForm((f) => ({ ...f, autoThumbnails: v }))}
+            note="Always runs during ingestion"
+          />
+          <OptionCheck
+            id="mark-nsfw"
+            label="Mark as NSFW"
+            checked={form.markNsfw}
+            onChange={(v) => setForm((f) => ({ ...f, markNsfw: v }))}
+          />
+          <OptionCheck
+            id="skip-dupes"
+            label="Skip duplicates (by hash)"
+            checked={form.skipDuplicatesByHash}
+            onChange={(v) => setForm((f) => ({ ...f, skipDuplicatesByHash: v }))}
+          />
+        </div>
+      </FormSection>
+
+      {/* Commit error */}
+      {commitMutation.error && (
+        <div
+          className="flex items-center gap-2 rounded-lg px-3 py-2.5 text-[13px]"
+          style={{
+            background: 'color-mix(in srgb, var(--ax-danger) 10%, transparent)',
+            border: '1px solid var(--ax-danger)',
+            color: 'var(--ax-danger)',
+          }}
+        >
+          {commitMutation.error instanceof Error
+            ? commitMutation.error.message
+            : 'Commit failed. Please try again.'}
+        </div>
+      )}
+
+      <Button
+        onClick={handleSubmit}
+        disabled={commitMutation.isPending}
+        className="w-full font-semibold"
+        style={{
+          background: 'var(--ax-amber)',
+          color: 'var(--ax-amber-fg)',
+          border: 'none',
+        }}
+      >
+        {commitMutation.isPending && <Loader2 className="h-4 w-4 animate-spin mr-2" />}
+        Import {detected.modelCount > 0 ? `${detected.modelCount} models` : 'archive'}
+      </Button>
+    </div>
+  );
+}
+
+function FormSection({
+  label,
+  children,
+}: {
+  label: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <Label
+        className="block text-[11px] font-semibold uppercase mb-1.5"
+        style={{
+          color: 'var(--ax-fg-muted)',
+          letterSpacing: '0.06em',
+        }}
+      >
+        {label}
+      </Label>
+      {children}
+    </div>
+  );
+}
+
+function OptionCheck({
+  id,
+  label,
+  checked,
+  onChange,
+  note,
+}: {
+  id: string;
+  label: string;
+  checked: boolean;
+  onChange: (v: boolean) => void;
+  note?: string;
+}) {
+  return (
+    <label
+      htmlFor={id}
+      className="flex items-center gap-2.5 py-1.5 px-1 cursor-pointer rounded"
+    >
+      <Checkbox
+        id={id}
+        checked={checked}
+        onChange={(e) => onChange(e.target.checked)}
+      />
+      <span className="text-[12.5px]" style={{ color: checked ? 'var(--ax-fg)' : 'var(--ax-fg-muted)' }}>
+        {label}
+        {note && (
+          <span className="ml-1.5 text-[11px]" style={{ color: 'var(--ax-fg-subtle)' }}>
+            ({note})
+          </span>
+        )}
+      </span>
+    </label>
+  );
+}

--- a/apps/frontend/src/components/upload/BatchMetadataForm.tsx
+++ b/apps/frontend/src/components/upload/BatchMetadataForm.tsx
@@ -63,16 +63,22 @@ export function BatchMetadataForm({ sessionId, detected, onCommitted }: BatchMet
   }
 
   async function handleSubmit() {
+    // collectionId and newCollectionName are mutually exclusive: if an existing
+    // collection is selected, don't also send newCollectionName.
+    const hasExistingCollection = !!form.collectionId && form.collectionId !== '__new__';
     const batchMetadata: BatchUploadMetadata = {
-      ...(form.collectionId && form.collectionId !== '__new__' ? { collectionId: form.collectionId } : {}),
-      ...(form.newCollectionName.trim() ? { newCollectionName: form.newCollectionName.trim() } : {}),
+      ...(hasExistingCollection ? { collectionId: form.collectionId } : {}),
+      ...(!hasExistingCollection && form.newCollectionName.trim()
+        ? { newCollectionName: form.newCollectionName.trim() }
+        : {}),
       ...(form.artist.trim() ? { artist: form.artist.trim() } : {}),
       ...(form.tags.length > 0 ? { tags: form.tags } : {}),
       options: {
         markPreSupported: form.markPreSupported,
         autoThumbnails: form.autoThumbnails,
         markNsfw: form.markNsfw,
-        skipDuplicatesByHash: form.skipDuplicatesByHash,
+        // skipDuplicatesByHash is sent as false — dedup by hash is not yet implemented.
+        skipDuplicatesByHash: false,
       },
     };
 
@@ -224,8 +230,10 @@ export function BatchMetadataForm({ sessionId, detected, onCommitted }: BatchMet
           <OptionCheck
             id="skip-dupes"
             label="Skip duplicates (by hash)"
-            checked={form.skipDuplicatesByHash}
-            onChange={(v) => setForm((f) => ({ ...f, skipDuplicatesByHash: v }))}
+            checked={false}
+            onChange={() => {}}
+            disabled
+            note="coming soon"
           />
         </div>
       </FormSection>
@@ -292,24 +300,27 @@ function OptionCheck({
   checked,
   onChange,
   note,
+  disabled,
 }: {
   id: string;
   label: string;
   checked: boolean;
   onChange: (v: boolean) => void;
   note?: string;
+  disabled?: boolean;
 }) {
   return (
     <label
       htmlFor={id}
-      className="flex items-center gap-2.5 py-1.5 px-1 cursor-pointer rounded"
+      className={`flex items-center gap-2.5 py-1.5 px-1 rounded ${disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
     >
       <Checkbox
         id={id}
         checked={checked}
-        onChange={(e) => onChange(e.target.checked)}
+        onChange={(e) => !disabled && onChange(e.target.checked)}
+        disabled={disabled}
       />
-      <span className="text-[12.5px]" style={{ color: checked ? 'var(--ax-fg)' : 'var(--ax-fg-muted)' }}>
+      <span className="text-[12.5px]" style={{ color: checked && !disabled ? 'var(--ax-fg)' : 'var(--ax-fg-muted)' }}>
         {label}
         {note && (
           <span className="ml-1.5 text-[11px]" style={{ color: 'var(--ax-fg-subtle)' }}>

--- a/apps/frontend/src/components/upload/DropZone.tsx
+++ b/apps/frontend/src/components/upload/DropZone.tsx
@@ -1,55 +1,76 @@
 import { useCallback, useRef, useState } from 'react';
-import { UploadCloud, FileArchive, X } from 'lucide-react';
+import { UploadCloud, FolderOpen } from 'lucide-react';
 import { SUPPORTED_ARCHIVE_EXTENSIONS } from '@alexandria/shared';
-import { uploadModel } from '../../api/models';
+import { useStartScan } from '../../hooks/use-import-sessions';
 import { formatFileSize } from '../../lib/format';
 import { cn } from '../../lib/utils';
-import { Button } from '../ui/button';
-import { UploadProgress } from './UploadProgress';
 
-type UploadState =
-  | { phase: 'idle' }
-  | { phase: 'selected'; file: File }
-  | { phase: 'uploading'; file: File; pct: number }
-  | { phase: 'processing'; file: File; modelId: string }
-  | { phase: 'error'; file: File; message: string };
+interface FileUploadState {
+  file: File;
+  pct: number;
+  error: string | null;
+}
 
-export function DropZone() {
-  const [state, setState] = useState<UploadState>({ phase: 'idle' });
+interface DropZoneProps {
+  /** When true, render the compact "drop more" banner instead of the full drop zone */
+  compact?: boolean;
+  onBrowseFolder?: () => void;
+}
+
+export function DropZone({ compact = false, onBrowseFolder }: DropZoneProps) {
   const [isDragging, setIsDragging] = useState(false);
+  const [uploading, setUploading] = useState<FileUploadState[]>([]);
   const inputRef = useRef<HTMLInputElement>(null);
+  const startScan = useStartScan();
 
-  const selectFile = useCallback((file: File) => {
+  const isValidArchive = (file: File) => {
     const lower = file.name.toLowerCase();
-    if (!SUPPORTED_ARCHIVE_EXTENSIONS.some((ext) => lower.endsWith(ext))) {
-      setState({ phase: 'error', file, message: 'Only .zip, .rar, .7z, and .tar.gz archives are supported.' });
-      return;
-    }
-    setState({ phase: 'selected', file });
-  }, []);
+    return SUPPORTED_ARCHIVE_EXTENSIONS.some((ext) => lower.endsWith(ext));
+  };
 
-  const startUpload = useCallback(async (file: File) => {
-    setState({ phase: 'uploading', file, pct: 0 });
-    try {
-      const { modelId } = await uploadModel(file, (pct) => {
-        setState({ phase: 'uploading', file, pct });
-      });
-      setState({ phase: 'processing', file, modelId });
-    } catch (err: unknown) {
-      const message =
-        err instanceof Error ? err.message : 'Upload failed. Please try again.';
-      setState({ phase: 'error', file, message });
-    }
-  }, []);
+  const enqueueFile = useCallback(
+    (file: File) => {
+      if (!isValidArchive(file)) return;
+
+      const entry: FileUploadState = { file, pct: 0, error: null };
+      setUploading((prev) => [...prev, entry]);
+
+      startScan.mutate(
+        {
+          file,
+          onProgress: (pct) => {
+            setUploading((prev) =>
+              prev.map((e) => (e.file === file ? { ...e, pct } : e))
+            );
+          },
+        },
+        {
+          onError: (err) => {
+            const msg = err instanceof Error ? err.message : 'Upload failed';
+            setUploading((prev) =>
+              prev.map((e) =>
+                e.file === file ? { ...e, error: msg } : e
+              )
+            );
+          },
+          onSuccess: () => {
+            // Remove from local uploading list once session exists in the queue
+            setUploading((prev) => prev.filter((e) => e.file !== file));
+          },
+        }
+      );
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [startScan]
+  );
 
   const handleDrop = useCallback(
     (e: React.DragEvent) => {
       e.preventDefault();
       setIsDragging(false);
-      const file = e.dataTransfer.files[0];
-      if (file) selectFile(file);
+      Array.from(e.dataTransfer.files).forEach(enqueueFile);
     },
-    [selectFile]
+    [enqueueFile]
   );
 
   const handleDragOver = (e: React.DragEvent) => {
@@ -60,53 +81,68 @@ export function DropZone() {
   const handleDragLeave = () => setIsDragging(false);
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (file) selectFile(file);
-    // reset so re-selecting the same file triggers onChange
+    Array.from(e.target.files ?? []).forEach(enqueueFile);
     e.target.value = '';
   };
 
-  const reset = () => {
-    setState({ phase: 'idle' });
-  };
-
-  // Idle/drop zone
-  if (state.phase === 'idle') {
+  if (compact) {
     return (
       <div
         onDrop={handleDrop}
         onDragOver={handleDragOver}
         onDragLeave={handleDragLeave}
-        onClick={() => inputRef.current?.click()}
         className={cn(
-          'flex flex-col items-center justify-center gap-4 rounded-xl border-2 border-dashed p-16 cursor-pointer transition-colors',
-          isDragging
-            ? 'border-primary bg-primary/5'
-            : 'border-border bg-muted/30 hover:border-primary/60 hover:bg-muted/50'
+          'flex items-center gap-3.5 rounded-xl p-3.5 mx-7 mt-4 transition-colors',
+          isDragging && 'ring-2 ring-[var(--ax-amber)]'
         )}
-        role="button"
-        tabIndex={0}
-        aria-label="Upload archive file"
-        onKeyDown={(e) => {
-          if (e.key === 'Enter' || e.key === ' ') inputRef.current?.click();
+        style={{
+          background: 'var(--ax-bg-elev)',
+          border: '1px dashed var(--ax-border-strong)',
         }}
       >
-        <UploadCloud
-          className={cn(
-            'h-12 w-12 transition-colors',
-            isDragging ? 'text-primary' : 'text-muted-foreground/60'
-          )}
-        />
-        <div className="text-center space-y-1">
-          <p className="text-base font-medium text-foreground">
-            Drag &amp; drop an archive here, or click to browse
+        <div
+          className="flex items-center justify-center rounded-xl flex-shrink-0"
+          style={{
+            width: 38,
+            height: 38,
+            background: 'var(--ax-amber-tint)',
+            color: 'var(--ax-amber-tint-fg)',
+          }}
+        >
+          <UploadCloud className="h-[18px] w-[18px]" />
+        </div>
+        <div className="flex-1 min-w-0">
+          <p className="text-[13px] font-semibold" style={{ color: 'var(--ax-fg)' }}>
+            Drop more archives anywhere
           </p>
-          <p className="text-sm text-muted-foreground">Supports .zip, .rar, .7z, and .tar.gz archives</p>
+          <p className="text-[12px]" style={{ color: 'var(--ax-fg-muted)' }}>
+            .zip, .rar, .7z, .tar.gz — multiple files OK
+          </p>
+        </div>
+        <div className="flex gap-2 flex-shrink-0">
+          <button
+            type="button"
+            onClick={() => inputRef.current?.click()}
+            className="ax-chip hover:opacity-80 transition-opacity cursor-pointer"
+          >
+            Browse files
+          </button>
+          {onBrowseFolder && (
+            <button
+              type="button"
+              onClick={onBrowseFolder}
+              className="ax-chip hover:opacity-80 transition-opacity cursor-pointer flex items-center gap-1"
+            >
+              <FolderOpen className="w-3 h-3" />
+              Server folder
+            </button>
+          )}
         </div>
         <input
           ref={inputRef}
           type="file"
-          accept=".zip,.rar,.7z,.tar.gz,.tgz,application/zip,application/x-rar-compressed,application/x-7z-compressed,application/x-tar"
+          multiple
+          accept=".zip,.rar,.7z,.tar.gz,.tgz"
           className="sr-only"
           onChange={handleInputChange}
           tabIndex={-1}
@@ -115,93 +151,107 @@ export function DropZone() {
     );
   }
 
-  // File selected — confirm before upload
-  if (state.phase === 'selected') {
-    return (
-      <div className="rounded-xl border bg-card p-6 space-y-4">
-        <div className="flex items-start gap-3">
-          <FileArchive className="h-8 w-8 text-primary shrink-0 mt-0.5" />
-          <div className="flex-1 min-w-0">
-            <p className="text-sm font-medium truncate">{state.file.name}</p>
-            <p className="text-xs text-muted-foreground">{formatFileSize(state.file.size)}</p>
-          </div>
-          <button
-            onClick={reset}
-            className="text-muted-foreground hover:text-foreground transition-colors"
-            aria-label="Remove selected file"
-          >
-            <X className="h-4 w-4" />
-          </button>
+  // Full drop zone (when no sessions yet)
+  return (
+    <div className="space-y-3">
+      <div
+        onDrop={handleDrop}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onClick={() => inputRef.current?.click()}
+        className={cn(
+          'flex flex-col items-center justify-center gap-4 rounded-xl border-2 border-dashed p-16 cursor-pointer transition-colors',
+          isDragging
+            ? 'border-[var(--ax-amber)] bg-[var(--ax-amber-tint)]'
+            : 'border-[var(--ax-border-strong)] hover:border-[var(--ax-amber)] hover:bg-[var(--ax-bg-elev)]'
+        )}
+        role="button"
+        tabIndex={0}
+        aria-label="Upload archive files"
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') inputRef.current?.click();
+        }}
+      >
+        <UploadCloud
+          className="h-12 w-12 transition-colors"
+          style={{ color: isDragging ? 'var(--ax-amber)' : 'var(--ax-fg-muted)' }}
+        />
+        <div className="text-center space-y-1">
+          <p className="text-base font-semibold" style={{ color: 'var(--ax-fg)' }}>
+            Drag &amp; drop archives here, or click to browse
+          </p>
+          <p className="text-sm" style={{ color: 'var(--ax-fg-muted)' }}>
+            Supports .zip, .rar, .7z, .tar.gz — drop multiple files at once
+          </p>
         </div>
-        <div className="flex gap-2">
-          <Button onClick={() => startUpload(state.file)}>Upload</Button>
-          <Button variant="outline" onClick={reset}>
-            Cancel
-          </Button>
-        </div>
+        <input
+          ref={inputRef}
+          type="file"
+          multiple
+          accept=".zip,.rar,.7z,.tar.gz,.tgz,application/zip,application/x-rar-compressed,application/x-7z-compressed,application/x-tar"
+          className="sr-only"
+          onChange={handleInputChange}
+          tabIndex={-1}
+        />
       </div>
-    );
-  }
 
-  // Uploading
-  if (state.phase === 'uploading') {
-    return (
-      <div className="rounded-xl border bg-card p-6 space-y-4">
-        <div className="flex items-start gap-3">
-          <FileArchive className="h-8 w-8 text-primary shrink-0 mt-0.5" />
-          <div className="flex-1 min-w-0">
-            <p className="text-sm font-medium truncate">{state.file.name}</p>
-            <p className="text-xs text-muted-foreground">{formatFileSize(state.file.size)}</p>
-          </div>
+      {/* In-flight upload progress rows */}
+      {uploading.length > 0 && (
+        <div className="space-y-2">
+          {uploading.map((entry, i) => (
+            <UploadRow key={i} entry={entry} />
+          ))}
         </div>
-        <div className="space-y-1.5">
-          <div className="flex items-center justify-between text-sm">
-            <span className="text-muted-foreground">Uploading...</span>
-            <span className="tabular-nums text-xs text-muted-foreground">{state.pct}%</span>
-          </div>
-          <div className="h-2 w-full rounded-full bg-muted overflow-hidden">
+      )}
+    </div>
+  );
+}
+
+function UploadRow({ entry }: { entry: FileUploadState }) {
+  return (
+    <div
+      className="rounded-lg px-4 py-3 space-y-2"
+      style={{
+        background: 'var(--ax-bg-elev)',
+        border: entry.error
+          ? '1px solid var(--ax-danger)'
+          : '1px solid var(--ax-border)',
+      }}
+    >
+      <div className="flex items-center justify-between gap-2">
+        <span
+          className="ax-code text-[12px] truncate"
+          style={{ color: 'var(--ax-fg)' }}
+        >
+          {entry.file.name}
+        </span>
+        <span className="ax-mono text-[11px] flex-shrink-0" style={{ color: 'var(--ax-fg-muted)' }}>
+          {formatFileSize(entry.file.size)}
+        </span>
+      </div>
+      {entry.error ? (
+        <p className="text-[11.5px]" style={{ color: 'var(--ax-danger)' }}>
+          {entry.error}
+        </p>
+      ) : (
+        <div className="flex items-center gap-2">
+          <div
+            className="flex-1 h-1.5 rounded-full overflow-hidden"
+            style={{ background: 'var(--ax-bg-sunk)' }}
+          >
             <div
-              className="h-full rounded-full bg-primary transition-all duration-200"
-              style={{ width: `${state.pct}%` }}
+              className="h-full rounded-full transition-all duration-200"
+              style={{
+                width: `${entry.pct}%`,
+                background: 'var(--ax-amber)',
+              }}
             />
           </div>
+          <span className="ax-mono text-[11px] flex-shrink-0" style={{ color: 'var(--ax-fg-muted)' }}>
+            {entry.pct}%
+          </span>
         </div>
-      </div>
-    );
-  }
-
-  // Processing (upload done, job running)
-  if (state.phase === 'processing') {
-    return (
-      <div className="rounded-xl border bg-card p-6 space-y-4">
-        <div className="flex items-start gap-3">
-          <FileArchive className="h-8 w-8 text-primary shrink-0 mt-0.5" />
-          <div className="flex-1 min-w-0">
-            <p className="text-sm font-medium truncate">{state.file.name}</p>
-            <p className="text-xs text-muted-foreground">Upload complete — processing job running</p>
-          </div>
-        </div>
-        <UploadProgress modelId={state.modelId} />
-        <Button variant="outline" size="sm" onClick={reset}>
-          Upload another
-        </Button>
-      </div>
-    );
-  }
-
-  // Error
-  return (
-    <div className="rounded-xl border border-destructive/40 bg-destructive/5 p-6 space-y-3">
-      <div className="flex items-start gap-3">
-        <FileArchive className="h-8 w-8 text-destructive/60 shrink-0 mt-0.5" />
-        <div className="flex-1 min-w-0">
-          <p className="text-sm font-medium truncate">{state.file.name}</p>
-          <p className="text-sm text-destructive mt-1">{state.message}</p>
-        </div>
-      </div>
-      <Button variant="outline" size="sm" onClick={reset}>
-        Try again
-      </Button>
+      )}
     </div>
   );
 }

--- a/apps/frontend/src/components/upload/FolderImport.tsx
+++ b/apps/frontend/src/components/upload/FolderImport.tsx
@@ -168,8 +168,14 @@ export function FolderImport() {
       )}
 
       {importState.phase === 'submitted' && (
-        <div className="rounded-lg border border-emerald-500/30 bg-emerald-50 dark:bg-emerald-950/20 px-4 py-3 space-y-2">
-          <p className="text-sm font-medium text-emerald-700 dark:text-emerald-400">
+        <div
+          className="rounded-lg px-4 py-3 space-y-2"
+          style={{
+            border: '1px solid var(--ax-success)',
+            background: 'color-mix(in srgb, var(--ax-success) 8%, transparent)',
+          }}
+        >
+          <p className="text-sm font-medium" style={{ color: 'var(--ax-success)' }}>
             Import job queued successfully.
           </p>
           <div className="flex gap-3">

--- a/apps/frontend/src/components/upload/RecentUploads.tsx
+++ b/apps/frontend/src/components/upload/RecentUploads.tsx
@@ -8,7 +8,7 @@ import type { ModelCard } from '@alexandria/shared';
 function StatusBadge({ status }: { status: ModelCard['status'] }) {
   if (status === 'processing') {
     return (
-      <span className="flex items-center gap-1 text-xs text-amber-600 dark:text-amber-500">
+      <span className="flex items-center gap-1 text-xs" style={{ color: 'var(--ax-warning)' }}>
         <Loader2 className="h-3 w-3 animate-spin" />
         Processing
       </span>
@@ -16,14 +16,14 @@ function StatusBadge({ status }: { status: ModelCard['status'] }) {
   }
   if (status === 'error') {
     return (
-      <span className="flex items-center gap-1 text-xs text-destructive">
+      <span className="flex items-center gap-1 text-xs" style={{ color: 'var(--ax-danger)' }}>
         <AlertCircle className="h-3 w-3" />
         Error
       </span>
     );
   }
   return (
-    <span className="flex items-center gap-1 text-xs text-emerald-600 dark:text-emerald-500">
+    <span className="flex items-center gap-1 text-xs" style={{ color: 'var(--ax-success)' }}>
       <CheckCircle2 className="h-3 w-3" />
       Ready
     </span>

--- a/apps/frontend/src/components/upload/ReviewPane.tsx
+++ b/apps/frontend/src/components/upload/ReviewPane.tsx
@@ -1,0 +1,224 @@
+import { Loader2, AlertCircle, Folder, FileCode2, File, Package } from 'lucide-react';
+import type { ImportSession, DetectedFolderNode } from '@alexandria/shared';
+import { BatchMetadataForm } from './BatchMetadataForm';
+import { UploadProgress } from './UploadProgress';
+import { Button } from '../ui/button';
+import { formatFileSize } from '../../lib/format';
+
+interface ReviewPaneProps {
+  session: ImportSession;
+  onCommitted: (modelId: string) => void;
+  onDiscard: () => void;
+  onRetry: () => void;
+}
+
+export function ReviewPane({ session, onCommitted, onDiscard, onRetry }: ReviewPaneProps) {
+  if (session.status === 'scanning') {
+    return (
+      <div className="flex flex-col items-center justify-center py-20 gap-5">
+        <div
+          className="flex items-center justify-center rounded-2xl"
+          style={{
+            width: 64,
+            height: 64,
+            background: 'var(--ax-amber-tint)',
+            color: 'var(--ax-amber-tint-fg)',
+          }}
+        >
+          <Loader2 className="h-7 w-7 animate-spin" />
+        </div>
+        <div className="text-center">
+          <h2
+            className="text-xl font-bold"
+            style={{ color: 'var(--ax-fg)' }}
+          >
+            Scanning archive…
+          </h2>
+          <p className="mt-1.5 text-[13px]" style={{ color: 'var(--ax-fg-muted)' }}>
+            Extracting, detecting folder structure and metadata
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  if (session.status === 'error') {
+    return (
+      <div
+        className="flex gap-4 rounded-xl p-8"
+        style={{
+          background: 'var(--ax-bg-elev)',
+          border: '1px solid var(--ax-danger)',
+        }}
+      >
+        <div
+          className="flex items-center justify-center rounded-xl flex-shrink-0"
+          style={{
+            width: 48,
+            height: 48,
+            background: 'color-mix(in srgb, var(--ax-danger) 12%, transparent)',
+            color: 'var(--ax-danger)',
+          }}
+        >
+          <AlertCircle className="h-6 w-6" />
+        </div>
+        <div className="flex-1">
+          <h2 className="text-[18px] font-semibold" style={{ color: 'var(--ax-fg)' }}>
+            Couldn't process this archive
+          </h2>
+          <p className="mt-1.5 mb-4 text-[13px]" style={{ color: 'var(--ax-fg-muted)' }}>
+            {session.error ?? 'An unknown error occurred during scanning.'}
+          </p>
+          <div className="flex gap-2">
+            <Button variant="outline" size="sm" onClick={onRetry}>
+              Retry upload
+            </Button>
+            <Button variant="outline" size="sm" onClick={onDiscard}>
+              Discard
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (session.status === 'committing' || session.status === 'committed') {
+    const modelId = session.modelId;
+    return (
+      <div className="flex flex-col items-center justify-center py-20 gap-5">
+        <div
+          className="flex items-center justify-center rounded-2xl"
+          style={{
+            width: 64,
+            height: 64,
+            background: 'var(--ax-teal-tint)',
+            color: 'var(--ax-teal-tint-fg)',
+          }}
+        >
+          <Package className="h-7 w-7" />
+        </div>
+        <div className="text-center max-w-sm">
+          <h2 className="text-xl font-bold" style={{ color: 'var(--ax-fg)' }}>
+            {session.status === 'committing' ? 'Importing…' : 'Imported!'}
+          </h2>
+          <p className="mt-1.5 text-[13px]" style={{ color: 'var(--ax-fg-muted)' }}>
+            {session.status === 'committing'
+              ? 'Your archive is being processed. This may take a moment.'
+              : 'Archive committed. Processing the model now.'}
+          </p>
+        </div>
+        {modelId && (
+          <div className="w-full max-w-sm">
+            <UploadProgress modelId={modelId} />
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  // ready_for_review
+  const { detected } = session;
+  if (!detected) {
+    return (
+      <div className="py-12 text-center text-[13px]" style={{ color: 'var(--ax-fg-muted)' }}>
+        Detected metadata unavailable. Try discarding and re-uploading.
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="grid gap-6"
+      style={{ gridTemplateColumns: '1.4fr 1fr' }}
+    >
+      {/* Left: folder structure + counts */}
+      <div>
+        <div className="flex items-baseline justify-between mb-2.5">
+          <h2 className="text-[16px] font-bold" style={{ color: 'var(--ax-fg)' }}>
+            {detected.modelCount} model{detected.modelCount !== 1 ? 's' : ''} detected
+          </h2>
+          <span className="ax-mono text-[12px]" style={{ color: 'var(--ax-fg-muted)' }}>
+            {detected.fileCount} files · {formatFileSize(detected.totalSizeBytes)}
+          </span>
+        </div>
+
+        <h3
+          className="text-[13px] font-semibold mb-2"
+          style={{ color: 'var(--ax-fg)' }}
+        >
+          Detected folder structure
+        </h3>
+        <div
+          className="ax-code rounded-xl p-3.5 text-[12px] leading-relaxed overflow-auto max-h-80"
+          style={{
+            background: 'var(--ax-bg-elev)',
+            border: '1px solid var(--ax-border)',
+            lineHeight: '1.7',
+          }}
+        >
+          {detected.folderStructure.length === 0 ? (
+            <span style={{ color: 'var(--ax-fg-muted)' }}>No folder structure detected</span>
+          ) : (
+            <FolderTree nodes={detected.folderStructure} depth={0} maxDepth={4} />
+          )}
+        </div>
+      </div>
+
+      {/* Right: batch metadata form */}
+      <BatchMetadataForm
+        sessionId={session.id}
+        detected={detected}
+        onCommitted={onCommitted}
+      />
+    </div>
+  );
+}
+
+function FolderTree({
+  nodes,
+  depth,
+  maxDepth,
+}: {
+  nodes: DetectedFolderNode[];
+  depth: number;
+  maxDepth: number;
+}) {
+  if (depth > maxDepth) {
+    return (
+      <div
+        style={{ paddingLeft: depth * 16, color: 'var(--ax-fg-muted)' }}
+        className="flex items-center gap-1.5"
+      >
+        <span>…</span>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      {nodes.map((node, i) => (
+        <div key={i}>
+          <div
+            style={{
+              paddingLeft: depth * 16,
+              color: node.type === 'folder' ? 'var(--ax-fg)' : 'var(--ax-fg-muted)',
+            }}
+            className="flex items-center gap-1.5"
+          >
+            {node.type === 'folder' ? (
+              <Folder className="w-3 h-3 flex-shrink-0" style={{ color: 'var(--ax-amber)' }} />
+            ) : node.fileType === 'stl' ? (
+              <FileCode2 className="w-3 h-3 flex-shrink-0" />
+            ) : (
+              <File className="w-3 h-3 flex-shrink-0" />
+            )}
+            <span>{node.name}</span>
+          </div>
+          {node.children && node.children.length > 0 && (
+            <FolderTree nodes={node.children} depth={depth + 1} maxDepth={maxDepth} />
+          )}
+        </div>
+      ))}
+    </>
+  );
+}

--- a/apps/frontend/src/components/upload/UploadProgress.tsx
+++ b/apps/frontend/src/components/upload/UploadProgress.tsx
@@ -75,7 +75,7 @@ export function UploadProgress({ modelId }: UploadProgressProps) {
   if (status.status === 'ready') {
     return (
       <div className="space-y-2">
-        <div className="flex items-center gap-2 text-sm text-emerald-600 dark:text-emerald-500">
+        <div className="flex items-center gap-2 text-sm" style={{ color: 'var(--ax-success)' }}>
           <CheckCircle2 className="h-4 w-4 shrink-0" />
           <span>Model is ready.</span>
         </div>

--- a/apps/frontend/src/components/upload/UploadQueue.tsx
+++ b/apps/frontend/src/components/upload/UploadQueue.tsx
@@ -1,0 +1,234 @@
+import { Loader2, CheckCircle2, AlertCircle, Archive, BookOpen } from 'lucide-react';
+import type { ImportSession } from '@alexandria/shared';
+import { formatFileSize } from '../../lib/format';
+import { cn } from '../../lib/utils';
+
+interface UploadQueueProps {
+  sessions: ImportSession[];
+  activeId: string | null;
+  onSelect: (id: string) => void;
+}
+
+function StatusIcon({ status }: { status: ImportSession['status'] }) {
+  const base = 'flex items-center justify-center rounded-md flex-shrink-0';
+  const size = 'w-[26px] h-[26px]';
+
+  if (status === 'error') {
+    return (
+      <span
+        className={cn(base, size)}
+        style={{ background: 'var(--ax-danger)', color: 'white' }}
+      >
+        <AlertCircle className="w-3 h-3" />
+      </span>
+    );
+  }
+  if (status === 'scanning') {
+    return (
+      <span
+        className={cn(base, size)}
+        style={{ background: 'var(--ax-warning)', color: 'white' }}
+      >
+        <Loader2 className="w-3 h-3 animate-spin" />
+      </span>
+    );
+  }
+  if (status === 'ready_for_review') {
+    return (
+      <span
+        className={cn(base, size)}
+        style={{ background: 'var(--ax-teal)', color: 'var(--ax-teal-fg)' }}
+      >
+        <Archive className="w-3 h-3" />
+      </span>
+    );
+  }
+  if (status === 'committing') {
+    return (
+      <span
+        className={cn(base, size)}
+        style={{ background: 'var(--ax-warning)', color: 'white' }}
+      >
+        <Loader2 className="w-3 h-3 animate-spin" />
+      </span>
+    );
+  }
+  // committed
+  return (
+    <span
+      className={cn(base, size)}
+      style={{ background: 'var(--ax-success)', color: 'white' }}
+    >
+      <CheckCircle2 className="w-3 h-3" />
+    </span>
+  );
+}
+
+function statusLabel(status: ImportSession['status']): string {
+  switch (status) {
+    case 'scanning': return 'Scanning…';
+    case 'ready_for_review': return 'Ready to review';
+    case 'committing': return 'Committing…';
+    case 'committed': return 'Committed';
+    case 'error': return 'Error';
+  }
+}
+
+export function UploadQueue({ sessions, activeId, onSelect }: UploadQueueProps) {
+  const totalSize = sessions.reduce((acc, s) => {
+    return acc + (s.detected?.totalSizeBytes ?? 0);
+  }, 0);
+  const errorCount = sessions.filter((s) => s.status === 'error').length;
+  const queuedCount = sessions.filter(
+    (s) => s.status === 'scanning' || s.status === 'ready_for_review'
+  ).length;
+
+  return (
+    <aside
+      className="flex flex-col h-screen flex-shrink-0"
+      style={{
+        width: 300,
+        background: 'var(--ax-rail)',
+        color: 'var(--ax-rail-fg)',
+        borderRight: '1px solid var(--ax-rail-border)',
+      }}
+    >
+      {/* Header */}
+      <div
+        className="flex-shrink-0 px-4 py-3.5"
+        style={{ borderBottom: '1px solid var(--ax-rail-border)' }}
+      >
+        <div className="flex items-center gap-2">
+          <BookOpen className="h-4 w-4 flex-shrink-0" style={{ color: 'var(--ax-amber)' }} />
+          <span
+            className="font-semibold text-sm truncate"
+            style={{ color: 'var(--ax-rail-fg)' }}
+          >
+            Alexandria
+          </span>
+          <span
+            className="ax-mono ml-auto text-[11px]"
+            style={{ color: 'var(--ax-rail-fg-muted)' }}
+          >
+            upload
+          </span>
+        </div>
+      </div>
+
+      {/* Queue label */}
+      <div className="flex items-center justify-between px-3 pt-3.5 pb-2">
+        <span
+          className="text-[11px] font-semibold uppercase tracking-wider"
+          style={{ color: 'var(--ax-rail-fg-muted)', letterSpacing: '0.06em' }}
+        >
+          Upload queue
+        </span>
+        <span className="ax-mono text-[11px]" style={{ color: 'var(--ax-rail-fg-muted)' }}>
+          {sessions.length}
+        </span>
+      </div>
+
+      {/* Session list */}
+      <div className="ax-scroll flex-1 overflow-y-auto px-2 pb-3">
+        {sessions.length === 0 && (
+          <p
+            className="text-[12px] text-center py-8"
+            style={{ color: 'var(--ax-rail-fg-muted)' }}
+          >
+            No uploads yet. Drop an archive to start.
+          </p>
+        )}
+        {sessions.map((session) => {
+          const active = session.id === activeId;
+          return (
+            <button
+              key={session.id}
+              onClick={() => onSelect(session.id)}
+              className="flex flex-col gap-1.5 w-full text-left px-3 py-2.5 rounded-lg mt-1 transition-colors"
+              style={{
+                background: active ? 'var(--ax-rail-elev)' : 'transparent',
+                border: `1px solid ${active ? 'var(--ax-rail-border)' : 'transparent'}`,
+                color: 'inherit',
+                fontFamily: 'inherit',
+                cursor: 'pointer',
+              }}
+            >
+              <div className="flex items-center gap-2">
+                <StatusIcon status={session.status} />
+                <div className="flex-1 min-w-0">
+                  <div
+                    className="ax-code text-[12px] font-medium truncate"
+                    style={{ color: 'var(--ax-rail-fg)' }}
+                  >
+                    {session.originalFilename}
+                  </div>
+                  <div
+                    className="ax-mono text-[11px]"
+                    style={{ color: 'var(--ax-rail-fg-muted)' }}
+                  >
+                    {session.detected
+                      ? `${formatFileSize(session.detected.totalSizeBytes)} · ${session.detected.fileCount} files`
+                      : statusLabel(session.status)}
+                  </div>
+                </div>
+              </div>
+              {session.status === 'error' && session.error && (
+                <div className="text-[10.5px] pl-[34px]" style={{ color: '#fca5a5' }}>
+                  {session.error}
+                </div>
+              )}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Stats footer */}
+      <div
+        className="flex-shrink-0 grid grid-cols-2 gap-3 px-4 py-3"
+        style={{ borderTop: '1px solid var(--ax-rail-border)' }}
+      >
+        <StatCell label="Queued" value={String(queuedCount)} />
+        <StatCell label="Total size" value={totalSize > 0 ? formatFileSize(totalSize) : '—'} />
+        <StatCell
+          label="Errors"
+          value={String(errorCount)}
+          danger={errorCount > 0}
+        />
+        <StatCell label="Done" value={String(sessions.filter((s) => s.status === 'committed').length)} />
+      </div>
+    </aside>
+  );
+}
+
+function StatCell({
+  label,
+  value,
+  danger,
+}: {
+  label: string;
+  value: string;
+  danger?: boolean;
+}) {
+  return (
+    <div>
+      <div
+        className="ax-mono text-[17px] font-bold"
+        style={{
+          color: danger ? '#fca5a5' : 'var(--ax-rail-fg)',
+          letterSpacing: '-0.01em',
+        }}
+      >
+        {value}
+      </div>
+      <div
+        className="text-[10px] font-semibold uppercase mt-0.5"
+        style={{
+          color: 'var(--ax-rail-fg-muted)',
+          letterSpacing: '0.06em',
+        }}
+      >
+        {label}
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/hooks/use-command-palette.tsx
+++ b/apps/frontend/src/hooks/use-command-palette.tsx
@@ -1,0 +1,62 @@
+import React, { createContext, useContext, useEffect, useRef, useState } from 'react';
+
+interface CommandPaletteContextValue {
+  isOpen: boolean;
+  open: () => void;
+  close: () => void;
+  toggle: () => void;
+}
+
+const CommandPaletteContext = createContext<CommandPaletteContextValue | null>(null);
+
+export function CommandPaletteProvider({ children }: { children: React.ReactNode }) {
+  const [isOpen, setIsOpen] = useState(false);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  function open() {
+    previousFocusRef.current = document.activeElement as HTMLElement;
+    setIsOpen(true);
+  }
+
+  function close() {
+    setIsOpen(false);
+    // Restore focus to the previously-focused element
+    requestAnimationFrame(() => {
+      previousFocusRef.current?.focus();
+    });
+  }
+
+  function toggle() {
+    if (isOpen) {
+      close();
+    } else {
+      open();
+    }
+  }
+
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+        e.preventDefault();
+        toggle();
+      }
+    }
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen]);
+
+  return (
+    <CommandPaletteContext.Provider value={{ isOpen, open, close, toggle }}>
+      {children}
+    </CommandPaletteContext.Provider>
+  );
+}
+
+export function useCommandPalette() {
+  const ctx = useContext(CommandPaletteContext);
+  if (!ctx) {
+    throw new Error('useCommandPalette must be used within a CommandPaletteProvider');
+  }
+  return ctx;
+}

--- a/apps/frontend/src/hooks/use-global-search.ts
+++ b/apps/frontend/src/hooks/use-global-search.ts
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+import type { GlobalSearchResult } from '@alexandria/shared';
+import { globalSearch } from '../api/search';
+
+export function useGlobalSearch(q: string, limit?: number) {
+  return useQuery<GlobalSearchResult>({
+    queryKey: ['search', q, limit],
+    queryFn: () => globalSearch({ q, limit }),
+    enabled: q.trim().length > 0,
+    staleTime: 30_000,
+  });
+}

--- a/apps/frontend/src/hooks/use-import-sessions.ts
+++ b/apps/frontend/src/hooks/use-import-sessions.ts
@@ -1,0 +1,104 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import type { BatchUploadMetadata, ImportSession } from '@alexandria/shared';
+import {
+  listImportSessions,
+  getImportSession,
+  commitImportSession,
+  discardImportSession,
+  scanUpload,
+} from '../api/models';
+
+const TERMINAL_STATUSES = new Set(['committed', 'error']);
+
+function isNonTerminal(session: ImportSession): boolean {
+  return !TERMINAL_STATUSES.has(session.status);
+}
+
+/**
+ * List all import sessions, polling every 2 s while any session is non-terminal.
+ */
+export function useImportSessions() {
+  return useQuery({
+    queryKey: ['import-sessions'],
+    queryFn: listImportSessions,
+    refetchInterval: (query) => {
+      const data = query.state.data;
+      if (!data) return 2000;
+      return data.some(isNonTerminal) ? 2000 : false;
+    },
+    staleTime: 0,
+  });
+}
+
+/**
+ * Single session, polling every 2 s while non-terminal.
+ */
+export function useImportSession(id: string | null) {
+  return useQuery({
+    queryKey: ['import-session', id],
+    queryFn: () => getImportSession(id!),
+    enabled: id !== null,
+    refetchInterval: (query) => {
+      const data = query.state.data;
+      if (!data) return 2000;
+      return isNonTerminal(data) ? 2000 : false;
+    },
+    staleTime: 0,
+  });
+}
+
+/**
+ * Upload a file, then invalidate the sessions list so the new session appears.
+ * Returns a mutation; call mutateAsync(file, { onProgress }) — progress is
+ * tracked via the onProgress arg passed to scanUpload.
+ */
+export function useStartScan() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      file,
+      onProgress,
+    }: {
+      file: File;
+      onProgress?: (pct: number) => void;
+    }) => scanUpload(file, onProgress),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['import-sessions'] });
+    },
+  });
+}
+
+/**
+ * Commit a ready_for_review session. Invalidates the session list and the
+ * individual session on success.
+ */
+export function useCommitSession() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      id,
+      batchMetadata,
+    }: {
+      id: string;
+      batchMetadata?: BatchUploadMetadata;
+    }) => commitImportSession(id, batchMetadata),
+    onSuccess: (_data, { id }) => {
+      queryClient.invalidateQueries({ queryKey: ['import-sessions'] });
+      queryClient.invalidateQueries({ queryKey: ['import-session', id] });
+    },
+  });
+}
+
+/**
+ * Discard (delete) a session. Removes it from the list immediately.
+ */
+export function useDiscardSession() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => discardImportSession(id),
+    onSuccess: (_data, id) => {
+      queryClient.invalidateQueries({ queryKey: ['import-sessions'] });
+      queryClient.removeQueries({ queryKey: ['import-session', id] });
+    },
+  });
+}

--- a/apps/frontend/src/pages/SearchPage.tsx
+++ b/apps/frontend/src/pages/SearchPage.tsx
@@ -1,0 +1,434 @@
+import { useRef, useState } from 'react';
+import { useSearchParams, useNavigate } from 'react-router-dom';
+import { Search, Zap, Box, Folder, User, Hash, SortAsc } from 'lucide-react';
+import { Loader2 } from 'lucide-react';
+import { useGlobalSearch } from '../hooks/use-global-search';
+import { ModelCard } from '../components/models/ModelCard';
+import { SearchSection } from '../components/search/SearchSection';
+import { CollectionResultRow } from '../components/search/CollectionResultRow';
+import { ArtistResultCard } from '../components/search/ArtistResultCard';
+import { TagResultPill } from '../components/search/TagResultPill';
+import { SearchRail } from '../components/search/SearchRail';
+
+type ResultTypeFilter = 'all' | 'models' | 'collections' | 'artists' | 'tags';
+
+const SEARCH_LIMIT = 6;
+
+// A small inline tooltip for the disabled pill
+function DisabledPill({ icon, label, tooltip }: { icon: React.ReactNode; label: string; tooltip: string }) {
+  const [showTip, setShowTip] = useState(false);
+
+  return (
+    <div style={{ position: 'relative', display: 'inline-flex' }}>
+      <button
+        type="button"
+        aria-disabled="true"
+        title={tooltip}
+        onMouseEnter={() => setShowTip(true)}
+        onMouseLeave={() => setShowTip(false)}
+        onFocus={() => setShowTip(true)}
+        onBlur={() => setShowTip(false)}
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 6,
+          padding: '5px 12px',
+          borderRadius: 999,
+          background: 'var(--ax-bg-elev)',
+          border: '1px solid var(--ax-border)',
+          color: 'var(--ax-fg-muted)',
+          fontSize: 12,
+          fontWeight: 500,
+          cursor: 'not-allowed',
+          opacity: 0.6,
+          fontFamily: 'inherit',
+        }}
+      >
+        {icon}
+        {label}
+      </button>
+      {showTip && (
+        <div
+          role="tooltip"
+          style={{
+            position: 'absolute',
+            bottom: 'calc(100% + 6px)',
+            left: '50%',
+            transform: 'translateX(-50%)',
+            whiteSpace: 'nowrap',
+            background: 'var(--ax-bg-sunk)',
+            border: '1px solid var(--ax-border)',
+            borderRadius: 6,
+            padding: '5px 10px',
+            fontSize: 11.5,
+            color: 'var(--ax-fg)',
+            boxShadow: '0 4px 12px rgba(0,0,0,0.3)',
+            zIndex: 100,
+            pointerEvents: 'none',
+          }}
+        >
+          {tooltip}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ResultPill({ count, label, icon }: { count: number; label: string; icon: React.ReactNode }) {
+  return (
+    <span
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 5,
+        padding: '3px 8px',
+        borderRadius: 5,
+        background: 'var(--ax-bg-sunk)',
+        color: 'var(--ax-fg-muted)',
+        fontSize: 11.5,
+      }}
+    >
+      {icon}
+      <span className="ax-mono" style={{ fontWeight: 600, color: 'var(--ax-fg)' }}>
+        {count}
+      </span>{' '}
+      {label}
+    </span>
+  );
+}
+
+export function SearchPage() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const q = searchParams.get('q') ?? '';
+  const refineRef = useRef<HTMLInputElement>(null);
+  const [refineValue, setRefineValue] = useState('');
+  const [activeType, setActiveType] = useState<ResultTypeFilter>('all');
+
+  const { data, isLoading, isError } = useGlobalSearch(q, SEARCH_LIMIT);
+
+  function handleRefineSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const val = refineValue.trim();
+    if (!val) return;
+    setSearchParams({ q: val });
+    setRefineValue('');
+    setActiveType('all');
+  }
+
+  const totalModels = data?.models.total ?? 0;
+  const totalCollections = data?.collections.length ?? 0;
+  const totalArtists = data?.artists.length ?? 0;
+  const totalTags = data?.tags.length ?? 0;
+  const grandTotal = totalModels + totalCollections + totalArtists + totalTags;
+
+  const showModels = activeType === 'all' || activeType === 'models';
+  const showCollections = activeType === 'all' || activeType === 'collections';
+  const showArtists = activeType === 'all' || activeType === 'artists';
+  const showTags = activeType === 'all' || activeType === 'tags';
+
+  return (
+    <div
+      className="flex h-full min-h-0"
+      style={{ background: 'var(--ax-bg)', color: 'var(--ax-fg)' }}
+    >
+      {/* Left search rail */}
+      <SearchRail result={data} activeType={activeType} onTypeChange={setActiveType} />
+
+      {/* Main content */}
+      <div className="flex flex-col flex-1 min-w-0 h-full">
+        {/* ── Top bar ─────────────────────────────────────────────────── */}
+        <div
+          className="flex-shrink-0 flex items-center gap-3 px-6 py-2.5"
+          style={{
+            borderBottom: '1px solid var(--ax-border)',
+            background: 'var(--ax-bg)',
+          }}
+        >
+          {/* Left: search context indicator */}
+          <div className="flex items-center gap-2.5 flex-1 min-w-0">
+            <Search size={16} style={{ color: 'var(--ax-fg-muted)', flexShrink: 0 }} />
+            <span style={{ fontSize: 15, fontWeight: 600, whiteSpace: 'nowrap' }}>
+              Search:{' '}
+              {q && (
+                <span
+                  style={{
+                    color: 'var(--ax-amber-tint-fg)',
+                    background: 'var(--ax-amber-tint)',
+                    padding: '2px 8px',
+                    borderRadius: 5,
+                  }}
+                >
+                  {q}
+                </span>
+              )}
+            </span>
+          </div>
+
+          {/* Center: refine search input */}
+          <form onSubmit={handleRefineSubmit} className="flex-shrink-0">
+            <label className="relative flex items-center">
+              <span className="sr-only">Refine search</span>
+              <Search
+                size={13}
+                className="absolute left-2.5 pointer-events-none"
+                style={{ color: 'var(--ax-fg-muted)' }}
+                aria-hidden
+              />
+              <input
+                ref={refineRef}
+                type="search"
+                placeholder="Refine search…"
+                value={refineValue}
+                onChange={(e) => setRefineValue(e.target.value)}
+                className="h-8 rounded-lg pl-8 pr-3 text-sm outline-none"
+                style={{
+                  width: 260,
+                  background: 'var(--ax-bg-elev)',
+                  border: '1px solid var(--ax-border)',
+                  color: 'var(--ax-fg)',
+                  fontFamily: 'inherit',
+                }}
+                aria-label="Refine search"
+              />
+            </label>
+          </form>
+
+          {/* Right: Save as Smart Collection (disabled) */}
+          <div className="flex-shrink-0">
+            <DisabledPill
+              icon={<Zap size={12} />}
+              label="Save as Smart Collection"
+              tooltip="Available in a later update"
+            />
+          </div>
+        </div>
+
+        {/* ── Results summary bar ──────────────────────────────────────── */}
+        {q && (
+          <div
+            className="flex-shrink-0 flex items-center gap-4 px-6 py-2.5"
+            style={{
+              borderBottom: '1px solid var(--ax-border)',
+              fontSize: 12.5,
+              color: 'var(--ax-fg-muted)',
+            }}
+          >
+            {isLoading ? (
+              <span style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                <Loader2 size={13} className="animate-spin" />
+                Searching…
+              </span>
+            ) : (
+              <>
+                <span className="ax-mono" style={{ color: 'var(--ax-fg)', fontWeight: 600 }}>
+                  {grandTotal.toLocaleString()} results
+                </span>
+                <span>across</span>
+                <ResultPill count={totalModels} label="models" icon={<Box size={11} />} />
+                <ResultPill count={totalCollections} label="collections" icon={<Folder size={11} />} />
+                <ResultPill count={totalArtists} label="artists" icon={<User size={11} />} />
+                <ResultPill count={totalTags} label="tags" icon={<Hash size={11} />} />
+                <div style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: 8 }}>
+                  <span>Sort:</span>
+                  <span
+                    style={{
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                      gap: 5,
+                      padding: '3px 8px',
+                      borderRadius: 5,
+                      background: 'var(--ax-bg-sunk)',
+                      fontSize: 11.5,
+                    }}
+                  >
+                    <SortAsc size={12} />
+                    Best match
+                  </span>
+                </div>
+              </>
+            )}
+          </div>
+        )}
+
+        {/* ── Scrollable results ───────────────────────────────────────── */}
+        <div className="flex-1 min-h-0 overflow-y-auto" style={{ padding: '8px 28px 28px' }}>
+          {/* No query state */}
+          {!q && (
+            <div
+              style={{
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                justifyContent: 'center',
+                minHeight: 300,
+                gap: 12,
+                textAlign: 'center',
+                color: 'var(--ax-fg-muted)',
+              }}
+            >
+              <Search size={40} style={{ opacity: 0.25 }} />
+              <p style={{ fontSize: 15, fontWeight: 500, color: 'var(--ax-fg)' }}>
+                Search your library
+              </p>
+              <p style={{ fontSize: 13, maxWidth: 320 }}>
+                Use the search bar above, or press{' '}
+                <kbd
+                  style={{
+                    display: 'inline-block',
+                    padding: '1px 5px',
+                    borderRadius: 4,
+                    background: 'var(--ax-bg-sunk)',
+                    border: '1px solid var(--ax-border)',
+                    fontFamily: 'inherit',
+                    fontSize: 11,
+                  }}
+                >
+                  ⌘K
+                </kbd>{' '}
+                to open the command palette
+              </p>
+            </div>
+          )}
+
+          {/* Error state */}
+          {q && isError && (
+            <div
+              style={{
+                marginTop: 24,
+                padding: '16px',
+                borderRadius: 10,
+                border: '1px solid var(--ax-danger, #ef4444)',
+                background: 'color-mix(in srgb, var(--ax-danger, #ef4444) 10%, transparent)',
+                color: 'var(--ax-danger, #ef4444)',
+                fontSize: 13,
+              }}
+            >
+              Search failed. Please try again.
+            </div>
+          )}
+
+          {/* Zero results */}
+          {q && !isLoading && !isError && grandTotal === 0 && (
+            <div
+              style={{
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                justifyContent: 'center',
+                minHeight: 260,
+                gap: 12,
+                textAlign: 'center',
+                color: 'var(--ax-fg-muted)',
+              }}
+            >
+              <Search size={36} style={{ opacity: 0.2 }} />
+              <p style={{ fontSize: 15, fontWeight: 500, color: 'var(--ax-fg)' }}>
+                No results for "{q}"
+              </p>
+              <p style={{ fontSize: 13 }}>
+                Try a different query, or check your spelling.
+              </p>
+            </div>
+          )}
+
+          {/* Results sections */}
+          {q && !isLoading && data && grandTotal > 0 && (
+            <>
+              {/* Models */}
+              {showModels && data.models.items.length > 0 && (
+                <SearchSection
+                  title="Models"
+                  count={data.models.total}
+                  icon={<Box size={14} style={{ color: 'var(--ax-fg-muted)' }} />}
+                >
+                  <div
+                    style={{
+                      display: 'grid',
+                      gridTemplateColumns: 'repeat(auto-fill, minmax(180px, 1fr))',
+                      gap: 14,
+                    }}
+                  >
+                    {data.models.items.slice(0, SEARCH_LIMIT).map((model) => (
+                      <ModelCard key={model.id} model={model} />
+                    ))}
+                  </div>
+                  {data.models.total > data.models.items.length && (
+                    <button
+                      type="button"
+                      onClick={() => navigate(`/?q=${encodeURIComponent(q)}`)}
+                      style={{
+                        marginTop: 12,
+                        padding: '8px 12px',
+                        borderRadius: 8,
+                        background: 'transparent',
+                        border: '1px solid var(--ax-border)',
+                        color: 'var(--ax-fg)',
+                        cursor: 'pointer',
+                        fontFamily: 'inherit',
+                        fontSize: 12,
+                      }}
+                    >
+                      Show all {data.models.total.toLocaleString()} models →
+                    </button>
+                  )}
+                </SearchSection>
+              )}
+
+              {/* Collections */}
+              {showCollections && data.collections.length > 0 && (
+                <SearchSection
+                  title="Collections"
+                  count={data.collections.length}
+                  icon={<Folder size={14} style={{ color: 'var(--ax-amber, #f59e0b)' }} />}
+                >
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+                    {data.collections.map((col) => (
+                      <CollectionResultRow key={col.id} collection={col} />
+                    ))}
+                  </div>
+                </SearchSection>
+              )}
+
+              {/* Artists */}
+              {showArtists && data.artists.length > 0 && (
+                <SearchSection
+                  title="Artists"
+                  count={data.artists.length}
+                  icon={<User size={14} style={{ color: 'var(--ax-fg-muted)' }} />}
+                >
+                  <div
+                    style={{
+                      display: 'grid',
+                      gridTemplateColumns: 'repeat(auto-fill, minmax(200px, 1fr))',
+                      gap: 12,
+                    }}
+                  >
+                    {data.artists.map((artist) => (
+                      <ArtistResultCard key={artist.name} artist={artist} />
+                    ))}
+                  </div>
+                </SearchSection>
+              )}
+
+              {/* Tags */}
+              {showTags && data.tags.length > 0 && (
+                <SearchSection
+                  title="Tags"
+                  count={data.tags.length}
+                  icon={<Hash size={14} style={{ color: 'var(--ax-fg-muted)' }} />}
+                >
+                  <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+                    {data.tags.map((tag) => (
+                      <TagResultPill key={tag.name} tag={tag} />
+                    ))}
+                  </div>
+                </SearchSection>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/pages/UploadPage.tsx
+++ b/apps/frontend/src/pages/UploadPage.tsx
@@ -1,63 +1,148 @@
-import { useState } from 'react';
-import { Upload, FolderOpen } from 'lucide-react';
-import { cn } from '../lib/utils';
+import { useState, useEffect } from 'react';
+import { FolderOpen } from 'lucide-react';
+import { useImportSessions } from '../hooks/use-import-sessions';
+import { UploadQueue } from '../components/upload/UploadQueue';
 import { DropZone } from '../components/upload/DropZone';
+import { ReviewPane } from '../components/upload/ReviewPane';
 import { FolderImport } from '../components/upload/FolderImport';
 import { RecentUploads } from '../components/upload/RecentUploads';
+import { cn } from '../lib/utils';
 
-type Tab = 'zip' | 'folder';
+type Tab = 'queue' | 'folder';
 
 export function UploadPage() {
-  const [activeTab, setActiveTab] = useState<Tab>('zip');
+  const { data: sessions = [] } = useImportSessions();
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [tab, setTab] = useState<Tab>('queue');
+
+  // Auto-select the first actionable (non-committed) session when the list loads
+  useEffect(() => {
+    if (activeId) {
+      // Keep existing selection if it's still in the list
+      const stillExists = sessions.some((s) => s.id === activeId);
+      if (stillExists) return;
+    }
+    // Find first ready_for_review, then scanning, then any
+    const preferred =
+      sessions.find((s) => s.status === 'ready_for_review') ??
+      sessions.find((s) => s.status !== 'committed') ??
+      sessions[0] ??
+      null;
+    setActiveId(preferred?.id ?? null);
+  }, [sessions]);
+
+  const activeSession = sessions.find((s) => s.id === activeId) ?? null;
+
+  const handleCommitted = (_modelId: string) => {
+    // Session transitions to committing automatically via polling; nothing to do here
+  };
+
+  const handleDiscard = () => {
+    setActiveId(null);
+  };
 
   return (
-    <div className="mx-auto max-w-2xl px-4 py-8 space-y-8">
-      {/* Page heading */}
-      <div>
-        <h1 className="text-2xl font-bold tracking-tight text-foreground">Add Models</h1>
-        <p className="mt-1 text-sm text-muted-foreground">
-          Upload a zip archive or import from a folder on the server.
-        </p>
-      </div>
+    <div className="flex h-screen overflow-hidden">
+      {/* Left rail: queue */}
+      <UploadQueue
+        sessions={sessions}
+        activeId={activeId}
+        onSelect={(id) => { setActiveId(id); setTab('queue'); }}
+      />
 
-      {/* Tab switcher */}
-      <div className="flex gap-1 rounded-lg bg-muted p-1 w-fit">
-        <button
-          onClick={() => setActiveTab('zip')}
-          className={cn(
-            'flex items-center gap-2 rounded-md px-4 py-2 text-sm font-medium transition-colors',
-            activeTab === 'zip'
-              ? 'bg-background text-foreground shadow-sm'
-              : 'text-muted-foreground hover:text-foreground'
-          )}
+      {/* Main content */}
+      <div className="flex-1 flex flex-col min-w-0 overflow-hidden">
+        {/* Tab bar */}
+        <div
+          className="flex items-center gap-1 px-7 pt-4 flex-shrink-0"
+          style={{ borderBottom: '1px solid var(--ax-border)' }}
         >
-          <Upload className="h-4 w-4" />
-          Upload Zip
-        </button>
-        <button
-          onClick={() => setActiveTab('folder')}
-          className={cn(
-            'flex items-center gap-2 rounded-md px-4 py-2 text-sm font-medium transition-colors',
-            activeTab === 'folder'
-              ? 'bg-background text-foreground shadow-sm'
-              : 'text-muted-foreground hover:text-foreground'
-          )}
-        >
-          <FolderOpen className="h-4 w-4" />
-          Import Folder
-        </button>
-      </div>
+          <button
+            onClick={() => setTab('queue')}
+            className={cn(
+              'flex items-center gap-1.5 px-4 py-2 text-[13px] font-medium rounded-t-lg border-b-2 transition-colors',
+              tab === 'queue'
+                ? 'border-[var(--ax-amber)] text-[var(--ax-amber)]'
+                : 'border-transparent text-muted-foreground hover:text-foreground'
+            )}
+          >
+            Archive upload
+          </button>
+          <button
+            onClick={() => setTab('folder')}
+            className={cn(
+              'flex items-center gap-1.5 px-4 py-2 text-[13px] font-medium rounded-t-lg border-b-2 transition-colors',
+              tab === 'folder'
+                ? 'border-[var(--ax-amber)] text-[var(--ax-amber)]'
+                : 'border-transparent text-muted-foreground hover:text-foreground'
+            )}
+          >
+            <FolderOpen className="h-3.5 w-3.5" />
+            Server folder import
+          </button>
+        </div>
 
-      {/* Tab content */}
-      <div>
-        {activeTab === 'zip' && <DropZone />}
-        {activeTab === 'folder' && <FolderImport />}
-      </div>
+        {tab === 'folder' ? (
+          <div className="flex-1 overflow-y-auto">
+            <div className="max-w-2xl mx-auto px-7 py-6">
+              <div className="space-y-2 mb-6">
+                <h1 className="text-xl font-bold" style={{ color: 'var(--ax-fg)' }}>
+                  Import from server folder
+                </h1>
+                <p className="text-[13px]" style={{ color: 'var(--ax-fg-muted)' }}>
+                  Point at a folder on the server and define how its hierarchy maps to
+                  collections and metadata.
+                </p>
+              </div>
+              <FolderImport />
+            </div>
+          </div>
+        ) : (
+          <div className="flex-1 overflow-hidden flex flex-col">
+            {/* Drop zone — compact when sessions exist, full when empty */}
+            {sessions.length > 0 ? (
+              <DropZone compact onBrowseFolder={() => setTab('folder')} />
+            ) : (
+              <div className="px-7 pt-6">
+                <div className="space-y-2 mb-4">
+                  <h1 className="text-xl font-bold" style={{ color: 'var(--ax-fg)' }}>
+                    Add models
+                  </h1>
+                  <p className="text-[13px]" style={{ color: 'var(--ax-fg-muted)' }}>
+                    Drop archives to scan, then review detected metadata before importing.
+                  </p>
+                </div>
+                <DropZone />
+              </div>
+            )}
 
-      {/* Recent uploads */}
-      <div className="space-y-3">
-        <h2 className="text-base font-semibold text-foreground">Recent models</h2>
-        <RecentUploads />
+            {/* Review pane or empty state */}
+            <div className="flex-1 overflow-y-auto ax-scroll px-7 py-5">
+              {activeSession ? (
+                <ReviewPane
+                  session={activeSession}
+                  onCommitted={handleCommitted}
+                  onDiscard={handleDiscard}
+                  onRetry={handleDiscard}
+                />
+              ) : sessions.length === 0 ? (
+                <div className="space-y-4 mt-4">
+                  <h2 className="text-base font-semibold" style={{ color: 'var(--ax-fg)' }}>
+                    Recent models
+                  </h2>
+                  <RecentUploads />
+                </div>
+              ) : (
+                <div
+                  className="flex flex-col items-center justify-center py-16 text-[13px]"
+                  style={{ color: 'var(--ax-fg-muted)' }}
+                >
+                  Select a session from the queue to review it.
+                </div>
+              )}
+            </div>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/docs/API.md
+++ b/docs/API.md
@@ -42,6 +42,8 @@ The session mechanism uses `@fastify/cookie` with signed cookies. The cookie val
 
 For single-request uploads (`POST /models/upload`), archive files are capped at 100 MB. For larger files, use the chunked upload protocol (`POST /models/upload/init` + chunk PUTs + `POST /models/upload/:uploadId/complete`), which supports files up to 5 GB with 10 MB chunks and per-chunk retry.
 
+Both upload paths now use the staged ingestion workflow. They return a `sessionId` (not a `modelId`) — the model is created only after the session is committed. See the Import Sessions section below for the full scan → review → commit protocol.
+
 ---
 
 ## Error Format
@@ -290,11 +292,11 @@ Each item in `data` is a `ModelCard`.
 
 ### POST /models/upload
 
-Upload an archive file to create a new model. The upload is accepted immediately and processed asynchronously. Returns a `modelId` and `jobId` to track progress.
+Upload an archive file to begin the staged ingestion workflow. The file is accepted, an import session is created, and a scan job is enqueued. Returns a `sessionId` — not a model ID. The model is created only after the session is committed via `POST /models/import-sessions/:id/commit`.
 
 **Auth required:** Yes
 
-**Library scope:** The new model is created in the authenticated user's default library, resolved server-side from the session. Clients do not pass a `libraryId`.
+**Library scope:** The import session is created in the authenticated user's default library, resolved server-side from the session. Clients do not pass a `libraryId`.
 
 **Request:** `multipart/form-data` with a single file field. The file must have a supported archive extension (`.zip`, `.rar`, `.7z`, `.tar.gz`, or `.tgz`) and must be 100 MB or smaller.
 
@@ -303,15 +305,14 @@ Upload an archive file to create a new model. The upload is accepted immediately
 ```json
 {
   "data": {
-    "modelId": "uuid",
-    "jobId": "string"
+    "sessionId": "uuid"
   },
   "meta": null,
   "errors": null
 }
 ```
 
-Poll `GET /models/:id/status` with the returned `modelId` to track processing.
+Poll `GET /models/import-sessions/:id` with the returned `sessionId` to track scan progress and retrieve detected metadata. Once the session reaches `ready_for_review`, commit it with `POST /models/import-sessions/:id/commit`.
 
 For files larger than 100 MB, use the chunked upload protocol described below.
 
@@ -384,11 +385,11 @@ Upload a single chunk of a file. The request body must be the raw binary chunk d
 
 ### POST /models/upload/:uploadId/complete
 
-Assemble all uploaded chunks and start ingestion processing. All chunks (0 through `totalChunks - 1`) must have been uploaded. The assembled file size must match the `totalSize` declared during init.
+Assemble all uploaded chunks and begin the staged ingestion workflow. All chunks (0 through `totalChunks - 1`) must have been uploaded. The assembled file size must match the `totalSize` declared during init.
 
 **Auth required:** Yes
 
-**Library scope:** The new model is created in the authenticated user's default library, resolved server-side from the session. Clients do not pass a `libraryId`.
+**Library scope:** The import session is created in the authenticated user's default library, resolved server-side from the session. Clients do not pass a `libraryId`.
 
 **Path parameter:** `uploadId` — UUID from `POST /models/upload/init`
 
@@ -397,15 +398,14 @@ Assemble all uploaded chunks and start ingestion processing. All chunks (0 throu
 ```json
 {
   "data": {
-    "modelId": "uuid",
-    "jobId": "string"
+    "sessionId": "uuid"
   },
   "meta": null,
   "errors": null
 }
 ```
 
-Same response shape as `POST /models/upload`. Poll `GET /models/:id/status` with the returned `modelId` to track processing.
+Same staged contract as `POST /models/upload`. Poll `GET /models/import-sessions/:id` with the returned `sessionId` to track scan progress, then commit via `POST /models/import-sessions/:id/commit`.
 
 ---
 
@@ -448,6 +448,164 @@ Start a folder import. Discovers models by walking a directory on the server's f
 ```
 
 Unlike archive upload, this response does not include a `modelId` because the import may create multiple models.
+
+---
+
+### GET /models/import-sessions
+
+List the authenticated user's active import sessions for the current library. Active sessions include those with status `scanning`, `ready_for_review`, `committing`, or `error`. Committed and expired sessions are not returned.
+
+**Auth required:** Yes
+
+**Library scope:** Results are scoped to the authenticated user's default library, resolved server-side from the session. Clients do not pass a `libraryId`.
+
+**Response (200):**
+
+```json
+{
+  "data": [
+    {
+      "id": "uuid",
+      "originalFilename": "dragon-bust.zip",
+      "status": "ready_for_review",
+      "detected": {
+        "modelCount": 1,
+        "fileCount": 14,
+        "totalSizeBytes": 8388608,
+        "artist": "Maker Name",
+        "tagsGuessed": ["fantasy", "bust"],
+        "folderStructure": [
+          { "name": "parts", "type": "folder", "children": [
+            { "name": "body.stl", "type": "file", "fileType": "stl" }
+          ]}
+        ]
+      },
+      "modelId": null,
+      "error": null,
+      "createdAt": "2026-05-30T10:00:00.000Z"
+    }
+  ],
+  "meta": null,
+  "errors": null
+}
+```
+
+`data` is an array of `ImportSession`. The `detected` field is `null` while the session is still scanning. Session TTL is 24 hours — sessions not committed within that window may be reaped.
+
+---
+
+### GET /models/import-sessions/:id
+
+Retrieve a single import session. Use this to poll scan progress and retrieve detected metadata.
+
+**Auth required:** Yes
+
+**Path parameter:** `id` — import session UUID
+
+**Response (200):**
+
+```json
+{
+  "data": {
+    "id": "uuid",
+    "originalFilename": "dragon-bust.zip",
+    "status": "ready_for_review",
+    "detected": {
+      "modelCount": 1,
+      "fileCount": 14,
+      "totalSizeBytes": 8388608,
+      "artist": "Maker Name",
+      "tagsGuessed": ["fantasy", "bust"],
+      "folderStructure": [...]
+    },
+    "modelId": null,
+    "error": null,
+    "createdAt": "2026-05-30T10:00:00.000Z"
+  },
+  "meta": null,
+  "errors": null
+}
+```
+
+`data` is an `ImportSession`. `status` transitions: `scanning` → `ready_for_review` on success, or `scanning` → `error` on failure. Poll until status leaves `scanning`.
+
+---
+
+### POST /models/import-sessions/:id/commit
+
+Commit a reviewed import session, creating a model and enqueuing the full ingestion pipeline. The session must be in `ready_for_review` status.
+
+**Auth required:** Yes
+
+**Library scope:** The model is created in the authenticated user's default library, resolved server-side from the session.
+
+**Path parameter:** `id` — import session UUID
+
+**Request body (optional):**
+
+```json
+{
+  "batchMetadata": {
+    "collectionId": "uuid-of-existing-collection",
+    "newCollectionName": "My New Collection",
+    "artist": "Maker Name",
+    "tags": ["fantasy", "bust"],
+    "options": {
+      "markPreSupported": false,
+      "markNsfw": false,
+      "skipDuplicatesByHash": false
+    }
+  }
+}
+```
+
+`batchMetadata` is fully optional. `collectionId` and `newCollectionName` are mutually exclusive — use one or neither. All metadata detected during scan can be overridden or supplemented here.
+
+| Field | Type | Constraints |
+|-------|------|-------------|
+| `batchMetadata` | object (optional) | Batch metadata to apply to the committed model |
+| `batchMetadata.collectionId` | UUID string (optional) | Assign model to an existing collection |
+| `batchMetadata.newCollectionName` | string (optional) | Create a new collection and assign the model to it (1–255 chars) |
+| `batchMetadata.artist` | string (optional) | Override detected artist (max 255 chars) |
+| `batchMetadata.tags` | string[] (optional) | Override detected tags (max 50 tags, each max 100 chars) |
+| `batchMetadata.options.markPreSupported` | boolean (optional) | Mark model as pre-supported |
+| `batchMetadata.options.markNsfw` | boolean (optional) | Mark model as NSFW |
+| `batchMetadata.options.skipDuplicatesByHash` | boolean (optional) | Skip if a model with the same file hash already exists |
+
+**Response (202):**
+
+```json
+{
+  "data": {
+    "modelId": "uuid",
+    "jobId": "string"
+  },
+  "meta": null,
+  "errors": null
+}
+```
+
+Poll `GET /models/:id/status` with the returned `modelId` to track ingestion progress.
+
+---
+
+### DELETE /models/import-sessions/:id
+
+Discard an import session and delete its staged files. The session can be in any active status.
+
+**Auth required:** Yes
+
+**Path parameter:** `id` — import session UUID
+
+**Response (200):**
+
+```json
+{
+  "data": null,
+  "meta": null,
+  "errors": null
+}
+```
 
 ---
 
@@ -1229,6 +1387,66 @@ Delete multiple models and clean up their storage in a single request. Storage c
 ```
 
 `deletedIds` reflects the models that were actually removed from the database. Models that did not exist are silently skipped.
+
+---
+
+## Search
+
+### GET /search
+
+Cross-entity search across models, collections, artists, and tags in a single request. Each result type is scored and limited independently. Requires an active library.
+
+**Auth required:** Yes
+
+**Library scope:** All results are scoped to the authenticated user's default library, resolved server-side from the session. Clients do not pass a `libraryId`.
+
+**Query parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `q` | string | — | Required. Search query (1–500 characters) |
+| `limit` | integer | 6 | Maximum results per entity type (1–50) |
+
+**Response (200):**
+
+```json
+{
+  "data": {
+    "q": "dragon",
+    "models": {
+      "items": [
+        {
+          "id": "uuid",
+          "name": "Dragon Bust",
+          "slug": "dragon-bust-a3f2",
+          "thumbnailUrl": "/files/thumbnails/uuid.webp",
+          "metadata": [...],
+          "fileCount": 4,
+          "totalSizeBytes": 8388608,
+          "status": "ready",
+          "createdAt": "2026-01-15T10:30:00.000Z"
+        }
+      ],
+      "total": 3
+    },
+    "collections": [
+      { "id": "uuid", "name": "Dragons", "slug": "dragons-b1c2", "modelCount": 8 }
+    ],
+    "artists": [
+      { "name": "DragonArtist", "modelCount": 5 }
+    ],
+    "tags": [
+      { "name": "dragon", "modelCount": 12 }
+    ]
+  },
+  "meta": null,
+  "errors": null
+}
+```
+
+`data` is a `GlobalSearchResult`. `models.items` contains up to `limit` `ModelCard` objects; `models.total` reflects the full count of matching models regardless of `limit`. `collections`, `artists`, and `tags` each contain up to `limit` hits.
+
+Models are ranked by full-text relevance. Collections are filtered by name substring and sorted by `modelCount` descending. Artists and tags are filtered by name substring, drawn from library-scoped metadata values, and sorted by `modelCount` descending. There is no unified cross-type relevance score.
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -80,11 +80,12 @@ The `runSeed` function is also exported for use as a standalone CLI script (`npm
 │         │           ┌──────▼───────┐                     │
 │         └──────────→│StorageService│                     │
 │                     └──────────────┘                     │
-│  ┌──────────────┐  ┌──────────────┐                      │
-│  │ JobService    │  │UploadService │  BullMQ + Redis      │
-│  │ (queue mgmt)  │  │(chunked      │                      │
-│  └──────────────┘  │ upload sess) │                      │
-│                     └──────────────┘                     │
+│  ┌──────────────┐  ┌──────────────┐  ┌─────────────────┐  │
+│  │ JobService    │  │UploadService │  │ImportSessionSvc │  │
+│  │ (queue mgmt)  │  │(chunked      │  │(staged upload   │  │
+│  │ import-scan / │  │ upload sess) │  │ sessions)       │  │
+│  │ import-commit │  └──────────────┘  └─────────────────┘  │
+│  └──────────────┘                   BullMQ + Redis          │
 └──────────────────────┬──────────────────────────────────┘
                        │
           ┌────────────▼────────────┐
@@ -124,15 +125,23 @@ The seed (`runSeed`) calls this method for the admin user on startup, so the adm
 
 **Security invariant:** `libraryId` is server-injected only. No route accepts a `libraryId` from the client in the query string, path, or request body. The value is always derived from the authenticated session. This prevents one user from accessing another user's library by supplying a different `libraryId`.
 
-Routes that apply `requireLibrary` (as of P1):
+Routes that apply `requireLibrary` (as of P3):
 
 - `GET /models`
 - `GET /collections`, `POST /collections`
 - `GET /collections/:id/models`
 - `GET /metadata/fields/:slug/values`
 - `POST /models/upload`, `POST /models/upload/:uploadId/complete`, `POST /models/import`
+- `GET /models/import-sessions`, `POST /models/import-sessions/:id/commit`
+- `GET /search`
 
 By-id detail routes (`GET /models/:id`, `GET /collections/:id`, `PATCH /models/:id`, etc.) remain owned by `userId` and are not yet library-scoped. Library scoping for detail routes is deferred to P5 multi-library.
+
+### P4 Deferrals
+
+The following are deferred to the Smart Collections phase:
+
+- Smart (rule-based) collections entity and rule engine. `SearchService.searchAll` returns only manual collections. When smart collections ship, `searchAll` will need to union both types.
 
 ### P5 Deferrals
 
@@ -156,15 +165,27 @@ The following are explicitly deferred to the multi-library phase:
 
 ### IngestionService
 
-**Owns:** Upload and import orchestration, pipeline sequencing, Model record creation in "processing" state.
+**Owns:** Upload and import orchestration, pipeline sequencing, Model record creation in "processing" state, staged scan/commit coordination.
 
 **Does not own:** File I/O, thumbnail generation, extraction logic, storage.
 
-**Behavior:** Receives upload or import requests. Creates a Model record in `processing` state. Enqueues a processing job via JobService. The job worker calls back into IngestionService's pipeline methods, which coordinate FileProcessingService, ThumbnailService, StorageService, and MetadataService in sequence. On completion, updates model status to `ready` or `error`.
+**Behavior:** Receives upload or import requests and coordinates the full pipeline. The job worker calls back into IngestionService's pipeline methods, which coordinate FileProcessingService, ThumbnailService, StorageService, and MetadataService in sequence. On completion, updates model status to `ready` or `error`.
 
-Two entry paths:
-- **Zip upload**: Receives multipart file, stores temp file, enqueues processing job.
-- **Folder import**: Receives ImportConfig (source path, pattern, strategy). Uses PatternParser to validate and parse the hierarchy pattern. Uses FileProcessingService to walk the directory. Uses the selected ImportStrategy to move files into managed storage. Then continues with the standard processing pipeline.
+Three entry paths:
+
+- **Staged upload (scan phase):** `handleScan` receives a temp file path, creates an `ImportSession` (via ImportSessionService), and enqueues a scan job on the `import-scan` BullMQ queue. The worker's `processScanJob` extracts the archive, detects metadata heuristically, and updates the session to `ready_for_review`. No model is created at this stage.
+
+- **Staged upload (commit phase):** `handleCommit` validates the session is `ready_for_review`, creates a Model record in `processing` state, transitions the session to `committing`, and enqueues a commit job on the `import-commit` BullMQ queue. The worker's `processCommitJob` copies staged files to managed storage, runs the thumbnail pipeline, and applies any `BatchUploadMetadata` supplied at commit time.
+
+- **Folder import:** `handleFolderImport` receives an `ImportConfig` (source path, pattern, strategy). Uses PatternParser to validate and parse the hierarchy pattern, FileProcessingService to walk the directory, and the selected ImportStrategy to move files into managed storage. Folder import retains its existing immediate behavior — it does not use the staged session model.
+
+### ImportSessionService
+
+**Owns:** `import_sessions` table CRUD — creating sessions, updating their status and detected metadata, listing active sessions, ownership validation.
+
+**Does not own:** File extraction (FileProcessingService), ingestion pipeline (IngestionService), storage cleanup.
+
+**Behavior:** `create` inserts a session in `scanning` status with a 24-hour `expiresAt`. `update` patches status and any combination of `detected`, `manifest`, `stagingPath`, `modelId`, and `error`. `listActive` returns sessions in `scanning`, `ready_for_review`, `committing`, or `error` status for a given user and library. `getOwnedRow` fetches a session and throws `NOT_FOUND` if it doesn't exist or belongs to a different user. `toDto` maps the DB row to the `ImportSession` API shape (omitting `manifest` and `stagingPath`).
 
 ### FileProcessingService
 
@@ -200,11 +221,15 @@ Uses the **PatternParser** utility (located in `utils/pattern-parser.ts`) — a 
 
 ### SearchService
 
-**Owns:** All query execution — browse, search, filter, sort, pagination. This is the single entry point for "give me models matching criteria."
+**Owns:** All query execution — browse, search, filter, sort, pagination, and cross-entity global search. This is the single entry point for "give me models matching criteria" and for the global search bar.
 
 **Does not own:** Data indexing, data mutation. SearchService is read-only.
 
-**Behavior:** Accepts query parameters (text search, metadata filters, collection filter, sort, pagination cursor). Executes against Postgres full-text search in MVP. Understands which metadata fields use optimized storage (tags → join table query) vs. generic storage (other fields → model_metadata table query). Returns paginated results as model IDs which PresenterService then assembles into response payloads.
+**Behavior:** Two public methods:
+
+- `searchModels(params, libraryId)` — accepts query parameters (text search, metadata filters, collection filter, sort, pagination cursor). Executes against Postgres full-text search. Understands which metadata fields use optimized storage (tags → join table query) vs. generic storage (other fields → model_metadata table query). Returns paginated results as `ModelCard` objects assembled by PresenterService.
+
+- `searchAll(params, userId, libraryId)` — cross-entity search. Calls `searchModels` for models (full-text), then filters in-memory against collections (by name substring, sorted by `modelCount`), artist values, and tag values (both by name substring, drawn from `listFieldValues`). Results for each entity type are limited to `params.limit` (default 6). Returns a `GlobalSearchResult`.
 
 **Abstraction:** The search implementation is behind an interface. Postgres FTS is the MVP implementation. A future MeiliSearch or Typesense implementation can be swapped in without changing any callers.
 
@@ -429,11 +454,15 @@ Because `ModelViewer3DScene` is lazy-loaded, Vite emits three.js as a separate a
 | GET | /models | Browse/search with filters | SearchService → PresenterService | Yes |
 | GET | /models/:id | Model detail | ModelService → PresenterService | No (userId) |
 | GET | /models/:id/files | File tree | ModelService → PresenterService | No (userId) |
-| POST | /models/upload | Upload archive (zip/rar/7z/tar.gz, ≤100 MB) | IngestionService → JobService | Yes |
+| POST | /models/upload | Upload archive → scan (returns sessionId) | IngestionService → ImportSessionService → JobService | Yes |
 | POST | /models/upload/init | Initiate chunked upload session | UploadService | No |
 | PUT | /models/upload/:uploadId/chunk/:index | Upload a single chunk | UploadService | No |
-| POST | /models/upload/:uploadId/complete | Assemble chunks, start ingestion | UploadService → IngestionService → JobService | Yes |
-| POST | /models/import | Folder import | IngestionService → JobService | Yes |
+| POST | /models/upload/:uploadId/complete | Assemble chunks → scan (returns sessionId) | UploadService → IngestionService → JobService | Yes |
+| POST | /models/import | Folder import (immediate; no staged session) | IngestionService → JobService | Yes |
+| GET | /models/import-sessions | List active staged sessions | ImportSessionService | Yes |
+| GET | /models/import-sessions/:id | Poll a single session | ImportSessionService | No (userId) |
+| POST | /models/import-sessions/:id/commit | Commit session → create model | IngestionService → JobService | Yes |
+| DELETE | /models/import-sessions/:id | Discard session + staged files | IngestionService | No (userId) |
 | GET | /models/:id/status | Processing status | JobService | No (userId) |
 | PATCH | /models/:id | Update model | ModelService → PresenterService | No (userId) |
 | DELETE | /models/:id | Delete model + files | ModelService → StorageService | No (userId) |
@@ -475,6 +504,11 @@ Because `ModelViewer3DScene` is lazy-loaded, Vite emits three.js as a separate a
 |--------|-------|---------|---------------|
 | GET | /files/thumbnails/:id.webp | Serve thumbnail | StorageService |
 | GET | /files/models/:modelId/* | Serve model file | StorageService |
+
+**Search**
+| Method | Route | Purpose | Service Chain | Library-scoped |
+|--------|-------|---------|---------------|---------------|
+| GET | /search | Cross-entity search (models, collections, artists, tags) | SearchService | Yes |
 
 **Bulk Operations**
 | Method | Route | Purpose | Service Chain |
@@ -533,3 +567,11 @@ The active pivot axis (`?axis=collections|artists|tags`) is stored in the URL so
 
 ### D15: three.js is isolated in a single lazy-loaded module
 `ModelViewer3DScene` is the only file in the frontend that imports `three`, `@react-three/fiber`, or `@react-three/drei`. All other code reaches it through `ModelViewer3DModal` via `React.lazy`, which causes Vite to emit three.js as a separate async chunk (~924 KB). The chunk is never fetched unless the 3D viewer is opened. This isolation is intentional: adding any static import of three anywhere else in the app would pull the entire bundle into the critical path. If the viewer grows to need additional three.js utilities, they must be added inside `ModelViewer3DScene` or co-located lazy modules — not imported at the app or component level.
+
+### D16: Staged ingestion — scan before commit
+Archive uploads no longer create a model immediately. Instead they create an `ImportSession`, extract the archive, and expose detected metadata for review before the user commits. This gives users a chance to verify and supplement auto-detected artist, tags, and collection assignment before the model record is created. Folder imports retain the existing immediate behavior because they operate on server-side directories where the user has already organized the content.
+
+The consequence is that `POST /models/upload` (and the chunked `complete` endpoint) return `{ sessionId }` rather than `{ modelId, jobId }`. Callers that previously polled `GET /models/:id/status` now poll `GET /models/import-sessions/:id`, then call `POST /models/import-sessions/:id/commit` to get a `{ modelId, jobId }` to track the final ingestion.
+
+### D17: Cross-entity global search is in-memory for non-model types
+`SearchService.searchAll` runs Postgres full-text search for models, but for collections, artists, and tags it fetches the full library-scoped list and filters in memory. This is acceptable because these lists are small (hundreds at most), require no dedicated index, and avoids schema complexity. If list sizes grow to a point where in-memory filtering is measurably slow, the internal implementation can be replaced with index-backed queries without changing the API or callers. Smart collections (P4) may warrant a dedicated index at that point.

--- a/docs/TYPES.md
+++ b/docs/TYPES.md
@@ -184,6 +184,35 @@ interface Collection {
 
 Join table `collection_models`: `{ collectionId: string, modelId: string }`
 
+### ImportSession
+
+A staged archive upload awaiting review and commit. Created by `POST /models/upload` (and the chunked complete endpoint); destroyed by commit or discard. The database schema is in `apps/backend/src/db/schema/import-session.ts` and migration `0008_add_import_sessions.sql`.
+
+```typescript
+interface ImportSession {
+  id: string;
+  userId: string;
+  libraryId: string;
+  originalFilename: string;
+  status: ImportSessionStatus;
+  detected: DetectedImportMetadata | null; // null while scanning
+  manifest: unknown | null;                // internal file manifest; not exposed in API responses
+  stagingPath: string | null;              // server-side path to extracted files; not exposed in API responses
+  modelId: string | null;                  // set during commit; FK → models (set null on model delete)
+  error: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+  expiresAt: Date | null;                  // sessions expire after 24 hours if not committed
+}
+
+type ImportSessionStatus =
+  | 'scanning'          // scan job running
+  | 'ready_for_review'  // scan complete; waiting for user to commit or discard
+  | 'committing'        // commit job running
+  | 'committed'         // model created; session complete (not returned by list endpoint)
+  | 'error';            // scan or commit failed
+```
+
 ---
 
 ## API Response Types
@@ -390,6 +419,113 @@ interface ImportJob {
 type ImportPhase = 'scanning' | 'importing' | 'processing' | 'complete' | 'error';
 ```
 
+### Staged Upload Types
+
+These types support the scan → review → commit ingestion workflow introduced in P3. All are defined in `packages/shared/src/types/upload.ts`.
+
+```typescript
+// API response from POST /models/upload and POST /models/upload/:uploadId/complete
+interface ScanUploadResponse {
+  sessionId: string;
+}
+
+// A node in the folder-structure preview detected during scan
+interface DetectedFolderNode {
+  name: string;
+  type: 'folder' | 'file';
+  fileType?: FileType;          // present for file nodes
+  children?: DetectedFolderNode[]; // present for folder nodes
+}
+
+// Heuristic metadata detected from archive contents and filename during the scan phase
+interface DetectedImportMetadata {
+  modelCount: number;           // count of detected sub-models (display only; one model is created on commit)
+  fileCount: number;
+  totalSizeBytes: number;
+  artist: string | null;        // extracted from folder structure or filename
+  tagsGuessed: string[];        // guessed from directory names; stopwords filtered
+  folderStructure: DetectedFolderNode[];
+}
+
+// The DTO returned by GET /models/import-sessions and GET /models/import-sessions/:id
+interface ImportSession {
+  id: string;
+  originalFilename: string;
+  status: ImportSessionStatus;
+  detected: DetectedImportMetadata | null; // null until scan completes
+  modelId: string | null;       // set once commit begins
+  error: string | null;
+  createdAt: string;
+}
+
+type ImportSessionStatus =
+  | 'scanning'
+  | 'ready_for_review'
+  | 'committing'
+  | 'committed'
+  | 'error';
+
+// Optional per-import options sent in the commit request body
+interface UploadOptions {
+  markPreSupported?: boolean;
+  autoThumbnails?: boolean;     // informational; auto-thumbnails always run during ingestion
+  markNsfw?: boolean;
+  skipDuplicatesByHash?: boolean;
+}
+
+// Batch metadata applied to the model at commit time
+interface BatchUploadMetadata {
+  collectionId?: string;        // assign to an existing collection
+  newCollectionName?: string;   // or create and assign a new collection by name
+  artist?: string;
+  tags?: string[];
+  options?: UploadOptions;
+}
+```
+
+### Global Search Types
+
+Defined in `packages/shared/src/types/search.ts`. Used by `GET /search`.
+
+```typescript
+interface GlobalSearchParams {
+  q: string;
+  limit?: number; // max hits per entity type; default 6, max 50
+}
+
+// A collection matched by name substring
+interface SearchCollectionHit {
+  id: string;
+  name: string;
+  slug: string;
+  modelCount: number;
+}
+
+// An artist metadata value matched by name substring
+interface SearchArtistHit {
+  name: string;
+  modelCount: number;
+}
+
+// A tag metadata value matched by name substring
+interface SearchTagHit {
+  name: string;
+  modelCount: number;
+}
+
+// Aggregated response from GET /search
+interface GlobalSearchResult {
+  q: string;
+  models: {
+    items: ModelCard[];
+    total: number; // total matching models, not capped by limit
+  };
+  collections: SearchCollectionHit[];
+  artists: SearchArtistHit[];
+  tags: SearchTagHit[];
+}
+```
+
 ---
 
 ## API Request Types
@@ -492,6 +628,17 @@ interface BulkDeleteRequest {
 }
 ```
 
+### Staged Upload Requests
+
+```typescript
+// POST /models/import-sessions/:id/commit request body
+interface CommitImportSessionRequest {
+  batchMetadata?: BatchUploadMetadata;
+}
+```
+
+Validation schemas: `commitImportSessionSchema`, `importSessionIdParamsSchema`, `batchUploadMetadataSchema` in `packages/shared/src/validation/upload.ts`.
+
 ### Query Parameters
 
 ```typescript
@@ -513,7 +660,15 @@ interface ModelSearchParams {
 interface CollectionListParams {
   depth?: number; // default: 1 (top-level only)
 }
+
+// GET /search query parameters
+interface GlobalSearchParams {
+  q: string;     // required; 1–500 characters
+  limit?: number; // max hits per entity type; default 6, max 50
+}
 ```
+
+Validation schema: `globalSearchParamsSchema` in `packages/shared/src/validation/search.ts`.
 
 ---
 
@@ -560,7 +715,10 @@ User ──owns──→ Library ──scopes──→ Model ──has many─�
   │               │                   └──many to many──→ Collection ──self-references──→ Collection
   │               │                       (via collection_models)     (via parentCollectionId)
   │               │
-  │               └──scopes──→ Collection
+  │               ├──scopes──→ Collection
+  │               │
+  │               └──scopes──→ ImportSession ──(on commit)──→ Model
+  │                              (staged upload; expires 24h; FK set null on model delete)
   │
   └──owns──→ Collection (via userId, for ownership; libraryId for scope)
 ```
@@ -569,3 +727,4 @@ The key insights:
 
 - Library is the top-level scope for models and collections. Every model and collection has a NOT NULL `libraryId` FK. The API enforces this via the `requireLibrary` preHandler, which injects `request.libraryId` from the session — clients never supply it.
 - Tag and model_tags exist as database-level optimizations. At the API level, tags are just metadata values of type `multi_enum`. MetadataService abstracts the storage routing.
+- `ImportSession` is a transient entity. It exists between `POST /models/upload` (scan enqueued) and `POST /models/import-sessions/:id/commit` (model created). The `modelId` FK is set to null on model deletion; the session row itself is deleted by the discard endpoint or reaped by the expiry cleanup.

--- a/docs/superpowers/plans/2026-05-30-p3-upload-workflow.md
+++ b/docs/superpowers/plans/2026-05-30-p3-upload-workflow.md
@@ -1,0 +1,1988 @@
+# P3 Upload Workflow (Scan → Review → Commit) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rebuild the Alexandria upload page into a staged scan→review→commit workflow with a dark queue rail and a main review pane driven by import sessions.
+
+**Architecture:** Upload archives → backend creates ImportSession (status: scanning) → frontend polls sessions and shows detected folder structure → user fills BatchMetadataForm → commit creates model → poll model status to ready. The left rail lists all in-flight sessions; the right main area shows the active session's review pane. The existing FolderImport tab is preserved as a secondary tab.
+
+**Tech Stack:** React + TanStack Query, TypeScript, Tailwind + `var(--ax-*)` tokens, shadcn/ui primitives, `@alexandria/shared` types.
+
+---
+
+## File Map
+
+**Created:**
+- `apps/frontend/src/api/models.ts` — updated: rename `uploadModel` → `scanUpload`, fix return type, add import-session API functions
+- `apps/frontend/src/hooks/use-import-sessions.ts` — new React Query hook: list sessions (with polling), upload+invalidate, commit, discard
+- `apps/frontend/src/components/upload/UploadQueue.tsx` — new: dark left rail showing all ImportSessions with status icons, selectable, stats footer
+- `apps/frontend/src/components/upload/DropZone.tsx` — restyle: compact collapsed form when sessions exist; multi-file drop starts scanUpload per file; upload progress per file
+- `apps/frontend/src/components/upload/ReviewPane.tsx` — new: renders scanning/ready_for_review/committing/committed/error states for active session
+- `apps/frontend/src/components/upload/BatchMetadataForm.tsx` — new: collection picker, artist, tags chip input, options checkboxes; calls commit
+- `apps/frontend/src/components/upload/FolderImport.tsx` — restyle: remove amber-/emerald- literals → semantic status colors
+- `apps/frontend/src/components/upload/RecentUploads.tsx` — restyle: remove amber-/emerald- literals → semantic status colors
+- `apps/frontend/src/components/upload/UploadProgress.tsx` — restyle: remove emerald- → semantic colors
+- `apps/frontend/src/components/upload/PatternBuilder.tsx` — no change unless amber-/emerald- found (check at end)
+- `apps/frontend/src/pages/UploadPage.tsx` — rebuild: two-column shell (UploadQueue rail + main area with DropZone + ReviewPane); keep FolderImport tab accessible
+
+---
+
+## Task 1: Update `src/api/models.ts` — scan upload + import session functions
+
+**Files:**
+- Modify: `apps/frontend/src/api/models.ts`
+
+- [ ] **Step 1: Read the current file** (already done in planning — summary: `uploadModel` returns `{ modelId }`, the `complete` step expects `{ modelId; jobId }`)
+
+- [ ] **Step 2: Replace `uploadModel` with `scanUpload` and add session API functions**
+
+Replace the entire `uploadModel` function and add the four import-session functions. The chunk init/chunk/complete mechanics stay the same; only the `complete` response type and return value change:
+
+```typescript
+import type {
+  ApiResponse,
+  ModelCard,
+  ModelDetail,
+  FileTreeNode,
+  JobStatus,
+  ModelSearchParams,
+  UpdateModelRequest,
+  ImportConfig,
+  ImportSession,
+  BatchUploadMetadata,
+  ScanUploadResponse,
+} from '@alexandria/shared';
+import { get, post, patch, del, putRaw } from './client';
+import { buildQueryString } from '../lib/query';
+
+export async function getModels(params: ModelSearchParams): Promise<ApiResponse<ModelCard[]>> {
+  const { metadataFilters, ...rest } = params;
+  const flat: Record<string, unknown> = { ...rest };
+
+  if (metadataFilters) {
+    for (const [key, value] of Object.entries(metadataFilters)) {
+      flat[`meta_${key}`] = value;
+    }
+  }
+
+  const qs = buildQueryString(flat);
+  return get<ModelCard[]>(`/models${qs}`);
+}
+
+export async function getModel(id: string): Promise<ModelDetail> {
+  const response = await get<ModelDetail>(`/models/${id}`);
+  return response.data;
+}
+
+export async function getModelFiles(id: string): Promise<FileTreeNode[]> {
+  const response = await get<FileTreeNode[]>(`/models/${id}/files`);
+  return response.data;
+}
+
+export async function getModelStatus(id: string): Promise<JobStatus> {
+  const response = await get<JobStatus>(`/models/${id}/status`);
+  return response.data;
+}
+
+export async function updateModel(id: string, data: UpdateModelRequest): Promise<ModelDetail> {
+  const response = await patch<ModelDetail>(`/models/${id}`, data);
+  return response.data;
+}
+
+export async function deleteModel(id: string): Promise<void> {
+  await del(`/models/${id}`);
+}
+
+const CHUNK_SIZE = 10 * 1024 * 1024; // 10MB
+const MAX_CHUNK_RETRIES = 3;
+
+/**
+ * Upload an archive file using chunked upload. Creates an import session
+ * (status: scanning) instead of immediately creating a model.
+ * Returns { sessionId } — poll the session to track scan progress.
+ */
+export async function scanUpload(
+  file: File,
+  onProgress?: (pct: number) => void
+): Promise<ScanUploadResponse> {
+  const totalChunks = Math.max(1, Math.ceil(file.size / CHUNK_SIZE));
+
+  // 1. Initiate chunked upload session
+  const initResponse = await post<{ uploadId: string; expiresAt: string }>(
+    '/models/upload/init',
+    { filename: file.name, totalSize: file.size, totalChunks },
+  );
+  const { uploadId } = initResponse.data;
+
+  // 2. Upload chunks sequentially with per-chunk retry
+  for (let i = 0; i < totalChunks; i++) {
+    const start = i * CHUNK_SIZE;
+    const end = Math.min(start + CHUNK_SIZE, file.size);
+    const chunk = file.slice(start, end);
+
+    let lastError: unknown;
+    for (let attempt = 0; attempt < MAX_CHUNK_RETRIES; attempt++) {
+      try {
+        await putRaw(
+          `/models/upload/${uploadId}/chunk/${i}`,
+          chunk,
+          (chunkPct) => {
+            if (onProgress) {
+              const chunkFraction = chunkPct / 100;
+              const overallPct = Math.round(((i + chunkFraction) / totalChunks) * 95);
+              onProgress(overallPct);
+            }
+          },
+        );
+        lastError = null;
+        break;
+      } catch (err) {
+        lastError = err;
+        if (attempt < MAX_CHUNK_RETRIES - 1) {
+          await new Promise((r) => setTimeout(r, 1000 * Math.pow(2, attempt)));
+        }
+      }
+    }
+    if (lastError) throw lastError;
+  }
+
+  onProgress?.(95);
+
+  // 3. Complete — assemble and start scan; returns { sessionId }
+  const completeResponse = await post<ScanUploadResponse>(
+    `/models/upload/${uploadId}/complete`,
+  );
+
+  onProgress?.(100);
+
+  return completeResponse.data;
+}
+
+export async function listImportSessions(): Promise<ImportSession[]> {
+  const response = await get<ImportSession[]>('/models/import-sessions');
+  return response.data;
+}
+
+export async function getImportSession(id: string): Promise<ImportSession> {
+  const response = await get<ImportSession>(`/models/import-sessions/${id}`);
+  return response.data;
+}
+
+export async function commitImportSession(
+  id: string,
+  batchMetadata?: BatchUploadMetadata
+): Promise<{ modelId: string; jobId: string }> {
+  const response = await post<{ modelId: string; jobId: string }>(
+    `/models/import-sessions/${id}/commit`,
+    batchMetadata ? { batchMetadata } : undefined
+  );
+  return response.data;
+}
+
+export async function discardImportSession(id: string): Promise<void> {
+  await del(`/models/import-sessions/${id}`);
+}
+
+export async function importFolder(config: ImportConfig): Promise<{ modelId: string }> {
+  const response = await post<{ modelId: string }>('/models/import', config);
+  return response.data;
+}
+```
+
+- [ ] **Step 3: Verify TypeScript compiles**
+
+```bash
+cd /Users/joseph/Projects/Alexandria/apps/frontend && npx tsc --noEmit 2>&1 | head -40
+```
+
+Expected: no errors related to `models.ts`. If `ScanUploadResponse` is missing from `@alexandria/shared`, check `packages/shared/src/types/upload.ts` — it is already defined there.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/joseph/Projects/Alexandria && git add apps/frontend/src/api/models.ts && git commit -m "feat(upload): update models API — scanUpload returns sessionId, add import-session functions"
+```
+
+---
+
+## Task 2: Create `src/hooks/use-import-sessions.ts`
+
+**Files:**
+- Create: `apps/frontend/src/hooks/use-import-sessions.ts`
+
+- [ ] **Step 1: Create the hook file**
+
+```typescript
+// apps/frontend/src/hooks/use-import-sessions.ts
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import type { BatchUploadMetadata, ImportSession } from '@alexandria/shared';
+import {
+  listImportSessions,
+  getImportSession,
+  commitImportSession,
+  discardImportSession,
+  scanUpload,
+} from '../api/models';
+
+const TERMINAL_STATUSES = new Set(['committed', 'error']);
+
+function isNonTerminal(session: ImportSession): boolean {
+  return !TERMINAL_STATUSES.has(session.status);
+}
+
+/**
+ * List all import sessions, polling every 2 s while any session is non-terminal.
+ */
+export function useImportSessions() {
+  return useQuery({
+    queryKey: ['import-sessions'],
+    queryFn: listImportSessions,
+    refetchInterval: (query) => {
+      const data = query.state.data;
+      if (!data) return 2000;
+      return data.some(isNonTerminal) ? 2000 : false;
+    },
+    staleTime: 0,
+  });
+}
+
+/**
+ * Single session, polling every 2 s while non-terminal.
+ */
+export function useImportSession(id: string | null) {
+  return useQuery({
+    queryKey: ['import-session', id],
+    queryFn: () => getImportSession(id!),
+    enabled: id !== null,
+    refetchInterval: (query) => {
+      const data = query.state.data;
+      if (!data) return 2000;
+      return isNonTerminal(data) ? 2000 : false;
+    },
+    staleTime: 0,
+  });
+}
+
+/**
+ * Upload a file, then invalidate the sessions list so the new session appears.
+ * Returns a mutation; call mutateAsync(file, { onProgress }) — progress is
+ * tracked via the onProgress arg passed to scanUpload.
+ */
+export function useStartScan() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      file,
+      onProgress,
+    }: {
+      file: File;
+      onProgress?: (pct: number) => void;
+    }) => scanUpload(file, onProgress),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['import-sessions'] });
+    },
+  });
+}
+
+/**
+ * Commit a ready_for_review session. Invalidates the session list and the
+ * individual session on success.
+ */
+export function useCommitSession() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      id,
+      batchMetadata,
+    }: {
+      id: string;
+      batchMetadata?: BatchUploadMetadata;
+    }) => commitImportSession(id, batchMetadata),
+    onSuccess: (_data, { id }) => {
+      queryClient.invalidateQueries({ queryKey: ['import-sessions'] });
+      queryClient.invalidateQueries({ queryKey: ['import-session', id] });
+    },
+  });
+}
+
+/**
+ * Discard (delete) a session. Removes it from the list immediately.
+ */
+export function useDiscardSession() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => discardImportSession(id),
+    onSuccess: (_data, id) => {
+      queryClient.invalidateQueries({ queryKey: ['import-sessions'] });
+      queryClient.removeQueries({ queryKey: ['import-session', id] });
+    },
+  });
+}
+```
+
+- [ ] **Step 2: Verify TypeScript**
+
+```bash
+cd /Users/joseph/Projects/Alexandria/apps/frontend && npx tsc --noEmit 2>&1 | head -40
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/joseph/Projects/Alexandria && git add apps/frontend/src/hooks/use-import-sessions.ts && git commit -m "feat(upload): add useImportSessions hook with polling and mutation helpers"
+```
+
+---
+
+## Task 3: Create `UploadQueue.tsx` — dark rail showing session list
+
+**Files:**
+- Create: `apps/frontend/src/components/upload/UploadQueue.tsx`
+
+- [ ] **Step 1: Create the component**
+
+```typescript
+// apps/frontend/src/components/upload/UploadQueue.tsx
+import { Loader2, CheckCircle2, AlertCircle, Archive, BookOpen } from 'lucide-react';
+import type { ImportSession } from '@alexandria/shared';
+import { formatFileSize } from '../../lib/format';
+import { cn } from '../../lib/utils';
+
+interface UploadQueueProps {
+  sessions: ImportSession[];
+  activeId: string | null;
+  onSelect: (id: string) => void;
+}
+
+function StatusIcon({ status }: { status: ImportSession['status'] }) {
+  const base = 'flex items-center justify-center rounded-md flex-shrink-0';
+  const size = 'w-[26px] h-[26px]';
+
+  if (status === 'error') {
+    return (
+      <span
+        className={cn(base, size)}
+        style={{ background: 'var(--ax-danger)', color: 'white' }}
+      >
+        <AlertCircle className="w-3 h-3" />
+      </span>
+    );
+  }
+  if (status === 'scanning') {
+    return (
+      <span
+        className={cn(base, size)}
+        style={{ background: 'var(--ax-warning)', color: 'white' }}
+      >
+        <Loader2 className="w-3 h-3 animate-spin" />
+      </span>
+    );
+  }
+  if (status === 'ready_for_review') {
+    return (
+      <span
+        className={cn(base, size)}
+        style={{ background: 'var(--ax-teal)', color: 'var(--ax-teal-fg)' }}
+      >
+        <Archive className="w-3 h-3" />
+      </span>
+    );
+  }
+  if (status === 'committing') {
+    return (
+      <span
+        className={cn(base, size)}
+        style={{ background: 'var(--ax-warning)', color: 'white' }}
+      >
+        <Loader2 className="w-3 h-3 animate-spin" />
+      </span>
+    );
+  }
+  // committed
+  return (
+    <span
+      className={cn(base, size)}
+      style={{ background: 'var(--ax-success)', color: 'white' }}
+    >
+      <CheckCircle2 className="w-3 h-3" />
+    </span>
+  );
+}
+
+function statusLabel(status: ImportSession['status']): string {
+  switch (status) {
+    case 'scanning': return 'Scanning…';
+    case 'ready_for_review': return 'Ready to review';
+    case 'committing': return 'Committing…';
+    case 'committed': return 'Committed';
+    case 'error': return 'Error';
+  }
+}
+
+export function UploadQueue({ sessions, activeId, onSelect }: UploadQueueProps) {
+  const totalSize = sessions.reduce((acc, s) => {
+    // Size is in detected metadata; fall back to 0 if not yet scanned
+    return acc + (s.detected?.totalSizeBytes ?? 0);
+  }, 0);
+  const errorCount = sessions.filter((s) => s.status === 'error').length;
+  const queuedCount = sessions.filter(
+    (s) => s.status === 'scanning' || s.status === 'ready_for_review'
+  ).length;
+
+  return (
+    <aside
+      className="flex flex-col h-screen flex-shrink-0"
+      style={{
+        width: 300,
+        background: 'var(--ax-rail)',
+        color: 'var(--ax-rail-fg)',
+        borderRight: '1px solid var(--ax-rail-border)',
+      }}
+    >
+      {/* Header */}
+      <div
+        className="flex-shrink-0 px-4 py-3.5"
+        style={{ borderBottom: '1px solid var(--ax-rail-border)' }}
+      >
+        <div className="flex items-center gap-2">
+          <BookOpen className="h-4 w-4 flex-shrink-0" style={{ color: 'var(--ax-amber)' }} />
+          <span
+            className="font-semibold text-sm truncate"
+            style={{ color: 'var(--ax-rail-fg)' }}
+          >
+            Alexandria
+          </span>
+          <span
+            className="ax-mono ml-auto text-[11px]"
+            style={{ color: 'var(--ax-rail-fg-muted)' }}
+          >
+            upload
+          </span>
+        </div>
+      </div>
+
+      {/* Queue label */}
+      <div
+        className="flex items-center justify-between px-3 pt-3.5 pb-2"
+      >
+        <span
+          className="text-[11px] font-semibold uppercase tracking-wider"
+          style={{ color: 'var(--ax-rail-fg-muted)', letterSpacing: '0.06em' }}
+        >
+          Upload queue
+        </span>
+        <span className="ax-mono text-[11px]" style={{ color: 'var(--ax-rail-fg-muted)' }}>
+          {sessions.length}
+        </span>
+      </div>
+
+      {/* Session list */}
+      <div className="ax-scroll flex-1 overflow-y-auto px-2 pb-3">
+        {sessions.length === 0 && (
+          <p
+            className="text-[12px] text-center py-8"
+            style={{ color: 'var(--ax-rail-fg-muted)' }}
+          >
+            No uploads yet. Drop an archive to start.
+          </p>
+        )}
+        {sessions.map((session) => {
+          const active = session.id === activeId;
+          return (
+            <button
+              key={session.id}
+              onClick={() => onSelect(session.id)}
+              className="flex flex-col gap-1.5 w-full text-left px-3 py-2.5 rounded-lg mt-1 transition-colors"
+              style={{
+                background: active ? 'var(--ax-rail-elev)' : 'transparent',
+                border: `1px solid ${active ? 'var(--ax-rail-border)' : 'transparent'}`,
+                color: 'inherit',
+                fontFamily: 'inherit',
+                cursor: 'pointer',
+              }}
+            >
+              <div className="flex items-center gap-2">
+                <StatusIcon status={session.status} />
+                <div className="flex-1 min-w-0">
+                  <div
+                    className="ax-code text-[12px] font-medium truncate"
+                    style={{ color: 'var(--ax-rail-fg)' }}
+                  >
+                    {session.originalFilename}
+                  </div>
+                  <div
+                    className="ax-mono text-[11px]"
+                    style={{ color: 'var(--ax-rail-fg-muted)' }}
+                  >
+                    {session.detected
+                      ? `${formatFileSize(session.detected.totalSizeBytes)} · ${session.detected.fileCount} files`
+                      : statusLabel(session.status)}
+                  </div>
+                </div>
+              </div>
+              {session.status === 'error' && session.error && (
+                <div className="text-[10.5px] pl-[34px]" style={{ color: '#fca5a5' }}>
+                  {session.error}
+                </div>
+              )}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Stats footer */}
+      <div
+        className="flex-shrink-0 grid grid-cols-2 gap-3 px-4 py-3"
+        style={{ borderTop: '1px solid var(--ax-rail-border)' }}
+      >
+        <StatCell label="Queued" value={String(queuedCount)} />
+        <StatCell label="Total size" value={totalSize > 0 ? formatFileSize(totalSize) : '—'} />
+        <StatCell
+          label="Errors"
+          value={String(errorCount)}
+          danger={errorCount > 0}
+        />
+        <StatCell label="Done" value={String(sessions.filter((s) => s.status === 'committed').length)} />
+      </div>
+    </aside>
+  );
+}
+
+function StatCell({
+  label,
+  value,
+  danger,
+}: {
+  label: string;
+  value: string;
+  danger?: boolean;
+}) {
+  return (
+    <div>
+      <div
+        className="ax-mono text-[17px] font-bold"
+        style={{
+          color: danger ? '#fca5a5' : 'var(--ax-rail-fg)',
+          letterSpacing: '-0.01em',
+        }}
+      >
+        {value}
+      </div>
+      <div
+        className="text-[10px] font-semibold uppercase mt-0.5"
+        style={{
+          color: 'var(--ax-rail-fg-muted)',
+          letterSpacing: '0.06em',
+        }}
+      >
+        {label}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verify TypeScript**
+
+```bash
+cd /Users/joseph/Projects/Alexandria/apps/frontend && npx tsc --noEmit 2>&1 | head -40
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/joseph/Projects/Alexandria && git add apps/frontend/src/components/upload/UploadQueue.tsx && git commit -m "feat(upload): add UploadQueue rail component with session status chips and stats footer"
+```
+
+---
+
+## Task 4: Create `BatchMetadataForm.tsx`
+
+**Files:**
+- Create: `apps/frontend/src/components/upload/BatchMetadataForm.tsx`
+
+- [ ] **Step 1: Create the component**
+
+This component receives `detected` metadata for pre-fill, a `sessionId`, and a `onCommitted` callback. It queries collections via `getCollections`, builds `BatchUploadMetadata`, and calls the commit mutation.
+
+```typescript
+// apps/frontend/src/components/upload/BatchMetadataForm.tsx
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Loader2, X, Plus, FolderOpen, User, Tag } from 'lucide-react';
+import type { DetectedImportMetadata, BatchUploadMetadata } from '@alexandria/shared';
+import { getCollections } from '../../api/collections';
+import { useCommitSession } from '../../hooks/use-import-sessions';
+import { Button } from '../ui/button';
+import { Input } from '../ui/input';
+import { Label } from '../ui/label';
+import { Checkbox } from '../ui/checkbox';
+
+interface BatchMetadataFormProps {
+  sessionId: string;
+  detected: DetectedImportMetadata;
+  onCommitted: (modelId: string) => void;
+}
+
+interface FormState {
+  collectionId: string;
+  newCollectionName: string;
+  artist: string;
+  tags: string[];
+  tagInput: string;
+  markPreSupported: boolean;
+  autoThumbnails: boolean;
+  markNsfw: boolean;
+  skipDuplicatesByHash: boolean;
+}
+
+export function BatchMetadataForm({ sessionId, detected, onCommitted }: BatchMetadataFormProps) {
+  const [form, setForm] = useState<FormState>({
+    collectionId: '',
+    newCollectionName: '',
+    artist: detected.artist ?? '',
+    tags: [...detected.tagsGuessed],
+    tagInput: '',
+    markPreSupported: false,
+    autoThumbnails: true,
+    markNsfw: false,
+    skipDuplicatesByHash: true,
+  });
+
+  const { data: collectionsResponse } = useQuery({
+    queryKey: ['collections'],
+    queryFn: () => getCollections({ depth: 1 }),
+    staleTime: 30_000,
+  });
+  const collections = collectionsResponse?.data ?? [];
+
+  const commitMutation = useCommitSession();
+
+  function addTag(tag: string) {
+    const t = tag.trim();
+    if (t && !form.tags.includes(t)) {
+      setForm((f) => ({ ...f, tags: [...f.tags, t], tagInput: '' }));
+    } else {
+      setForm((f) => ({ ...f, tagInput: '' }));
+    }
+  }
+
+  function removeTag(tag: string) {
+    setForm((f) => ({ ...f, tags: f.tags.filter((t) => t !== tag) }));
+  }
+
+  async function handleSubmit() {
+    const batchMetadata: BatchUploadMetadata = {
+      ...(form.collectionId ? { collectionId: form.collectionId } : {}),
+      ...(form.newCollectionName.trim() ? { newCollectionName: form.newCollectionName.trim() } : {}),
+      ...(form.artist.trim() ? { artist: form.artist.trim() } : {}),
+      ...(form.tags.length > 0 ? { tags: form.tags } : {}),
+      options: {
+        markPreSupported: form.markPreSupported,
+        autoThumbnails: form.autoThumbnails,
+        markNsfw: form.markNsfw,
+        skipDuplicatesByHash: form.skipDuplicatesByHash,
+      },
+    };
+
+    try {
+      const result = await commitMutation.mutateAsync({ id: sessionId, batchMetadata });
+      onCommitted(result.modelId);
+    } catch {
+      // Error surfaces via commitMutation.error
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Destination collection */}
+      <FormSection label="Destination collection">
+        {collections.length > 0 ? (
+          <select
+            value={form.collectionId}
+            onChange={(e) => setForm((f) => ({ ...f, collectionId: e.target.value, newCollectionName: '' }))}
+            className="w-full rounded-lg px-3 py-2 text-[13px]"
+            style={{
+              background: 'var(--ax-bg-elev)',
+              border: '1px solid var(--ax-border)',
+              color: 'var(--ax-fg)',
+              fontFamily: 'inherit',
+            }}
+          >
+            <option value="">— None —</option>
+            {collections.map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.name}
+              </option>
+            ))}
+            <option value="__new__">+ New collection…</option>
+          </select>
+        ) : (
+          <select
+            value={form.collectionId}
+            onChange={(e) => setForm((f) => ({ ...f, collectionId: e.target.value }))}
+            className="w-full rounded-lg px-3 py-2 text-[13px]"
+            style={{
+              background: 'var(--ax-bg-elev)',
+              border: '1px solid var(--ax-border)',
+              color: 'var(--ax-fg)',
+              fontFamily: 'inherit',
+            }}
+          >
+            <option value="">— No collections yet —</option>
+            <option value="__new__">+ New collection…</option>
+          </select>
+        )}
+        {(form.collectionId === '__new__') && (
+          <div className="flex items-center gap-2 mt-2">
+            <FolderOpen className="h-4 w-4 flex-shrink-0" style={{ color: 'var(--ax-amber)' }} />
+            <Input
+              placeholder="New collection name"
+              value={form.newCollectionName}
+              onChange={(e) => setForm((f) => ({ ...f, newCollectionName: e.target.value }))}
+              className="text-[13px]"
+            />
+          </div>
+        )}
+      </FormSection>
+
+      {/* Artist */}
+      <FormSection
+        label={
+          <span>
+            Artist
+            {detected.artist && (
+              <span
+                className="ml-2 font-normal text-[11px]"
+                style={{ color: 'var(--ax-fg-subtle)' }}
+              >
+                auto-detected
+              </span>
+            )}
+          </span>
+        }
+      >
+        <div className="flex items-center gap-2">
+          <User className="h-4 w-4 flex-shrink-0" style={{ color: 'var(--ax-fg-muted)' }} />
+          <Input
+            value={form.artist}
+            onChange={(e) => setForm((f) => ({ ...f, artist: e.target.value }))}
+            placeholder="Artist name (optional)"
+            className="text-[13px]"
+          />
+        </div>
+      </FormSection>
+
+      {/* Tags */}
+      <FormSection label="Tags to apply to all">
+        <div
+          className="flex flex-wrap gap-1.5 p-2.5 rounded-lg min-h-[40px]"
+          style={{
+            background: 'var(--ax-bg-elev)',
+            border: '1px solid var(--ax-border)',
+          }}
+        >
+          {form.tags.map((tag) => (
+            <span
+              key={tag}
+              className="ax-chip ax-chip-amber flex items-center gap-1"
+              style={{ height: 22 }}
+            >
+              <Tag className="w-2.5 h-2.5" />
+              {tag}
+              <button
+                type="button"
+                onClick={() => removeTag(tag)}
+                className="ml-0.5 hover:opacity-70"
+                aria-label={`Remove tag ${tag}`}
+              >
+                <X className="w-2.5 h-2.5" />
+              </button>
+            </span>
+          ))}
+          <input
+            value={form.tagInput}
+            onChange={(e) => setForm((f) => ({ ...f, tagInput: e.target.value }))}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ',') {
+                e.preventDefault();
+                addTag(form.tagInput);
+              }
+            }}
+            placeholder={form.tags.length === 0 ? 'Type a tag and press Enter…' : '+ tag'}
+            className="bg-transparent text-[12px] outline-none flex-1 min-w-[80px] placeholder:text-[var(--ax-fg-muted)]"
+            style={{ color: 'var(--ax-fg)', fontFamily: 'inherit' }}
+          />
+        </div>
+        <p className="text-[11.5px] mt-1.5" style={{ color: 'var(--ax-fg-muted)' }}>
+          Inferred from filenames + folder paths. Press Enter or comma to add.
+        </p>
+      </FormSection>
+
+      {/* Options */}
+      <FormSection label="Options">
+        <div className="flex flex-col gap-1">
+          <OptionCheck
+            id="pre-supported"
+            label="Mark all as pre-supported"
+            checked={form.markPreSupported}
+            onChange={(v) => setForm((f) => ({ ...f, markPreSupported: v }))}
+          />
+          <OptionCheck
+            id="auto-thumbnails"
+            label="Auto-generate thumbnails"
+            checked={form.autoThumbnails}
+            onChange={(v) => setForm((f) => ({ ...f, autoThumbnails: v }))}
+            note="Always runs during ingestion"
+          />
+          <OptionCheck
+            id="mark-nsfw"
+            label="Mark as NSFW"
+            checked={form.markNsfw}
+            onChange={(v) => setForm((f) => ({ ...f, markNsfw: v }))}
+          />
+          <OptionCheck
+            id="skip-dupes"
+            label="Skip duplicates (by hash)"
+            checked={form.skipDuplicatesByHash}
+            onChange={(v) => setForm((f) => ({ ...f, skipDuplicatesByHash: v }))}
+          />
+        </div>
+      </FormSection>
+
+      {/* Commit action */}
+      {commitMutation.error && (
+        <div
+          className="flex items-center gap-2 rounded-lg px-3 py-2.5 text-[13px]"
+          style={{
+            background: 'color-mix(in srgb, var(--ax-danger) 10%, transparent)',
+            border: '1px solid var(--ax-danger)',
+            color: 'var(--ax-danger)',
+          }}
+        >
+          {commitMutation.error instanceof Error
+            ? commitMutation.error.message
+            : 'Commit failed. Please try again.'}
+        </div>
+      )}
+
+      <Button
+        onClick={handleSubmit}
+        disabled={commitMutation.isPending}
+        className="w-full font-semibold"
+        style={{
+          background: 'var(--ax-amber)',
+          color: 'var(--ax-amber-fg)',
+          border: 'none',
+        }}
+      >
+        {commitMutation.isPending && <Loader2 className="h-4 w-4 animate-spin mr-2" />}
+        Import {detected.modelCount > 0 ? `${detected.modelCount} models` : 'archive'}
+      </Button>
+    </div>
+  );
+}
+
+function FormSection({
+  label,
+  children,
+}: {
+  label: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <Label
+        className="block text-[11px] font-semibold uppercase mb-1.5"
+        style={{
+          color: 'var(--ax-fg-muted)',
+          letterSpacing: '0.06em',
+        }}
+      >
+        {label}
+      </Label>
+      {children}
+    </div>
+  );
+}
+
+function OptionCheck({
+  id,
+  label,
+  checked,
+  onChange,
+  note,
+}: {
+  id: string;
+  label: string;
+  checked: boolean;
+  onChange: (v: boolean) => void;
+  note?: string;
+}) {
+  return (
+    <label
+      htmlFor={id}
+      className="flex items-center gap-2.5 py-1.5 px-1 cursor-pointer rounded"
+    >
+      <Checkbox
+        id={id}
+        checked={checked}
+        onCheckedChange={(c) => onChange(c === true)}
+      />
+      <span className="text-[12.5px]" style={{ color: checked ? 'var(--ax-fg)' : 'var(--ax-fg-muted)' }}>
+        {label}
+        {note && (
+          <span className="ml-1.5 text-[11px]" style={{ color: 'var(--ax-fg-subtle)' }}>
+            ({note})
+          </span>
+        )}
+      </span>
+    </label>
+  );
+}
+```
+
+- [ ] **Step 2: Verify TypeScript**
+
+```bash
+cd /Users/joseph/Projects/Alexandria/apps/frontend && npx tsc --noEmit 2>&1 | head -40
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/joseph/Projects/Alexandria && git add apps/frontend/src/components/upload/BatchMetadataForm.tsx && git commit -m "feat(upload): add BatchMetadataForm with collection picker, artist, tags, and options"
+```
+
+---
+
+## Task 5: Create `ReviewPane.tsx`
+
+**Files:**
+- Create: `apps/frontend/src/components/upload/ReviewPane.tsx`
+
+- [ ] **Step 1: Create the component**
+
+ReviewPane renders by `session.status`. For `ready_for_review`, it shows the detected folder structure tree and `BatchMetadataForm` side by side. For `committing`/`committed`, it polls model status via `UploadProgress`. For `error`, shows danger card + Retry/Discard.
+
+```typescript
+// apps/frontend/src/components/upload/ReviewPane.tsx
+import { Loader2, AlertCircle, Folder, FileCode2, File, Package } from 'lucide-react';
+import { Link } from 'react-router-dom';
+import type { ImportSession, DetectedFolderNode } from '@alexandria/shared';
+import { BatchMetadataForm } from './BatchMetadataForm';
+import { UploadProgress } from './UploadProgress';
+import { Button } from '../ui/button';
+import { formatFileSize } from '../../lib/format';
+
+interface ReviewPaneProps {
+  session: ImportSession;
+  onCommitted: (modelId: string) => void;
+  onDiscard: () => void;
+  onRetry: () => void;
+}
+
+export function ReviewPane({ session, onCommitted, onDiscard, onRetry }: ReviewPaneProps) {
+  if (session.status === 'scanning') {
+    return (
+      <div className="flex flex-col items-center justify-center py-20 gap-5">
+        <div
+          className="flex items-center justify-center rounded-2xl"
+          style={{
+            width: 64,
+            height: 64,
+            background: 'var(--ax-amber-tint)',
+            color: 'var(--ax-amber-tint-fg)',
+          }}
+        >
+          <Loader2 className="h-7 w-7 animate-spin" />
+        </div>
+        <div className="text-center">
+          <h2
+            className="text-xl font-bold"
+            style={{ color: 'var(--ax-fg)' }}
+          >
+            Scanning archive…
+          </h2>
+          <p className="mt-1.5 text-[13px]" style={{ color: 'var(--ax-fg-muted)' }}>
+            Extracting, detecting folder structure and metadata
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  if (session.status === 'error') {
+    return (
+      <div
+        className="flex gap-4 rounded-xl p-8"
+        style={{
+          background: 'var(--ax-bg-elev)',
+          border: '1px solid var(--ax-danger)',
+        }}
+      >
+        <div
+          className="flex items-center justify-center rounded-xl flex-shrink-0"
+          style={{
+            width: 48,
+            height: 48,
+            background: 'color-mix(in srgb, var(--ax-danger) 12%, transparent)',
+            color: 'var(--ax-danger)',
+          }}
+        >
+          <AlertCircle className="h-6 w-6" />
+        </div>
+        <div className="flex-1">
+          <h2 className="text-[18px] font-semibold" style={{ color: 'var(--ax-fg)' }}>
+            Couldn't process this archive
+          </h2>
+          <p className="mt-1.5 mb-4 text-[13px]" style={{ color: 'var(--ax-fg-muted)' }}>
+            {session.error ?? 'An unknown error occurred during scanning.'}
+          </p>
+          <div className="flex gap-2">
+            <Button variant="outline" size="sm" onClick={onRetry}>
+              Retry upload
+            </Button>
+            <Button variant="outline" size="sm" onClick={onDiscard}>
+              Discard
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (session.status === 'committing' || session.status === 'committed') {
+    const modelId = session.modelId;
+    return (
+      <div className="flex flex-col items-center justify-center py-20 gap-5">
+        <div
+          className="flex items-center justify-center rounded-2xl"
+          style={{
+            width: 64,
+            height: 64,
+            background: 'var(--ax-teal-tint)',
+            color: 'var(--ax-teal-tint-fg)',
+          }}
+        >
+          <Package className="h-7 w-7" />
+        </div>
+        <div className="text-center max-w-sm">
+          <h2 className="text-xl font-bold" style={{ color: 'var(--ax-fg)' }}>
+            {session.status === 'committing' ? 'Importing…' : 'Imported!'}
+          </h2>
+          <p className="mt-1.5 text-[13px]" style={{ color: 'var(--ax-fg-muted)' }}>
+            {session.status === 'committing'
+              ? 'Your archive is being processed. This may take a moment.'
+              : 'Archive committed. Processing the model now.'}
+          </p>
+        </div>
+        {modelId && (
+          <div className="w-full max-w-sm">
+            <UploadProgress modelId={modelId} />
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  // ready_for_review
+  const { detected } = session;
+  if (!detected) {
+    // Shouldn't happen — status is ready_for_review but detected is null
+    return (
+      <div className="py-12 text-center text-[13px]" style={{ color: 'var(--ax-fg-muted)' }}>
+        Detected metadata unavailable. Try discarding and re-uploading.
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="grid gap-6"
+      style={{ gridTemplateColumns: '1.4fr 1fr' }}
+    >
+      {/* Left: folder structure + counts */}
+      <div>
+        <div className="flex items-baseline justify-between mb-2.5">
+          <h2 className="text-[16px] font-bold" style={{ color: 'var(--ax-fg)' }}>
+            {detected.modelCount} model{detected.modelCount !== 1 ? 's' : ''} detected
+          </h2>
+          <span className="ax-mono text-[12px]" style={{ color: 'var(--ax-fg-muted)' }}>
+            {detected.fileCount} files · {formatFileSize(detected.totalSizeBytes)}
+          </span>
+        </div>
+
+        <h3
+          className="text-[13px] font-semibold mb-2"
+          style={{ color: 'var(--ax-fg)' }}
+        >
+          Detected folder structure
+        </h3>
+        <div
+          className="ax-code rounded-xl p-3.5 text-[12px] leading-relaxed overflow-auto max-h-80"
+          style={{
+            background: 'var(--ax-bg-elev)',
+            border: '1px solid var(--ax-border)',
+            lineHeight: '1.7',
+          }}
+        >
+          {detected.folderStructure.length === 0 ? (
+            <span style={{ color: 'var(--ax-fg-muted)' }}>No folder structure detected</span>
+          ) : (
+            <FolderTree nodes={detected.folderStructure} depth={0} maxDepth={4} />
+          )}
+        </div>
+      </div>
+
+      {/* Right: batch metadata form */}
+      <BatchMetadataForm
+        sessionId={session.id}
+        detected={detected}
+        onCommitted={onCommitted}
+      />
+    </div>
+  );
+}
+
+function FolderTree({
+  nodes,
+  depth,
+  maxDepth,
+}: {
+  nodes: DetectedFolderNode[];
+  depth: number;
+  maxDepth: number;
+}) {
+  if (depth > maxDepth) {
+    return (
+      <div
+        style={{ paddingLeft: depth * 16, color: 'var(--ax-fg-muted)' }}
+        className="flex items-center gap-1.5"
+      >
+        <span>…</span>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      {nodes.map((node, i) => (
+        <div key={i}>
+          <div
+            style={{
+              paddingLeft: depth * 16,
+              color: node.type === 'folder' ? 'var(--ax-fg)' : 'var(--ax-fg-muted)',
+            }}
+            className="flex items-center gap-1.5"
+          >
+            {node.type === 'folder' ? (
+              <Folder className="w-3 h-3 flex-shrink-0" style={{ color: 'var(--ax-amber)' }} />
+            ) : node.fileType === 'stl' ? (
+              <FileCode2 className="w-3 h-3 flex-shrink-0" />
+            ) : (
+              <File className="w-3 h-3 flex-shrink-0" />
+            )}
+            <span>{node.name}</span>
+          </div>
+          {node.children && node.children.length > 0 && (
+            <FolderTree nodes={node.children} depth={depth + 1} maxDepth={maxDepth} />
+          )}
+        </div>
+      ))}
+    </>
+  );
+}
+```
+
+- [ ] **Step 2: Verify TypeScript**
+
+```bash
+cd /Users/joseph/Projects/Alexandria/apps/frontend && npx tsc --noEmit 2>&1 | head -40
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/joseph/Projects/Alexandria && git add apps/frontend/src/components/upload/ReviewPane.tsx && git commit -m "feat(upload): add ReviewPane rendering scan/review/commit/error states + folder tree"
+```
+
+---
+
+## Task 6: Restyle `DropZone.tsx`
+
+The new DropZone is compact when sessions exist (collapsed banner) and accepts multiple files. Each dropped archive calls `scanUpload` immediately and appears in the queue. Per-file upload progress shown inline.
+
+**Files:**
+- Modify: `apps/frontend/src/components/upload/DropZone.tsx`
+
+- [ ] **Step 1: Rewrite DropZone**
+
+```typescript
+// apps/frontend/src/components/upload/DropZone.tsx
+import { useCallback, useRef, useState } from 'react';
+import { UploadCloud, FolderOpen } from 'lucide-react';
+import { SUPPORTED_ARCHIVE_EXTENSIONS } from '@alexandria/shared';
+import { useStartScan } from '../../hooks/use-import-sessions';
+import { formatFileSize } from '../../lib/format';
+import { cn } from '../../lib/utils';
+
+interface FileUploadState {
+  file: File;
+  pct: number;
+  error: string | null;
+}
+
+interface DropZoneProps {
+  /** When true, render the compact "drop more" banner instead of the full drop zone */
+  compact?: boolean;
+  onBrowseFolder?: () => void;
+}
+
+export function DropZone({ compact = false, onBrowseFolder }: DropZoneProps) {
+  const [isDragging, setIsDragging] = useState(false);
+  const [uploading, setUploading] = useState<FileUploadState[]>([]);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const startScan = useStartScan();
+
+  const isValidArchive = (file: File) => {
+    const lower = file.name.toLowerCase();
+    return SUPPORTED_ARCHIVE_EXTENSIONS.some((ext) => lower.endsWith(ext));
+  };
+
+  const enqueueFile = useCallback(
+    (file: File) => {
+      if (!isValidArchive(file)) return;
+
+      const entry: FileUploadState = { file, pct: 0, error: null };
+      setUploading((prev) => [...prev, entry]);
+
+      startScan.mutate(
+        {
+          file,
+          onProgress: (pct) => {
+            setUploading((prev) =>
+              prev.map((e) => (e.file === file ? { ...e, pct } : e))
+            );
+          },
+        },
+        {
+          onError: (err) => {
+            const msg = err instanceof Error ? err.message : 'Upload failed';
+            setUploading((prev) =>
+              prev.map((e) =>
+                e.file === file ? { ...e, error: msg } : e
+              )
+            );
+          },
+          onSuccess: () => {
+            // Remove from local uploading list once session exists in the queue
+            setUploading((prev) => prev.filter((e) => e.file !== file));
+          },
+        }
+      );
+    },
+    [startScan]
+  );
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      setIsDragging(false);
+      Array.from(e.dataTransfer.files).forEach(enqueueFile);
+    },
+    [enqueueFile]
+  );
+
+  const handleDragOver = (e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragging(true);
+  };
+
+  const handleDragLeave = () => setIsDragging(false);
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    Array.from(e.target.files ?? []).forEach(enqueueFile);
+    e.target.value = '';
+  };
+
+  if (compact) {
+    return (
+      <div
+        onDrop={handleDrop}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        className={cn(
+          'flex items-center gap-3.5 rounded-xl p-3.5 mx-7 mt-4 transition-colors',
+          isDragging && 'ring-2 ring-[var(--ax-amber)]'
+        )}
+        style={{
+          background: 'var(--ax-bg-elev)',
+          border: '1px dashed var(--ax-border-strong)',
+        }}
+      >
+        <div
+          className="flex items-center justify-center rounded-xl flex-shrink-0"
+          style={{
+            width: 38,
+            height: 38,
+            background: 'var(--ax-amber-tint)',
+            color: 'var(--ax-amber-tint-fg)',
+          }}
+        >
+          <UploadCloud className="h-[18px] w-[18px]" />
+        </div>
+        <div className="flex-1 min-w-0">
+          <p className="text-[13px] font-semibold" style={{ color: 'var(--ax-fg)' }}>
+            Drop more archives anywhere
+          </p>
+          <p className="text-[12px]" style={{ color: 'var(--ax-fg-muted)' }}>
+            .zip, .rar, .7z, .tar.gz — multiple files OK
+          </p>
+        </div>
+        <div className="flex gap-2 flex-shrink-0">
+          <button
+            type="button"
+            onClick={() => inputRef.current?.click()}
+            className="ax-chip hover:opacity-80 transition-opacity cursor-pointer"
+          >
+            Browse files
+          </button>
+          {onBrowseFolder && (
+            <button
+              type="button"
+              onClick={onBrowseFolder}
+              className="ax-chip hover:opacity-80 transition-opacity cursor-pointer"
+            >
+              <FolderOpen className="w-3 h-3" />
+              Server folder
+            </button>
+          )}
+        </div>
+        <input
+          ref={inputRef}
+          type="file"
+          multiple
+          accept=".zip,.rar,.7z,.tar.gz,.tgz"
+          className="sr-only"
+          onChange={handleInputChange}
+          tabIndex={-1}
+        />
+      </div>
+    );
+  }
+
+  // Full drop zone (when no sessions yet)
+  return (
+    <div className="space-y-3">
+      <div
+        onDrop={handleDrop}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onClick={() => inputRef.current?.click()}
+        className={cn(
+          'flex flex-col items-center justify-center gap-4 rounded-xl border-2 border-dashed p-16 cursor-pointer transition-colors',
+          isDragging
+            ? 'border-[var(--ax-amber)] bg-[var(--ax-amber-tint)]'
+            : 'border-[var(--ax-border-strong)] hover:border-[var(--ax-amber)] hover:bg-[var(--ax-bg-elev)]'
+        )}
+        role="button"
+        tabIndex={0}
+        aria-label="Upload archive files"
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') inputRef.current?.click();
+        }}
+      >
+        <UploadCloud
+          className="h-12 w-12 transition-colors"
+          style={{ color: isDragging ? 'var(--ax-amber)' : 'var(--ax-fg-muted)' }}
+        />
+        <div className="text-center space-y-1">
+          <p className="text-base font-semibold" style={{ color: 'var(--ax-fg)' }}>
+            Drag &amp; drop archives here, or click to browse
+          </p>
+          <p className="text-sm" style={{ color: 'var(--ax-fg-muted)' }}>
+            Supports .zip, .rar, .7z, .tar.gz — drop multiple files at once
+          </p>
+        </div>
+        <input
+          ref={inputRef}
+          type="file"
+          multiple
+          accept=".zip,.rar,.7z,.tar.gz,.tgz,application/zip,application/x-rar-compressed,application/x-7z-compressed,application/x-tar"
+          className="sr-only"
+          onChange={handleInputChange}
+          tabIndex={-1}
+        />
+      </div>
+
+      {/* In-flight upload progress rows */}
+      {uploading.length > 0 && (
+        <div className="space-y-2">
+          {uploading.map((entry, i) => (
+            <UploadRow key={i} entry={entry} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function UploadRow({ entry }: { entry: FileUploadState }) {
+  return (
+    <div
+      className="rounded-lg px-4 py-3 space-y-2"
+      style={{
+        background: 'var(--ax-bg-elev)',
+        border: entry.error
+          ? '1px solid var(--ax-danger)'
+          : '1px solid var(--ax-border)',
+      }}
+    >
+      <div className="flex items-center justify-between gap-2">
+        <span
+          className="ax-code text-[12px] truncate"
+          style={{ color: 'var(--ax-fg)' }}
+        >
+          {entry.file.name}
+        </span>
+        <span className="ax-mono text-[11px] flex-shrink-0" style={{ color: 'var(--ax-fg-muted)' }}>
+          {formatFileSize(entry.file.size)}
+        </span>
+      </div>
+      {entry.error ? (
+        <p className="text-[11.5px]" style={{ color: 'var(--ax-danger)' }}>
+          {entry.error}
+        </p>
+      ) : (
+        <div className="flex items-center gap-2">
+          <div
+            className="flex-1 h-1.5 rounded-full overflow-hidden"
+            style={{ background: 'var(--ax-bg-sunk)' }}
+          >
+            <div
+              className="h-full rounded-full transition-all duration-200"
+              style={{
+                width: `${entry.pct}%`,
+                background: 'var(--ax-amber)',
+              }}
+            />
+          </div>
+          <span className="ax-mono text-[11px] flex-shrink-0" style={{ color: 'var(--ax-fg-muted)' }}>
+            {entry.pct}%
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verify TypeScript**
+
+```bash
+cd /Users/joseph/Projects/Alexandria/apps/frontend && npx tsc --noEmit 2>&1 | head -40
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/joseph/Projects/Alexandria && git add apps/frontend/src/components/upload/DropZone.tsx && git commit -m "feat(upload): restyle DropZone — multi-file, compact mode, per-file progress, token colors"
+```
+
+---
+
+## Task 7: Restyle `UploadProgress.tsx`, `RecentUploads.tsx`, `FolderImport.tsx` — remove amber-/emerald-
+
+**Files:**
+- Modify: `apps/frontend/src/components/upload/UploadProgress.tsx`
+- Modify: `apps/frontend/src/components/upload/RecentUploads.tsx`
+- Modify: `apps/frontend/src/components/upload/FolderImport.tsx`
+
+- [ ] **Step 1: Fix UploadProgress.tsx — replace `text-emerald-*` with semantic tokens**
+
+Find `text-emerald-600 dark:text-emerald-500` in UploadProgress and replace with inline style using `var(--ax-success)`:
+
+```typescript
+// Replace the "ready" state JSX in UploadProgress:
+      <div className="flex items-center gap-2 text-sm" style={{ color: 'var(--ax-success)' }}>
+        <CheckCircle2 className="h-4 w-4 shrink-0" />
+        <span>Model is ready.</span>
+      </div>
+```
+
+The full updated file:
+
+```typescript
+import { useEffect } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Link } from 'react-router-dom';
+import { Loader2, CheckCircle2, AlertCircle, ArrowRight } from 'lucide-react';
+import { getModelStatus } from '../../api/models';
+import type { JobStatus } from '@alexandria/shared';
+
+interface UploadProgressProps {
+  modelId: string;
+}
+
+function statusLabel(status: JobStatus['status'], progress: number | null): string {
+  if (status === 'error') return 'Processing failed';
+  if (status === 'ready') return 'Done!';
+  if (progress === null || progress === 0) return 'Processing...';
+  if (progress < 40) return 'Extracting files...';
+  if (progress < 70) return 'Classifying files...';
+  if (progress < 90) return 'Generating thumbnails...';
+  return 'Finishing up...';
+}
+
+export function UploadProgress({ modelId }: UploadProgressProps) {
+  const { data: status, error } = useQuery({
+    queryKey: ['model-status', modelId],
+    queryFn: () => getModelStatus(modelId),
+    refetchInterval: (query) => {
+      const data = query.state.data;
+      if (!data) return 2000;
+      if (data.status === 'ready' || data.status === 'error') return false;
+      return 2000;
+    },
+    staleTime: 0,
+  });
+
+  const progress = status?.progress ?? null;
+  const pct = typeof progress === 'number' ? progress : 0;
+  const isIndeterminate = progress === null && status?.status === 'processing';
+
+  if (error) {
+    return (
+      <div className="flex items-center gap-2 text-sm text-destructive">
+        <AlertCircle className="h-4 w-4 shrink-0" />
+        <span>Could not fetch processing status.</span>
+      </div>
+    );
+  }
+
+  if (!status) {
+    return (
+      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        <Loader2 className="h-4 w-4 animate-spin shrink-0" />
+        <span>Loading status...</span>
+      </div>
+    );
+  }
+
+  if (status.status === 'error') {
+    return (
+      <div className="space-y-2">
+        <div className="flex items-center gap-2 text-sm text-destructive">
+          <AlertCircle className="h-4 w-4 shrink-0" />
+          <span>{status.error ?? 'Processing failed with an unknown error.'}</span>
+        </div>
+        <Link
+          to={`/models/${modelId}`}
+          className="text-sm text-primary hover:underline inline-flex items-center gap-1"
+        >
+          View model anyway <ArrowRight className="h-3 w-3" />
+        </Link>
+      </div>
+    );
+  }
+
+  if (status.status === 'ready') {
+    return (
+      <div className="space-y-2">
+        <div className="flex items-center gap-2 text-sm" style={{ color: 'var(--ax-success)' }}>
+          <CheckCircle2 className="h-4 w-4 shrink-0" />
+          <span>Model is ready.</span>
+        </div>
+        <Link
+          to={`/models/${modelId}`}
+          className="inline-flex items-center gap-1 rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+        >
+          View model <ArrowRight className="h-3.5 w-3.5" />
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between text-sm">
+        <span className="flex items-center gap-2 text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin shrink-0" />
+          {statusLabel(status.status, progress)}
+        </span>
+        {!isIndeterminate && (
+          <span className="text-xs tabular-nums text-muted-foreground">{pct}%</span>
+        )}
+      </div>
+      <div className="h-2 w-full rounded-full bg-muted overflow-hidden">
+        {isIndeterminate ? (
+          <div className="h-full w-1/3 rounded-full bg-primary animate-[slide_1.5s_ease-in-out_infinite]" />
+        ) : (
+          <div
+            className="h-full rounded-full bg-primary transition-all duration-500"
+            style={{ width: `${pct}%` }}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Fix RecentUploads.tsx — replace `text-amber-*` and `text-emerald-*` with semantic tokens**
+
+In `StatusBadge`, replace:
+- `text-amber-600 dark:text-amber-500` → `style={{ color: 'var(--ax-warning)' }}`
+- `text-emerald-600 dark:text-emerald-500` → `style={{ color: 'var(--ax-success)' }}`
+
+The full updated `StatusBadge`:
+
+```typescript
+function StatusBadge({ status }: { status: ModelCard['status'] }) {
+  if (status === 'processing') {
+    return (
+      <span className="flex items-center gap-1 text-xs" style={{ color: 'var(--ax-warning)' }}>
+        <Loader2 className="h-3 w-3 animate-spin" />
+        Processing
+      </span>
+    );
+  }
+  if (status === 'error') {
+    return (
+      <span className="flex items-center gap-1 text-xs" style={{ color: 'var(--ax-danger)' }}>
+        <AlertCircle className="h-3 w-3" />
+        Error
+      </span>
+    );
+  }
+  return (
+    <span className="flex items-center gap-1 text-xs" style={{ color: 'var(--ax-success)' }}>
+      <CheckCircle2 className="h-3 w-3" />
+      Ready
+    </span>
+  );
+}
+```
+
+- [ ] **Step 3: Fix FolderImport.tsx — replace `border-emerald-500/30 bg-emerald-50 dark:bg-emerald-950/20 text-emerald-700 dark:text-emerald-400` with token equivalents**
+
+In the `submitted` state block, replace the entire `<div>` with:
+
+```typescript
+      {importState.phase === 'submitted' && (
+        <div
+          className="rounded-lg px-4 py-3 space-y-2"
+          style={{
+            border: '1px solid var(--ax-success)',
+            background: 'color-mix(in srgb, var(--ax-success) 8%, transparent)',
+          }}
+        >
+          <p className="text-sm font-medium" style={{ color: 'var(--ax-success)' }}>
+            Import job queued successfully.
+          </p>
+          <div className="flex gap-3">
+            <Link
+              to={`/models/${importState.modelId}`}
+              className="inline-flex items-center gap-1 text-sm text-primary hover:underline"
+            >
+              Track progress <ArrowRight className="h-3.5 w-3.5" />
+            </Link>
+            <button
+              onClick={reset}
+              className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+            >
+              Import another folder
+            </button>
+          </div>
+        </div>
+      )}
+```
+
+- [ ] **Step 4: Verify no amber-/emerald- in upload components**
+
+```bash
+grep -rE "amber-|emerald-" /Users/joseph/Projects/Alexandria/apps/frontend/src/components/upload
+```
+
+Expected: no output.
+
+- [ ] **Step 5: Verify TypeScript**
+
+```bash
+cd /Users/joseph/Projects/Alexandria/apps/frontend && npx tsc --noEmit 2>&1 | head -40
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/joseph/Projects/Alexandria && git add apps/frontend/src/components/upload/UploadProgress.tsx apps/frontend/src/components/upload/RecentUploads.tsx apps/frontend/src/components/upload/FolderImport.tsx && git commit -m "refactor(upload): replace amber-/emerald- Tailwind literals with ax-* token colors"
+```
+
+---
+
+## Task 8: Rebuild `UploadPage.tsx`
+
+**Files:**
+- Modify: `apps/frontend/src/pages/UploadPage.tsx`
+
+- [ ] **Step 1: Rewrite the page**
+
+The page is the two-column shell. Left = `UploadQueue` (fixed 300px dark rail). Right = compact `DropZone` + active `ReviewPane` when a session is selected, or a `FolderImport` tab if the user switches. The `activeId` is local state; auto-select the first non-committed session when sessions load.
+
+```typescript
+// apps/frontend/src/pages/UploadPage.tsx
+import { useState, useEffect } from 'react';
+import { FolderOpen } from 'lucide-react';
+import { useImportSessions } from '../hooks/use-import-sessions';
+import { UploadQueue } from '../components/upload/UploadQueue';
+import { DropZone } from '../components/upload/DropZone';
+import { ReviewPane } from '../components/upload/ReviewPane';
+import { FolderImport } from '../components/upload/FolderImport';
+import { RecentUploads } from '../components/upload/RecentUploads';
+import { cn } from '../lib/utils';
+
+type Tab = 'queue' | 'folder';
+
+export function UploadPage() {
+  const { data: sessions = [] } = useImportSessions();
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [tab, setTab] = useState<Tab>('queue');
+
+  // Auto-select the first actionable (non-committed) session when the list loads
+  useEffect(() => {
+    if (activeId) {
+      // Keep existing selection if it's still in the list
+      const stillExists = sessions.some((s) => s.id === activeId);
+      if (stillExists) return;
+    }
+    // Find first ready_for_review, then scanning, then any
+    const preferred =
+      sessions.find((s) => s.status === 'ready_for_review') ??
+      sessions.find((s) => s.status !== 'committed') ??
+      sessions[0] ??
+      null;
+    setActiveId(preferred?.id ?? null);
+  }, [sessions]);
+
+  const activeSession = sessions.find((s) => s.id === activeId) ?? null;
+
+  const handleCommitted = (modelId: string) => {
+    // Session transitions to committing automatically via polling; nothing to do
+  };
+
+  const handleDiscard = () => {
+    // Discard is called from ReviewPane; the session will disappear from the list
+    setActiveId(null);
+  };
+
+  return (
+    <div className="flex h-screen overflow-hidden">
+      {/* Left rail: queue */}
+      <UploadQueue
+        sessions={sessions}
+        activeId={activeId}
+        onSelect={(id) => { setActiveId(id); setTab('queue'); }}
+      />
+
+      {/* Main content */}
+      <div className="flex-1 flex flex-col min-w-0 overflow-hidden">
+        {/* Tab bar */}
+        <div
+          className="flex items-center gap-1 px-7 pt-4 flex-shrink-0"
+          style={{ borderBottom: '1px solid var(--ax-border)' }}
+        >
+          <button
+            onClick={() => setTab('queue')}
+            className={cn(
+              'flex items-center gap-1.5 px-4 py-2 text-[13px] font-medium rounded-t-lg border-b-2 transition-colors',
+              tab === 'queue'
+                ? 'border-[var(--ax-amber)] text-[var(--ax-amber)]'
+                : 'border-transparent text-muted-foreground hover:text-foreground'
+            )}
+          >
+            Archive upload
+          </button>
+          <button
+            onClick={() => setTab('folder')}
+            className={cn(
+              'flex items-center gap-1.5 px-4 py-2 text-[13px] font-medium rounded-t-lg border-b-2 transition-colors',
+              tab === 'folder'
+                ? 'border-[var(--ax-amber)] text-[var(--ax-amber)]'
+                : 'border-transparent text-muted-foreground hover:text-foreground'
+            )}
+          >
+            <FolderOpen className="h-3.5 w-3.5" />
+            Server folder import
+          </button>
+        </div>
+
+        {tab === 'folder' ? (
+          <div className="flex-1 overflow-y-auto">
+            <div className="max-w-2xl mx-auto px-7 py-6">
+              <div className="space-y-2 mb-6">
+                <h1 className="text-xl font-bold" style={{ color: 'var(--ax-fg)' }}>
+                  Import from server folder
+                </h1>
+                <p className="text-[13px]" style={{ color: 'var(--ax-fg-muted)' }}>
+                  Point at a folder on the server and define how its hierarchy maps to
+                  collections and metadata.
+                </p>
+              </div>
+              <FolderImport />
+            </div>
+          </div>
+        ) : (
+          <div className="flex-1 overflow-hidden flex flex-col">
+            {/* Drop zone — compact when sessions exist, full when empty */}
+            {sessions.length > 0 ? (
+              <DropZone compact onBrowseFolder={() => setTab('folder')} />
+            ) : (
+              <div className="px-7 pt-6">
+                <div className="space-y-2 mb-4">
+                  <h1 className="text-xl font-bold" style={{ color: 'var(--ax-fg)' }}>
+                    Add models
+                  </h1>
+                  <p className="text-[13px]" style={{ color: 'var(--ax-fg-muted)' }}>
+                    Drop archives to scan, then review detected metadata before importing.
+                  </p>
+                </div>
+                <DropZone />
+              </div>
+            )}
+
+            {/* Review pane or empty state */}
+            <div className="flex-1 overflow-y-auto ax-scroll px-7 py-5">
+              {activeSession ? (
+                <ReviewPane
+                  session={activeSession}
+                  onCommitted={handleCommitted}
+                  onDiscard={handleDiscard}
+                  onRetry={() => {
+                    // Discard the errored session so user can re-upload
+                    handleDiscard();
+                  }}
+                />
+              ) : sessions.length === 0 ? (
+                <div className="space-y-4 mt-4">
+                  <h2 className="text-base font-semibold" style={{ color: 'var(--ax-fg)' }}>
+                    Recent models
+                  </h2>
+                  <RecentUploads />
+                </div>
+              ) : (
+                <div className="flex flex-col items-center justify-center py-16 text-[13px]" style={{ color: 'var(--ax-fg-muted)' }}>
+                  Select a session from the queue to review it.
+                </div>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verify TypeScript**
+
+```bash
+cd /Users/joseph/Projects/Alexandria/apps/frontend && npx tsc --noEmit 2>&1 | head -60
+```
+
+- [ ] **Step 3: Full build check**
+
+```bash
+cd /Users/joseph/Projects/Alexandria/apps/frontend && npm run build 2>&1 | tail -30
+```
+
+Expected: Build succeeds, no TypeScript errors.
+
+- [ ] **Step 4: Final amber-/emerald- grep**
+
+```bash
+grep -rE "amber-|emerald-" /Users/joseph/Projects/Alexandria/apps/frontend/src/components/upload
+```
+
+Expected: no output.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/joseph/Projects/Alexandria && git add apps/frontend/src/pages/UploadPage.tsx && git commit -m "feat(upload): rebuild UploadPage as two-column queue-rail + review-pane shell (P3)"
+```
+
+---
+
+## Task 9: Final verification and cleanup
+
+- [ ] **Step 1: Full build + type check**
+
+```bash
+cd /Users/joseph/Projects/Alexandria/apps/frontend && npm run build 2>&1
+```
+
+Expected: Build output with no errors. Resolve any remaining type errors.
+
+- [ ] **Step 2: Grep for forbidden color literals**
+
+```bash
+grep -rE "amber-|emerald-" /Users/joseph/Projects/Alexandria/apps/frontend/src/components/upload
+```
+
+Expected: no output.
+
+- [ ] **Step 3: Verify protected files were not touched**
+
+```bash
+git -C /Users/joseph/Projects/Alexandria diff HEAD~10 -- apps/frontend/src/App.tsx apps/frontend/src/components/AppShell.tsx apps/frontend/src/components/pivot/PivotMain.tsx 2>/dev/null | head -5
+```
+
+Expected: no diff output (no changes to those files on this branch).
+
+- [ ] **Step 4: Verify the flow mentally**
+  - Drop archive → `DropZone.enqueueFile` calls `startScan.mutate` → `scanUpload` chunks upload → `complete` returns `{ sessionId }` → invalidate `['import-sessions']` → queue re-fetches → session appears with status `scanning`
+  - Polling every 2s → status changes to `ready_for_review` → `ReviewPane` shows folder tree + `BatchMetadataForm`
+  - User fills form → "Import" → `commitImportSession` → session goes `committing` → `ReviewPane` shows `UploadProgress` polling `GET /models/:id/status`
+  - Status hits `ready` → `UploadProgress` shows "View model" link to `/models/:id`
+  - Error state: `ReviewPane` shows danger card with Retry (sets `activeId` to null) / Discard
+
+- [ ] **Step 5: Commit any remaining fixes and push to `feat/p3-workflow-pages`**
+
+```bash
+cd /Users/joseph/Projects/Alexandria && git push -u origin feat/p3-workflow-pages
+```
+
+---
+
+## Self-Review
+
+**Spec coverage check:**
+
+| Requirement | Task |
+|---|---|
+| `scanUpload` returns `{ sessionId }`, fix `uploadModel` | Task 1 |
+| `listImportSessions`, `getImportSession`, `commitImportSession`, `discardImportSession` | Task 1 |
+| `useImportSessions` hook with polling + mutations | Task 2 |
+| `UploadQueue` rail with status icons, filename, size/count, error line, stats footer | Task 3 |
+| `BatchMetadataForm` with collection picker, artist, tags chip input, options checkboxes | Task 4 |
+| `ReviewPane` with scanning/ready/committing/error states, folder tree | Task 5 |
+| `DropZone` multi-file, compact mode, per-file progress, token colors | Task 6 |
+| Remove all `amber-*/emerald-*` from upload components | Task 7 |
+| Rebuild `UploadPage` two-column shell + FolderImport tab | Task 8 |
+| Build verification + grep check | Task 9 |
+
+**Deviations from design handoff (as specified in task spec):**
+- Thumbnail grid in "ready_for_review" is NOT implemented (files not committed yet). Instead shows `FolderTree` from `detected.folderStructure`. This is the explicit directive.
+- `useDiscardSession` is exported from the hook but called from `ReviewPane` via the `onDiscard` prop to keep components decoupled from mutations.
+
+**Placeholder scan:** None. All code blocks are complete implementations.
+
+**Type consistency:**
+- `ImportSession`, `DetectedImportMetadata`, `DetectedFolderNode`, `BatchUploadMetadata`, `ScanUploadResponse` all imported from `@alexandria/shared`
+- `scanUpload` returns `Promise<ScanUploadResponse>` (= `{ sessionId: string }`)
+- `commitImportSession` returns `Promise<{ modelId: string; jobId: string }>`
+- `useStartScan` mutation arg: `{ file: File; onProgress?: (pct: number) => void }` — consistent with `DropZone` usage
+- `useCommitSession` mutation arg: `{ id: string; batchMetadata?: BatchUploadMetadata }` — consistent with `BatchMetadataForm` usage

--- a/docs/superpowers/specs/2026-05-29-design-system-foundation-design.md
+++ b/docs/superpowers/specs/2026-05-29-design-system-foundation-design.md
@@ -51,7 +51,7 @@ with no rewrite, while keeping runtime palette-switching + density.
 | **P0** | Design System Foundation | no | Shipped | Port tokens, bridge to shadcn, palette/theme/density state, fonts, icon strategy, verification sandbox. **(this spec)** |
 | **P1** | App Shell + Pivot Workspace | thin Library layer | Shipped | Dark rail + axis picker + main pane/header; Pivot by Collections / Tags / Artists end-to-end; view toggle (grid/list/group), density, thumbnails toggle. Smart axis deferred. |
 | **P2** | Model Detail + 3D Viewer | no | Shipped | Restyle detail with multi-hierarchy breadcrumb; 3D modal (files already served). |
-| **P3** | Workflow Pages | no | Pending | Restyle Upload + global Search. |
+| **P3** | Workflow Pages | no | Shipped | Restyle Upload + global Search. |
 | **P4** | Smart Collections | yes | Pending | New entity + rule engine (extends SearchService); Smart pivot axis + composer. |
 | **P5** | Multi-library | yes | Pending | Surface the Library layer: All-Libraries home, switcher, `/lib/:id` routing, per-library scoping in UI. |
 | **P6** | Users / Roles / Admin | yes | Pending | Multi-user + roles in AuthService; admin pages (libraries, users, bulk edit, auto-tagging). |

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -4,3 +4,5 @@ export * from './metadata.js';
 export * from './collection.js';
 export * from './library.js';
 export * from './api.js';
+export * from './upload.js';
+export * from './search.js';

--- a/packages/shared/src/types/search.ts
+++ b/packages/shared/src/types/search.ts
@@ -1,0 +1,62 @@
+/**
+ * Global (cross-entity) search types.
+ *
+ * One query fans out across every type Alexandria indexes — models, collections,
+ * artists, and tags — and the results are grouped by type for the search page.
+ */
+
+import type { ModelCard } from './model.js';
+
+/**
+ * Parameters for a global search request.
+ */
+export interface GlobalSearchParams {
+  q: string;
+  /** Max hits returned per result type (default applied server-side). */
+  limit?: number;
+}
+
+/**
+ * A collection that matched the query.
+ */
+export interface SearchCollectionHit {
+  id: string;
+  name: string;
+  slug: string;
+  modelCount: number;
+}
+
+/**
+ * An artist (a metadata value) that matched the query.
+ */
+export interface SearchArtistHit {
+  name: string;
+  modelCount: number;
+}
+
+/**
+ * A tag that matched the query.
+ */
+export interface SearchTagHit {
+  name: string;
+  modelCount: number;
+}
+
+/**
+ * Aggregated cross-entity search result.
+ *
+ * Each result type is scored/sorted independently — there is no unified
+ * relevance score across types (models use full-text rank, the rest are ordered
+ * by usage count).
+ */
+export interface GlobalSearchResult {
+  q: string;
+  models: {
+    items: ModelCard[];
+    /** Total matching models, ignoring the per-type limit. */
+    total: number;
+  };
+  collections: SearchCollectionHit[];
+  artists: SearchArtistHit[];
+  tags: SearchTagHit[];
+}

--- a/packages/shared/src/types/upload.ts
+++ b/packages/shared/src/types/upload.ts
@@ -1,0 +1,116 @@
+/**
+ * Upload and ingestion types.
+ */
+
+import type { FileType } from './model.js';
+
+export interface UploadInitResponse {
+  uploadId: string;
+  chunkSize: number;
+  totalChunks: number;
+}
+
+export interface ChunkUploadResponse {
+  uploadId: string;
+  index: number;
+  received: number;
+  totalChunks: number;
+}
+
+export interface UploadCompleteResponse {
+  modelId: string;
+  jobId: string;
+}
+
+export interface UploadProgress {
+  modelId: string;
+  chunkIndex: number;
+  totalChunks: number;
+  uploadedBytes: number;
+  totalBytes: number;
+}
+
+// ---------------------------------------------------------------------------
+// Staged upload: scan → review → commit
+// ---------------------------------------------------------------------------
+
+/**
+ * Lifecycle of a staged archive upload.
+ *
+ * An archive is first scanned (extracted + inspected) without being committed,
+ * then the user reviews/edits the detected metadata, then commits it to a model.
+ */
+export type ImportSessionStatus =
+  | 'scanning'
+  | 'ready_for_review'
+  | 'committing'
+  | 'committed'
+  | 'error';
+
+/**
+ * A node in the detected folder structure preview.
+ */
+export interface DetectedFolderNode {
+  name: string;
+  type: 'folder' | 'file';
+  fileType?: FileType;
+  children?: DetectedFolderNode[];
+}
+
+/**
+ * Best-effort metadata detected during the scan phase. All fields are
+ * heuristic and fully editable by the user before commit.
+ */
+export interface DetectedImportMetadata {
+  /** Count of detected sub-models (display only — commit creates one model). */
+  modelCount: number;
+  fileCount: number;
+  totalSizeBytes: number;
+  artist: string | null;
+  tagsGuessed: string[];
+  folderStructure: DetectedFolderNode[];
+}
+
+/**
+ * A staged import session — one uploaded archive awaiting review/commit.
+ */
+export interface ImportSession {
+  id: string;
+  originalFilename: string;
+  status: ImportSessionStatus;
+  detected: DetectedImportMetadata | null;
+  modelId: string | null;
+  error: string | null;
+  createdAt: string;
+}
+
+/**
+ * Response from initiating a scan (archive upload).
+ */
+export interface ScanUploadResponse {
+  sessionId: string;
+}
+
+/**
+ * Per-import options toggled in the review form.
+ */
+export interface UploadOptions {
+  markPreSupported?: boolean;
+  /** Auto-thumbnails always run during ingestion; this is informational. */
+  autoThumbnails?: boolean;
+  markNsfw?: boolean;
+  skipDuplicatesByHash?: boolean;
+}
+
+/**
+ * Batch metadata applied to the committed model.
+ */
+export interface BatchUploadMetadata {
+  /** Assign to an existing collection. */
+  collectionId?: string;
+  /** Or create-and-assign a new collection by name. */
+  newCollectionName?: string;
+  artist?: string;
+  tags?: string[];
+  options?: UploadOptions;
+}

--- a/packages/shared/src/validation/search.ts
+++ b/packages/shared/src/validation/search.ts
@@ -27,3 +27,12 @@ export const modelSearchParamsSchema = z.object({
 
   metadataFilters: z.record(z.string(), z.string()).optional(),
 });
+
+/**
+ * Parameters for the cross-entity global search endpoint.
+ * `limit` caps hits returned per result type.
+ */
+export const globalSearchParamsSchema = z.object({
+  q: z.string().trim().min(1).max(500),
+  limit: z.coerce.number().int().min(1).max(50).default(6),
+});

--- a/packages/shared/src/validation/upload.ts
+++ b/packages/shared/src/validation/upload.ts
@@ -22,6 +22,33 @@ export const uploadCompleteParamsSchema = z.object({
   uploadId: z.string().uuid(),
 });
 
+// ---------------------------------------------------------------------------
+// Staged upload: review/commit
+// ---------------------------------------------------------------------------
+
+export const uploadOptionsSchema = z.object({
+  markPreSupported: z.boolean().optional(),
+  autoThumbnails: z.boolean().optional(),
+  markNsfw: z.boolean().optional(),
+  skipDuplicatesByHash: z.boolean().optional(),
+});
+
+export const batchUploadMetadataSchema = z.object({
+  collectionId: z.string().uuid().optional(),
+  newCollectionName: z.string().min(1).max(255).optional(),
+  artist: z.string().max(255).optional(),
+  tags: z.array(z.string().min(1).max(100)).max(50).optional(),
+  options: uploadOptionsSchema.optional(),
+});
+
+export const commitImportSessionSchema = z.object({
+  batchMetadata: batchUploadMetadataSchema.optional(),
+});
+
+export const importSessionIdParamsSchema = z.object({
+  id: z.string().uuid(),
+});
+
 export type UploadInitRequest = z.infer<typeof uploadInitSchema>;
 export type ChunkIndexParams = z.infer<typeof chunkIndexParamsSchema>;
 export type UploadCompleteParams = z.infer<typeof uploadCompleteParamsSchema>;


### PR DESCRIPTION
## P3 — Workflow Pages

Implements **P3** of the Alexandria redesign program: a **staged archive-upload pipeline** and **cross-entity global search**, both rebuilt to the design handoff.

### Staged upload (scan → review → commit)
- New `import_sessions` table + `import-scan` / `import-commit` BullMQ queues.
- Uploading an archive now **scans** it (extract + heuristic detection of artist, tags, and folder structure) into a session **without committing**. The user **reviews/edits** batch metadata (destination collection, artist, tags, options) and then **commits**, which persists the files and applies the metadata to the model.
- One model per archive (preserves existing cardinality). Folder-import keeps its existing immediate behavior.
- `POST /models/upload` and `…/complete` now return `{ sessionId }`; new `GET/POST/DELETE /models/import-sessions[...]` endpoints drive the queue/review/commit/discard flow.

### Global search + ⌘K
- `GET /search` aggregates **models** (full-text) + **collections** + **artists** + **tags**, library-scoped.
- New `/search` page with collapsible per-type sections; a global **⌘K command palette**; the pivot top-bar search now navigates to `/search`.
- "Save as Smart Collection" is rendered disabled (deferred to **P4**); the library filter is single-library only (multi-library is **P5**).

### UI
- Upload restyled to the handoff; hardcoded amber/emerald Tailwind literals replaced with semantic status tokens.

### Quality
- Monorepo `npm run build` is clean (backend + frontend + shared); 78 new backend tests + the existing frontend suite pass.
- A code-review pass was run and its findings addressed in `6ab385d`: a cross-tenant collection-write guard (validate destination-collection ownership before commit), commit-job idempotency (`attempts: 1`), honest UI for not-yet-implemented options, and a canonical upload-init type. A verification re-review came back clean.
- Docs updated: `docs/API.md`, `docs/ARCHITECTURE.md`, `docs/TYPES.md`, and the redesign roadmap.

### Deferred (later phases)
Smart collections + rule engine (P4), multi-library switching (P5), splitting one archive into multiple models, and an abandoned-session reaper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
