### PR TITLE
feat(p4): Smart Collections — rule engine, composer, Smart pivot axis

### DIFF
--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -10,6 +10,7 @@ import { modelRoutes } from './routes/models.js';
 import { metadataFieldRoutes, modelMetadataRoute } from './routes/metadata.js';
 import { bulkRoutes } from './routes/bulk.js';
 import { collectionRoutes } from './routes/collections.js';
+import { smartCollectionRoutes } from './routes/smart-collections.js';
 import { fileRoutes } from './routes/files.js';
 import { searchRoutes } from './routes/search.js';
 import { startIngestionWorker } from './workers/ingestion.worker.js';
@@ -65,6 +66,7 @@ export async function buildApp(): Promise<ReturnType<typeof Fastify>> {
   await app.register(modelMetadataRoute, { prefix: '/models' });
   await app.register(bulkRoutes, { prefix: '/bulk' });
   await app.register(collectionRoutes, { prefix: '/collections' });
+  await app.register(smartCollectionRoutes, { prefix: '/smart-collections' });
   await app.register(fileRoutes, { prefix: '/files' });
   await app.register(searchRoutes, { prefix: '/search' });
 

--- a/apps/backend/src/db/migrations/0009_add_smart_collections.sql
+++ b/apps/backend/src/db/migrations/0009_add_smart_collections.sql
@@ -1,0 +1,25 @@
+-- Add smart_collections table for dynamic, rule-based collections (P4).
+-- A smart collection stores only its rule tree in `definition` (jsonb); the
+-- result set is derived on read by compiling the tree into a model query.
+-- No membership join table and no parent_collection_id — the rule tree is the
+-- structure. FK onDelete mirrors `collections` (no action) for consistency.
+
+CREATE TABLE "smart_collections" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "name" varchar(255) NOT NULL,
+  "slug" varchar(255) NOT NULL,
+  "description" text,
+  "definition" jsonb NOT NULL,
+  "user_id" uuid NOT NULL,
+  "library_id" uuid NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "smart_collections_slug_unique" UNIQUE("slug")
+);--> statement-breakpoint
+ALTER TABLE "smart_collections" ADD CONSTRAINT "smart_collections_user_id_users_id_fk"
+  FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "smart_collections" ADD CONSTRAINT "smart_collections_library_id_libraries_id_fk"
+  FOREIGN KEY ("library_id") REFERENCES "public"."libraries"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "smart_collections_slug_idx" ON "smart_collections" USING btree ("slug");--> statement-breakpoint
+CREATE INDEX "smart_collections_user_id_idx" ON "smart_collections" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "smart_collections_library_id_idx" ON "smart_collections" USING btree ("library_id");

--- a/apps/backend/src/db/migrations/meta/_journal.json
+++ b/apps/backend/src/db/migrations/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1748591400000,
       "tag": "0008_add_import_sessions",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1772100003000,
+      "tag": "0009_add_smart_collections",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/backend/src/db/schema/index.ts
+++ b/apps/backend/src/db/schema/index.ts
@@ -7,4 +7,5 @@ export * from './thumbnail.js';
 export * from './metadata.js';
 export * from './tag.js';
 export * from './collection.js';
+export * from './smart-collection.js';
 export * from './import-session.js';

--- a/apps/backend/src/db/schema/smart-collection.ts
+++ b/apps/backend/src/db/schema/smart-collection.ts
@@ -1,0 +1,45 @@
+import { pgTable, uuid, varchar, text, jsonb, timestamp, index } from 'drizzle-orm/pg-core';
+import type { RuleNode } from '@alexandria/shared';
+import { users } from './user.js';
+import { libraries } from './library.js';
+
+// Smart collections — dynamic, rule-based collections (P4).
+// Unlike `collections` (manual membership via a join table), a smart collection
+// stores only its rule tree in `definition`; the result set is derived on read
+// by compiling that tree into a model query (see services/rule-engine.ts).
+// There is no membership join table and no parent/child nesting — the rule tree
+// provides all the structure.
+export const smartCollections = pgTable(
+  'smart_collections',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    name: varchar('name', { length: 255 }).notNull(),
+    // URL-safe slug generated from name + random suffix
+    slug: varchar('slug', { length: 255 }).notNull().unique(),
+    description: text('description'),
+    // The rule tree. Typed as RuleNode (the shared discriminated union) so reads
+    // are typed without a cast; validated by the shared zod schema before write.
+    definition: jsonb('definition').$type<RuleNode>().notNull(),
+    userId: uuid('user_id')
+      .notNull()
+      .references(() => users.id),
+    // Library this smart collection belongs to. NOT NULL — every smart
+    // collection is scoped to a library, like manual collections.
+    libraryId: uuid('library_id')
+      .notNull()
+      .references(() => libraries.id),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => [
+    // Lookup by slug for URL-based access
+    index('smart_collections_slug_idx').on(table.slug),
+    // List smart collections owned by a user
+    index('smart_collections_user_id_idx').on(table.userId),
+    // Filter smart collections belonging to a library (library browse query)
+    index('smart_collections_library_id_idx').on(table.libraryId),
+  ],
+);
+
+export type SmartCollection = typeof smartCollections.$inferSelect;
+export type NewSmartCollection = typeof smartCollections.$inferInsert;

--- a/apps/backend/src/routes/smart-collections.test.ts
+++ b/apps/backend/src/routes/smart-collections.test.ts
@@ -1,0 +1,421 @@
+/**
+ * Integration tests for /smart-collections (P4).
+ *
+ * Hit the real Fastify app against the real test database. Auth via the login
+ * cookie pattern from search.test.ts. requireLibrary injects libraryId.
+ *
+ * Coverage:
+ * - CRUD happy paths + { data, meta, errors } envelope.
+ * - GET /:id/models derived result set + ad-hoc pagination.
+ * - POST /preview on an unsaved tree.
+ * - Cross-tenant guard: another user's smart collection → 404 on every :id route.
+ * - Validation: unknown metadata slug → 400; illegal metadata operator → 400;
+ *   over-deep tree → 400.
+ * - Status-default regression: tree without status → only ready models; a tree
+ *   whose rule references status='processing' surfaces processing models.
+ * - Library isolation: a model in another library never appears.
+ * - Auth guard: no cookie → 401.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import { eq, inArray } from 'drizzle-orm';
+import { buildApp } from '../app.js';
+import { db } from '../db/index.js';
+import {
+  users,
+  libraries,
+  models,
+  modelFiles,
+  tags,
+  modelTags,
+  metadataFieldDefinitions,
+  modelMetadata,
+  smartCollections,
+} from '../db/schema/index.js';
+import type { RuleNode } from '@alexandria/shared';
+
+let app: FastifyInstance;
+let sessionCookie: string;
+let otherCookie: string;
+
+let userId: string;
+let libraryId: string;
+let otherUserId: string;
+let otherLibraryId: string;
+
+const modelIds: string[] = [];
+let dragonModelId: string;
+let processingModelId: string;
+let otherLibraryModelId: string;
+let dragonTagId: string;
+let otherSmartId: string;
+
+async function login(email: string, password: string): Promise<string> {
+  const res = await app.inject({ method: 'POST', url: '/auth/login', payload: { email, password } });
+  const setCookie = res.headers['set-cookie'];
+  const cookieStr = Array.isArray(setCookie) ? setCookie[0] : String(setCookie);
+  return cookieStr.split(';')[0];
+}
+
+function authedPost(url: string, body: object, cookie = sessionCookie) {
+  return app.inject({ method: 'POST', url, headers: { cookie }, payload: body });
+}
+function authedGet(url: string, cookie = sessionCookie) {
+  return app.inject({ method: 'GET', url, headers: { cookie } });
+}
+
+const EMAIL = 'sc-route-test@example.com';
+const OTHER_EMAIL = 'sc-route-other@example.com';
+
+beforeAll(async () => {
+  app = await buildApp();
+  await app.ready();
+  const ts = Date.now();
+
+  // Clean leftover fixtures
+  const leftover = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(inArray(users.email, [EMAIL, OTHER_EMAIL]));
+  if (leftover.length > 0) {
+    const ids = leftover.map((u) => u.id);
+    await db.delete(smartCollections).where(inArray(smartCollections.userId, ids));
+    await db.delete(models).where(inArray(models.userId, ids));
+    await db.delete(libraries).where(inArray(libraries.userId, ids));
+    await db.delete(users).where(inArray(users.id, ids));
+  }
+
+  const authService = (
+    app as FastifyInstance & { authService: import('../services/auth.service.js').AuthService }
+  ).authService;
+  await authService.createUser(EMAIL, 'password123', 'SC Test User');
+  await authService.createUser(OTHER_EMAIL, 'password123', 'SC Other User');
+
+  const [u] = await db.select().from(users).where(eq(users.email, EMAIL)).limit(1);
+  const [other] = await db.select().from(users).where(eq(users.email, OTHER_EMAIL)).limit(1);
+  userId = u.id;
+  otherUserId = other.id;
+
+  const [lib] = await db
+    .insert(libraries)
+    .values({ name: 'SC Lib', slug: `sc-lib-${ts}`, userId, isDefault: true })
+    .returning();
+  libraryId = lib.id;
+  const [otherLib] = await db
+    .insert(libraries)
+    .values({ name: 'SC Other Lib', slug: `sc-other-lib-${ts}`, userId: otherUserId, isDefault: true })
+    .returning();
+  otherLibraryId = otherLib.id;
+
+  const fieldDefs = await db
+    .select({ id: metadataFieldDefinitions.id, slug: metadataFieldDefinitions.slug })
+    .from(metadataFieldDefinitions)
+    .where(eq(metadataFieldDefinitions.isDefault, true));
+  const fieldDefIds: Record<string, string> = {};
+  for (const fd of fieldDefs) fieldDefIds[fd.slug] = fd.id;
+
+  // Models in the main library
+  const defs = [
+    { name: 'SC Dragon Model', desc: 'a dragon for sc tests', status: 'ready' as const },
+    { name: 'SC Fantasy Model', desc: 'a fantasy model', status: 'ready' as const },
+    { name: 'SC Processing Model', desc: 'still processing', status: 'processing' as const },
+  ];
+  for (let i = 0; i < defs.length; i++) {
+    const [m] = await db
+      .insert(models)
+      .values({
+        name: defs[i].name,
+        slug: `sc-${i}-${ts}`,
+        description: defs[i].desc,
+        userId,
+        libraryId,
+        sourceType: 'zip_upload',
+        status: defs[i].status,
+        totalSizeBytes: 1_000_000,
+        fileCount: 1,
+      })
+      .returning();
+    modelIds.push(m.id);
+  }
+  dragonModelId = modelIds[0];
+  processingModelId = modelIds[2];
+
+  // STL file on the dragon model (for fileType rules)
+  await db.insert(modelFiles).values({
+    modelId: dragonModelId,
+    filename: 'dragon.stl',
+    relativePath: 'dragon.stl',
+    fileType: 'stl',
+    mimeType: 'model/stl',
+    sizeBytes: 1000,
+    storagePath: `models/${dragonModelId}/dragon.stl`,
+    hash: 'a'.repeat(64),
+  });
+
+  // Dragon tag on the dragon model
+  const [tag] = await db
+    .insert(tags)
+    .values({ name: `Dragon-sc-${ts}`, slug: `dragon-sc-${ts}` })
+    .returning();
+  dragonTagId = tag.id;
+  await db.insert(modelTags).values({ modelId: dragonModelId, tagId: dragonTagId });
+
+  // Artist metadata on the dragon model
+  if (fieldDefIds['artist']) {
+    await db.insert(modelMetadata).values({
+      modelId: dragonModelId,
+      fieldDefinitionId: fieldDefIds['artist'],
+      value: 'Loot Studios',
+    });
+  }
+
+  // A model in ANOTHER library (isolation)
+  const [otherModel] = await db
+    .insert(models)
+    .values({
+      name: 'SC Dragon Other Library',
+      slug: `sc-other-${ts}`,
+      description: 'a dragon in another library',
+      userId: otherUserId,
+      libraryId: otherLibraryId,
+      sourceType: 'zip_upload',
+      status: 'ready',
+      totalSizeBytes: 1,
+      fileCount: 0,
+    })
+    .returning();
+  otherLibraryModelId = otherModel.id;
+
+  // A smart collection owned by the OTHER user (cross-tenant target)
+  const [otherSc] = await db
+    .insert(smartCollections)
+    .values({
+      name: 'Other SC',
+      slug: `other-sc-${ts}`,
+      definition: { kind: 'group', op: 'and', children: [] } as RuleNode,
+      userId: otherUserId,
+      libraryId: otherLibraryId,
+    })
+    .returning();
+  otherSmartId = otherSc.id;
+
+  sessionCookie = await login(EMAIL, 'password123');
+  otherCookie = await login(OTHER_EMAIL, 'password123');
+});
+
+afterAll(async () => {
+  await db.delete(smartCollections).where(inArray(smartCollections.userId, [userId, otherUserId]));
+  const all = [...modelIds, otherLibraryModelId].filter(Boolean);
+  if (all.length) await db.delete(models).where(inArray(models.id, all));
+  if (dragonTagId) await db.delete(tags).where(eq(tags.id, dragonTagId));
+  await db.delete(libraries).where(inArray(libraries.id, [libraryId, otherLibraryId]));
+  await db.delete(users).where(inArray(users.id, [userId, otherUserId]));
+  await app.close();
+});
+
+describe('POST /smart-collections — create', () => {
+  it('creates a smart collection and returns detail with modelCount', async () => {
+    const definition: RuleNode = {
+      kind: 'group',
+      op: 'and',
+      children: [
+        { kind: 'condition', field: { source: 'builtin', field: 'fileType' }, operator: 'has', value: 'stl' },
+      ],
+    };
+    const res = await authedPost('/smart-collections', { name: 'STL models', definition });
+    expect(res.statusCode).toBe(201);
+    const body = res.json();
+    expect(body.errors).toBeNull();
+    expect(body.data.name).toBe('STL models');
+    expect(body.data.slug).toBeTruthy();
+    expect(body.data.definition).toEqual(definition);
+    // only the dragon model has an STL file
+    expect(body.data.modelCount).toBe(1);
+  });
+
+  it('rejects an unknown metadata field slug with 400', async () => {
+    const definition: RuleNode = {
+      kind: 'group',
+      op: 'and',
+      children: [
+        { kind: 'condition', field: { source: 'metadata', slug: 'not-a-real-field' }, operator: 'equals', value: 'x' },
+      ],
+    };
+    const res = await authedPost('/smart-collections', { name: 'bad', definition });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().errors[0].code).toBe('VALIDATION_ERROR');
+  });
+
+  it('rejects an illegal operator for a metadata field type with 400', async () => {
+    // artist is a text field; `has` is not a legal operator for it
+    const definition: RuleNode = {
+      kind: 'group',
+      op: 'and',
+      children: [
+        { kind: 'condition', field: { source: 'metadata', slug: 'artist' }, operator: 'has', value: 'x' },
+      ],
+    };
+    const res = await authedPost('/smart-collections', { name: 'bad op', definition });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('rejects a tree exceeding the max nesting depth with 400', async () => {
+    const leaf: RuleNode = { kind: 'condition', field: { source: 'builtin', field: 'status' }, operator: 'is', value: 'ready' };
+    const definition: RuleNode = {
+      kind: 'group',
+      op: 'and',
+      children: [{ kind: 'group', op: 'and', children: [{ kind: 'group', op: 'and', children: [{ kind: 'group', op: 'and', children: [leaf] }] }] }],
+    };
+    const res = await authedPost('/smart-collections', { name: 'too deep', definition });
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+describe('GET /smart-collections — list', () => {
+  it('lists the user\'s smart collections', async () => {
+    const res = await authedGet('/smart-collections');
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(Array.isArray(body.data)).toBe(true);
+    expect(body.data.some((sc: { name: string }) => sc.name === 'STL models')).toBe(true);
+    // the other user's smart collection must not leak in
+    expect(body.data.some((sc: { id: string }) => sc.id === otherSmartId)).toBe(false);
+  });
+});
+
+describe('GET /smart-collections/:id/models — derived set', () => {
+  it('returns models matching the saved rule tree', async () => {
+    const createRes = await authedPost('/smart-collections', {
+      name: 'Dragons',
+      definition: {
+        kind: 'group',
+        op: 'and',
+        children: [
+          { kind: 'condition', field: { source: 'builtin', field: 'fileType' }, operator: 'has', value: 'stl' },
+        ],
+      },
+    });
+    const id = createRes.json().data.id;
+    const res = await authedGet(`/smart-collections/${id}/models`);
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.meta.total).toBe(1);
+    expect(body.data[0].id).toBe(dragonModelId);
+  });
+});
+
+describe('POST /smart-collections/preview — dry run', () => {
+  it('returns count + cards for an unsaved tree', async () => {
+    const res = await authedPost('/smart-collections/preview', {
+      definition: { kind: 'group', op: 'and', children: [] },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    // empty root = match all READY models in the library (2 of 3; one is processing)
+    expect(body.meta.total).toBe(2);
+  });
+});
+
+describe('status default handling', () => {
+  it('a tree without a status rule returns only ready models', async () => {
+    const res = await authedPost('/smart-collections/preview', {
+      definition: { kind: 'group', op: 'and', children: [] },
+    });
+    const ids = res.json().data.map((m: { id: string }) => m.id);
+    expect(ids).not.toContain(processingModelId);
+  });
+
+  it('a tree that references status=processing surfaces processing models', async () => {
+    const res = await authedPost('/smart-collections/preview', {
+      definition: {
+        kind: 'group',
+        op: 'and',
+        children: [
+          { kind: 'condition', field: { source: 'builtin', field: 'status' }, operator: 'is', value: 'processing' },
+        ],
+      },
+    });
+    expect(res.statusCode).toBe(200);
+    const ids = res.json().data.map((m: { id: string }) => m.id);
+    expect(ids).toContain(processingModelId);
+  });
+});
+
+describe('library isolation', () => {
+  it('never returns a model from another library', async () => {
+    const res = await authedPost('/smart-collections/preview', {
+      definition: {
+        kind: 'group',
+        op: 'and',
+        children: [
+          { kind: 'condition', field: { source: 'builtin', field: 'name' }, operator: 'contains', value: 'dragon' },
+        ],
+      },
+    });
+    const ids = res.json().data.map((m: { id: string }) => m.id);
+    expect(ids).not.toContain(otherLibraryModelId);
+  });
+});
+
+describe('cross-tenant guard', () => {
+  it('GET /:id → 404 for another user\'s smart collection', async () => {
+    expect((await authedGet(`/smart-collections/${otherSmartId}`)).statusCode).toBe(404);
+  });
+  it('GET /:id/models → 404', async () => {
+    expect((await authedGet(`/smart-collections/${otherSmartId}/models`)).statusCode).toBe(404);
+  });
+  it('PATCH /:id → 404', async () => {
+    const res = await app.inject({
+      method: 'PATCH',
+      url: `/smart-collections/${otherSmartId}`,
+      headers: { cookie: sessionCookie },
+      payload: { name: 'hijack' },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+  it('DELETE /:id → 404', async () => {
+    const res = await app.inject({
+      method: 'DELETE',
+      url: `/smart-collections/${otherSmartId}`,
+      headers: { cookie: sessionCookie },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+  it('the other user CAN access their own smart collection', async () => {
+    expect((await authedGet(`/smart-collections/${otherSmartId}`, otherCookie)).statusCode).toBe(200);
+  });
+});
+
+describe('PATCH + DELETE lifecycle', () => {
+  it('updates then deletes a smart collection', async () => {
+    const create = await authedPost('/smart-collections', {
+      name: 'Temp',
+      definition: { kind: 'group', op: 'and', children: [] },
+    });
+    const id = create.json().data.id;
+
+    const patch = await app.inject({
+      method: 'PATCH',
+      url: `/smart-collections/${id}`,
+      headers: { cookie: sessionCookie },
+      payload: { name: 'Renamed' },
+    });
+    expect(patch.statusCode).toBe(200);
+    expect(patch.json().data.name).toBe('Renamed');
+
+    const del = await app.inject({
+      method: 'DELETE',
+      url: `/smart-collections/${id}`,
+      headers: { cookie: sessionCookie },
+    });
+    expect(del.statusCode).toBe(200);
+    expect((await authedGet(`/smart-collections/${id}`)).statusCode).toBe(404);
+  });
+});
+
+describe('auth guard', () => {
+  it('401 without a session cookie', async () => {
+    expect((await app.inject({ method: 'GET', url: '/smart-collections' })).statusCode).toBe(401);
+  });
+});

--- a/apps/backend/src/routes/smart-collections.test.ts
+++ b/apps/backend/src/routes/smart-collections.test.ts
@@ -260,6 +260,18 @@ describe('POST /smart-collections — create', () => {
     expect(res.statusCode).toBe(400);
   });
 
+  it('rejects a metadata rule on the optimized tags field with 400', async () => {
+    const definition: RuleNode = {
+      kind: 'group',
+      op: 'and',
+      children: [
+        { kind: 'condition', field: { source: 'metadata', slug: 'tags' }, operator: 'contains', value: 'dragon' },
+      ],
+    };
+    const res = await authedPost('/smart-collections', { name: 'tags-meta', definition });
+    expect(res.statusCode).toBe(400);
+  });
+
   it('rejects a tree exceeding the max nesting depth with 400', async () => {
     const leaf: RuleNode = { kind: 'condition', field: { source: 'builtin', field: 'status' }, operator: 'is', value: 'ready' };
     const definition: RuleNode = {

--- a/apps/backend/src/routes/smart-collections.ts
+++ b/apps/backend/src/routes/smart-collections.ts
@@ -1,0 +1,132 @@
+import type { FastifyInstance } from 'fastify';
+import type {
+  CreateSmartCollectionRequest,
+  UpdateSmartCollectionRequest,
+  PreviewSmartCollectionRequest,
+  ModelSearchParams,
+} from '@alexandria/shared';
+import {
+  createSmartCollectionSchema,
+  updateSmartCollectionSchema,
+  previewSmartCollectionSchema,
+  modelSearchParamsSchema,
+} from '@alexandria/shared';
+import { requireAuth } from '../middleware/auth.js';
+import { requireLibrary } from '../middleware/library.js';
+import { validate } from '../middleware/validate.js';
+import { smartCollectionService } from '../services/smart-collection.service.js';
+import type { SearchResult } from '../services/search.service.js';
+import { validationError } from '../utils/errors.js';
+
+/** Parse model-search query params (including metadata.* keys) from a raw query. */
+function parseModelParams(rawQuery: Record<string, unknown>): ModelSearchParams {
+  const metadataFilters: Record<string, string> = {};
+  for (const [key, val] of Object.entries(rawQuery)) {
+    if (key.startsWith('metadata.') && typeof val === 'string') {
+      const fieldSlug = key.slice('metadata.'.length);
+      if (fieldSlug) metadataFilters[fieldSlug] = val;
+    }
+  }
+
+  const parsed = modelSearchParamsSchema.safeParse({
+    ...rawQuery,
+    ...(Object.keys(metadataFilters).length > 0 ? { metadataFilters } : {}),
+  });
+  if (!parsed.success) {
+    const firstIssue = parsed.error.issues[0];
+    throw validationError(firstIssue?.message ?? 'Validation failed', firstIssue?.path.join('.'));
+  }
+  return parsed.data as ModelSearchParams;
+}
+
+function modelsEnvelope(result: SearchResult) {
+  return {
+    data: result.models,
+    meta: { total: result.total, cursor: result.cursor, pageSize: result.pageSize },
+    errors: null,
+  };
+}
+
+export async function smartCollectionRoutes(app: FastifyInstance): Promise<void> {
+  // requireLibrary is mandatory on every route: libraryId comes ONLY from
+  // request.libraryId, never from query or body. Every :id route additionally
+  // goes through the service's requireOwnedSmartCollection cross-tenant guard.
+
+  // GET / — list smart collections (no derived counts; kept cheap)
+  app.get('/', { preHandler: [requireAuth, requireLibrary] }, async (request, reply) => {
+    const items = await smartCollectionService.list(request.user!.id, request.libraryId!);
+    return reply.status(200).send({
+      data: items,
+      meta: { total: items.length, cursor: null, pageSize: items.length },
+      errors: null,
+    });
+  });
+
+  // POST / — create a smart collection
+  app.post(
+    '/',
+    { preHandler: [requireAuth, requireLibrary, validate(createSmartCollectionSchema)] },
+    async (request, reply) => {
+      const body = request.body as CreateSmartCollectionRequest;
+      const detail = await smartCollectionService.create(body, request.user!.id, request.libraryId!);
+      return reply.status(201).send({ data: detail, meta: null, errors: null });
+    },
+  );
+
+  // POST /preview — dry-run an unsaved rule tree (static route; declared before /:id)
+  app.post(
+    '/preview',
+    { preHandler: [requireAuth, requireLibrary, validate(previewSmartCollectionSchema)] },
+    async (request, reply) => {
+      const body = request.body as PreviewSmartCollectionRequest;
+      const { definition, ...rest } = body;
+      const params = rest as ModelSearchParams;
+      const result = await smartCollectionService.preview(definition, params, request.libraryId!);
+      return reply.status(200).send(modelsEnvelope(result));
+    },
+  );
+
+  // GET /:id — single smart collection (with derived model count)
+  app.get('/:id', { preHandler: [requireAuth, requireLibrary] }, async (request, reply) => {
+    const { id } = request.params as { id: string };
+    const detail = await smartCollectionService.getById(id, request.user!.id, request.libraryId!);
+    return reply.status(200).send({ data: detail, meta: null, errors: null });
+  });
+
+  // PATCH /:id — update name/description/definition
+  app.patch(
+    '/:id',
+    { preHandler: [requireAuth, requireLibrary, validate(updateSmartCollectionSchema)] },
+    async (request, reply) => {
+      const { id } = request.params as { id: string };
+      const body = request.body as UpdateSmartCollectionRequest;
+      const detail = await smartCollectionService.update(
+        id,
+        body,
+        request.user!.id,
+        request.libraryId!,
+      );
+      return reply.status(200).send({ data: detail, meta: null, errors: null });
+    },
+  );
+
+  // DELETE /:id — delete a smart collection
+  app.delete('/:id', { preHandler: [requireAuth, requireLibrary] }, async (request, reply) => {
+    const { id } = request.params as { id: string };
+    await smartCollectionService.delete(id, request.user!.id, request.libraryId!);
+    return reply.status(200).send({ data: null, meta: null, errors: null });
+  });
+
+  // GET /:id/models — the rule-derived result set
+  app.get('/:id/models', { preHandler: [requireAuth, requireLibrary] }, async (request, reply) => {
+    const { id } = request.params as { id: string };
+    const params = parseModelParams(request.query as Record<string, unknown>);
+    const result = await smartCollectionService.getModels(
+      id,
+      params,
+      request.user!.id,
+      request.libraryId!,
+    );
+    return reply.status(200).send(modelsEnvelope(result));
+  });
+}

--- a/apps/backend/src/services/rule-engine.test.ts
+++ b/apps/backend/src/services/rule-engine.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Unit tests for the rule engine. Pure — no database. SQL fragments are
+ * rendered with PgDialect and asserted on shape + parameters.
+ *
+ * Coverage:
+ * - buildLeafCondition: one assertion per (field, operator) pair, including the
+ *   exact subquery shapes that mirror searchModels.
+ * - compileRuleTree: nested AND/OR nesting, single-child unwrapping, empty-root
+ *   match-all (undefined), value/operator error paths.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import type { RuleNode, RuleCondition } from '@alexandria/shared';
+import { buildLeafCondition, compileRuleTree, buildTsQuery, collectConditions } from './rule-engine.js';
+
+const dialect = new PgDialect();
+
+function render(node: RuleNode) {
+  const compiled = compileRuleTree(node);
+  if (compiled === undefined) return { sql: undefined, params: undefined };
+  const q = dialect.sqlToQuery(compiled);
+  return { sql: q.sql, params: q.params };
+}
+
+function renderLeaf(leaf: RuleCondition) {
+  return dialect.sqlToQuery(buildLeafCondition(leaf));
+}
+
+const cond = (
+  field: RuleCondition['field'],
+  operator: RuleCondition['operator'],
+  value: string | null = null,
+): RuleCondition => ({ kind: 'condition', field, operator, value });
+
+const builtin = (f: string) => ({ source: 'builtin' as const, field: f as never });
+const meta = (slug: string) => ({ source: 'metadata' as const, slug });
+
+describe('buildTsQuery', () => {
+  it('prefix-matches the last token only', () => {
+    expect(buildTsQuery('dragon bust')).toBe('dragon & bust:*');
+  });
+  it('returns empty for punctuation-only input', () => {
+    expect(buildTsQuery('!!!')).toBe('');
+  });
+});
+
+describe('buildLeafCondition — builtin fields', () => {
+  it('name/contains uses full-text search on search_vector', () => {
+    const q = renderLeaf(cond(builtin('name'), 'contains', 'dragon'));
+    expect(q.sql).toContain('@@ to_tsquery');
+    expect(q.params).toContain('dragon:*');
+  });
+
+  it('name/contains with unparseable value matches everything', () => {
+    const q = renderLeaf(cond(builtin('name'), 'contains', '!!!'));
+    expect(q.sql.toLowerCase()).toContain('true');
+  });
+
+  it('name/equals is a case-insensitive exact match', () => {
+    const q = renderLeaf(cond(builtin('name'), 'equals', 'Dragon'));
+    expect(q.sql).toContain('lower(');
+    expect(q.params).toContain('Dragon');
+  });
+
+  it('status/is and isNot', () => {
+    expect(renderLeaf(cond(builtin('status'), 'is', 'ready')).sql).toContain('"status" =');
+    expect(renderLeaf(cond(builtin('status'), 'isNot', 'ready')).sql).toContain('<>');
+  });
+
+  it('fileType/has is an EXISTS subquery; notHas negates it', () => {
+    const has = renderLeaf(cond(builtin('fileType'), 'has', 'stl'));
+    expect(has.sql).toContain('EXISTS');
+    expect(has.sql).toContain('model_files');
+    expect(has.params).toContain('stl');
+    expect(renderLeaf(cond(builtin('fileType'), 'notHas', 'stl')).sql).toContain('NOT EXISTS');
+  });
+
+  it('collection/inCollection and notInCollection use membership subqueries', () => {
+    const inC = renderLeaf(cond(builtin('collection'), 'inCollection', 'c-id'));
+    expect(inC.sql).toContain('collection_models');
+    expect(inC.sql).toContain('IN (');
+    expect(renderLeaf(cond(builtin('collection'), 'notInCollection', 'c-id')).sql).toContain('NOT IN (');
+  });
+
+  it('tag/hasTag joins tags case-insensitively', () => {
+    const q = renderLeaf(cond(builtin('tag'), 'hasTag', 'Dragon'));
+    expect(q.sql).toContain('model_tags');
+    expect(q.sql).toContain('lower(t.name) = lower(');
+    expect(q.params).toContain('Dragon');
+    expect(renderLeaf(cond(builtin('tag'), 'notHasTag', 'Dragon')).sql).toContain('NOT IN');
+  });
+});
+
+describe('buildLeafCondition — metadata fields', () => {
+  it('equals/is uses the slug-join subquery (mirrors searchModels)', () => {
+    const q = renderLeaf(cond(meta('artist'), 'equals', 'Loot Studios'));
+    expect(q.sql).toContain('model_metadata');
+    expect(q.sql).toContain('metadata_field_definitions');
+    expect(q.sql).toContain('fd.slug =');
+    expect(q.params).toEqual(expect.arrayContaining(['artist', 'Loot Studios']));
+  });
+
+  it('notEquals negates membership', () => {
+    expect(renderLeaf(cond(meta('artist'), 'notEquals', 'X')).sql).toContain('NOT IN');
+  });
+
+  it('contains uses ILIKE with wildcards', () => {
+    const q = renderLeaf(cond(meta('artist'), 'contains', 'loot'));
+    expect(q.sql).toContain('ILIKE');
+    expect(q.params).toContain('%loot%');
+  });
+
+  it('exists / notExists check for a non-empty value', () => {
+    expect(renderLeaf(cond(meta('artist'), 'exists')).sql).toContain("mm.value <> ''");
+    expect(renderLeaf(cond(meta('artist'), 'notExists')).sql).toContain('NOT IN');
+  });
+});
+
+describe('buildLeafCondition — error paths', () => {
+  it('throws when a value-required operator has no value', () => {
+    expect(() => buildLeafCondition(cond(builtin('status'), 'is', null))).toThrow();
+  });
+  it('throws on an illegal field/operator pair', () => {
+    expect(() => buildLeafCondition(cond(builtin('status'), 'contains', 'x'))).toThrow();
+  });
+});
+
+describe('compileRuleTree', () => {
+  it('returns undefined for an empty root group (match all)', () => {
+    expect(compileRuleTree({ kind: 'group', op: 'and', children: [] })).toBeUndefined();
+  });
+
+  it('unwraps a single-child group (no AND/OR wrapper)', () => {
+    const single: RuleNode = {
+      kind: 'group',
+      op: 'and',
+      children: [cond(builtin('status'), 'is', 'ready')],
+    };
+    const q = render(single);
+    expect(q.sql).toContain('"status" =');
+    expect(q.sql).not.toMatch(/\band\b/i);
+  });
+
+  it('combines children with AND', () => {
+    const tree: RuleNode = {
+      kind: 'group',
+      op: 'and',
+      children: [cond(builtin('tag'), 'hasTag', 'dragon'), cond(builtin('fileType'), 'has', 'stl')],
+    };
+    const q = render(tree);
+    expect(q.sql).toContain(' and ');
+    expect(q.params).toEqual(expect.arrayContaining(['dragon', 'stl']));
+  });
+
+  it('combines children with OR', () => {
+    const tree: RuleNode = {
+      kind: 'group',
+      op: 'or',
+      children: [cond(builtin('status'), 'is', 'ready'), cond(builtin('status'), 'is', 'processing')],
+    };
+    expect(render(tree).sql).toContain(' or ');
+  });
+
+  it('nests groups: (tag AND fileType) OR status', () => {
+    const tree: RuleNode = {
+      kind: 'group',
+      op: 'or',
+      children: [
+        {
+          kind: 'group',
+          op: 'and',
+          children: [cond(builtin('tag'), 'hasTag', 'dragon'), cond(builtin('fileType'), 'has', 'stl')],
+        },
+        cond(builtin('status'), 'is', 'error'),
+      ],
+    };
+    const q = render(tree);
+    expect(q.sql).toContain(' or ');
+    expect(q.sql).toContain(' and ');
+    expect(q.params).toEqual(expect.arrayContaining(['dragon', 'stl', 'error']));
+  });
+});
+
+describe('collectConditions', () => {
+  it('flattens every leaf in a nested tree', () => {
+    const tree: RuleNode = {
+      kind: 'group',
+      op: 'or',
+      children: [
+        { kind: 'group', op: 'and', children: [cond(builtin('status'), 'is', 'ready')] },
+        cond(builtin('tag'), 'hasTag', 'dragon'),
+      ],
+    };
+    expect(collectConditions(tree)).toHaveLength(2);
+  });
+});

--- a/apps/backend/src/services/rule-engine.ts
+++ b/apps/backend/src/services/rule-engine.ts
@@ -1,0 +1,230 @@
+import { and, or, sql, SQL } from 'drizzle-orm';
+import type { RuleNode, RuleCondition, RuleFieldRef } from '@alexandria/shared';
+import { models } from '../db/schema/index.js';
+import { validationError } from '../utils/errors.js';
+
+// ---------------------------------------------------------------------------
+// Rule engine — compiles a smart-collection rule tree into a single Drizzle SQL
+// condition over the models table.
+//
+// The per-leaf SQL fragments mirror EXACTLY the subquery shapes used by
+// search.service `searchModels`, so a flat ModelSearchParams filter and the
+// equivalent rule tree produce identical results. searchModels is refactored to
+// build its own conditions via `buildLeafCondition` too, so there is a single
+// source of truth for "what SQL a filter on dimension X looks like".
+//
+// The compiler is pure: no I/O, no DB access, no context needed. All v1
+// operators are text comparisons, so it never needs a metadata field's type to
+// emit SQL. Validation that a field exists and that its operator is legal for
+// its type happens in SmartCollectionService before compilation.
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert a user-supplied search string into a Postgres tsquery expression.
+ * Mirrors the global search bar: "dragon bust" → "dragon & bust:*" (prefix
+ * match on the final token only). Returns '' when nothing usable remains.
+ *
+ * Defined here (not in search.service) so both the rule engine and the
+ * refactored searchModels can share it without a circular import.
+ */
+export function buildTsQuery(q: string): string {
+  const tokens = q.trim().split(/\s+/).filter(Boolean);
+  if (tokens.length === 0) return '';
+
+  // Strip characters that have special meaning in tsquery
+  const safe = tokens.map((t) => t.replace(/[!'()*:&|<>]/g, ''));
+  const filtered = safe.filter(Boolean);
+  if (filtered.length === 0) return '';
+
+  const last = filtered.length - 1;
+  const parts = filtered.map((t, i) => (i === last ? `${t}:*` : t));
+  return parts.join(' & ');
+}
+
+/** A non-null, non-empty value is required for every operator except exists/notExists. */
+function requireValue(leaf: RuleCondition): string {
+  if (leaf.value === null || leaf.value.trim() === '') {
+    throw validationError(`Rule operator '${leaf.operator}' requires a value`);
+  }
+  return leaf.value;
+}
+
+function describeField(field: RuleFieldRef): string {
+  return field.source === 'builtin' ? field.field : `metadata:${field.slug}`;
+}
+
+function illegal(leaf: RuleCondition): never {
+  throw validationError(
+    `Operator '${leaf.operator}' is not valid for field '${describeField(leaf.field)}'`,
+  );
+}
+
+// ---- Built-in field leaves ----
+
+function buildBuiltinCondition(leaf: RuleCondition): SQL {
+  if (leaf.field.source !== 'builtin') illegal(leaf);
+  const op = leaf.operator;
+
+  switch (leaf.field.field) {
+    case 'name': {
+      // `contains` performs a full-text search across the model's indexed text
+      // (name weighted above description) — identical to the search bar's `q`.
+      if (op === 'contains') {
+        const tsQuery = buildTsQuery(requireValue(leaf));
+        if (!tsQuery) return sql`true`; // unparseable query → no constraint (matches search)
+        return sql`${models.searchVector} @@ to_tsquery('english', ${tsQuery})`;
+      }
+      if (op === 'equals') {
+        return sql`lower(${models.name}) = lower(${requireValue(leaf)})`;
+      }
+      return illegal(leaf);
+    }
+
+    case 'description': {
+      // True substring match on the description column (search_vector cannot
+      // separate name from description, so this uses the column directly).
+      if (op === 'contains') {
+        return sql`${models.description} ILIKE ${'%' + requireValue(leaf) + '%'}`;
+      }
+      return illegal(leaf);
+    }
+
+    case 'status': {
+      if (op === 'is') return sql`${models.status} = ${requireValue(leaf)}`;
+      if (op === 'isNot') return sql`${models.status} <> ${requireValue(leaf)}`;
+      return illegal(leaf);
+    }
+
+    case 'fileType': {
+      const value = requireValue(leaf);
+      const exists = sql`EXISTS (
+        SELECT 1 FROM model_files mf
+        WHERE mf.model_id = ${models.id}
+          AND mf.file_type = ${value}
+      )`;
+      if (op === 'has') return exists;
+      if (op === 'notHas') return sql`NOT ${exists}`;
+      return illegal(leaf);
+    }
+
+    case 'collection': {
+      const value = requireValue(leaf);
+      const inSet = sql`${models.id} IN (
+        SELECT cm.model_id FROM collection_models cm
+        WHERE cm.collection_id = ${value}
+      )`;
+      if (op === 'inCollection') return inSet;
+      if (op === 'notInCollection') return sql`${models.id} NOT IN (
+        SELECT cm.model_id FROM collection_models cm
+        WHERE cm.collection_id = ${value}
+      )`;
+      return illegal(leaf);
+    }
+
+    case 'tag': {
+      const value = requireValue(leaf);
+      const inSet = sql`${models.id} IN (
+        SELECT mt.model_id FROM model_tags mt
+        INNER JOIN tags t ON t.id = mt.tag_id
+        WHERE lower(t.name) = lower(${value})
+      )`;
+      if (op === 'hasTag') return inSet;
+      if (op === 'notHasTag') return sql`${models.id} NOT IN (
+        SELECT mt.model_id FROM model_tags mt
+        INNER JOIN tags t ON t.id = mt.tag_id
+        WHERE lower(t.name) = lower(${value})
+      )`;
+      return illegal(leaf);
+    }
+
+    default:
+      return illegal(leaf);
+  }
+}
+
+// ---- Metadata field leaves ----
+//
+// All use the slug-join form (identical to searchModels' metadataFilters
+// subquery) so the SQL is provably the same as flat search. Membership is
+// expressed as IN / NOT IN over model ids.
+
+function metadataMembership(slug: string, valuePredicate: SQL): SQL {
+  return sql`(
+    SELECT mm.model_id FROM model_metadata mm
+    INNER JOIN metadata_field_definitions fd ON fd.id = mm.field_definition_id
+    WHERE fd.slug = ${slug} AND ${valuePredicate}
+  )`;
+}
+
+function buildMetadataCondition(leaf: RuleCondition): SQL {
+  if (leaf.field.source !== 'metadata') illegal(leaf);
+  const slug = leaf.field.slug;
+  const op = leaf.operator;
+
+  switch (op) {
+    case 'equals':
+    case 'is': {
+      const sub = metadataMembership(slug, sql`mm.value = ${requireValue(leaf)}`);
+      return sql`${models.id} IN ${sub}`;
+    }
+    case 'notEquals':
+    case 'isNot': {
+      const sub = metadataMembership(slug, sql`mm.value = ${requireValue(leaf)}`);
+      return sql`${models.id} NOT IN ${sub}`;
+    }
+    case 'contains': {
+      const sub = metadataMembership(slug, sql`mm.value ILIKE ${'%' + requireValue(leaf) + '%'}`);
+      return sql`${models.id} IN ${sub}`;
+    }
+    case 'exists': {
+      const sub = metadataMembership(slug, sql`mm.value <> ''`);
+      return sql`${models.id} IN ${sub}`;
+    }
+    case 'notExists': {
+      const sub = metadataMembership(slug, sql`mm.value <> ''`);
+      return sql`${models.id} NOT IN ${sub}`;
+    }
+    default:
+      return illegal(leaf);
+  }
+}
+
+/** Compile a single leaf condition to SQL. */
+export function buildLeafCondition(leaf: RuleCondition): SQL {
+  return leaf.field.source === 'builtin'
+    ? buildBuiltinCondition(leaf)
+    : buildMetadataCondition(leaf);
+}
+
+/**
+ * Compile a rule tree into a single SQL condition over the models table.
+ *
+ * Returns `undefined` when the tree imposes no constraint (an empty root
+ * group) — the caller treats that as "match every model in the library".
+ * Non-empty groups always produce SQL because leaves always do.
+ */
+export function compileRuleTree(node: RuleNode): SQL | undefined {
+  if (node.kind === 'condition') {
+    return buildLeafCondition(node);
+  }
+
+  const compiled = node.children
+    .map((child) => compileRuleTree(child))
+    .filter((c): c is SQL => c !== undefined);
+
+  if (compiled.length === 0) {
+    // Only reachable for an empty root group (nested groups require >=1 child).
+    return undefined;
+  }
+  if (compiled.length === 1) {
+    return compiled[0];
+  }
+  // and()/or() with >=2 defined operands always return a defined SQL.
+  return (node.op === 'and' ? and(...compiled) : or(...compiled)) as SQL;
+}
+
+/** Walk every condition leaf in a tree (used by callers for inspection). */
+export function collectConditions(node: RuleNode): RuleCondition[] {
+  if (node.kind === 'condition') return [node];
+  return node.children.flatMap(collectConditions);
+}

--- a/apps/backend/src/services/rule-engine.ts
+++ b/apps/backend/src/services/rule-engine.ts
@@ -169,6 +169,8 @@ function buildMetadataCondition(leaf: RuleCondition): SQL {
     }
     case 'notEquals':
     case 'isNot': {
+      // NOT IN also matches models that have NO value for this field (not just a
+      // different value). Safe here: model_metadata.model_id is NOT NULL.
       const sub = metadataMembership(slug, sql`mm.value = ${requireValue(leaf)}`);
       return sql`${models.id} NOT IN ${sub}`;
     }

--- a/apps/backend/src/services/search.service.ts
+++ b/apps/backend/src/services/search.service.ts
@@ -10,6 +10,8 @@ import { models } from '../db/schema/index.js';
 import { presenterService } from './presenter.service.js';
 import { collectionService } from './collection.service.js';
 import { metadataService } from './metadata.service.js';
+import { buildLeafCondition, buildTsQuery } from './rule-engine.js';
+import type { RuleCondition, RuleFieldRef, RuleOperator } from '@alexandria/shared';
 import { validationError } from '../utils/errors.js';
 import { createLogger } from '../utils/logger.js';
 
@@ -23,8 +25,23 @@ const DEFAULT_GLOBAL_LIMIT = 6;
 // Public interfaces
 // ---------------------------------------------------------------------------
 
+/**
+ * Extra options for searchModels. `ruleWhere` is a pre-compiled smart-collection
+ * rule tree (see rule-engine) ANDed into the query. `applyDefaultStatus`
+ * controls the implicit status='ready' default — smart collections suppress it
+ * when their rule tree references status, to avoid a contradiction.
+ */
+export interface SearchModelsOptions {
+  ruleWhere?: SQL;
+  applyDefaultStatus?: boolean;
+}
+
 export interface ISearchService {
-  searchModels(params: ModelSearchParams, libraryId: string): Promise<SearchResult>;
+  searchModels(
+    params: ModelSearchParams,
+    libraryId: string,
+    options?: SearchModelsOptions,
+  ): Promise<SearchResult>;
   searchAll(
     params: GlobalSearchParams,
     userId: string,
@@ -53,23 +70,12 @@ interface CursorPayload {
 // ---------------------------------------------------------------------------
 
 /**
- * Convert a user-supplied search string into a Postgres tsquery expression.
- * Example: "dragon bust" → "dragon & bust:*"
- * Prefix matching is applied only to the last token so mid-string words still
- * require exact form, keeping result quality reasonable.
+ * Build a single flat filter as a rule-engine leaf, so flat search and smart
+ * collections emit identical SQL per dimension (buildTsQuery is shared too).
  */
-function buildTsQuery(q: string): string {
-  const tokens = q.trim().split(/\s+/).filter(Boolean);
-  if (tokens.length === 0) return '';
-
-  // Escape characters that have special meaning in tsquery
-  const safe = tokens.map((t) => t.replace(/[!'()*:&|<>]/g, ''));
-  const filtered = safe.filter(Boolean);
-  if (filtered.length === 0) return '';
-
-  const last = filtered.length - 1;
-  const parts = filtered.map((t, i) => (i === last ? `${t}:*` : t));
-  return parts.join(' & ');
+function leaf(field: RuleFieldRef, operator: RuleOperator, value: string) {
+  const condition: RuleCondition = { kind: 'condition', field, operator, value };
+  return buildLeafCondition(condition);
 }
 
 function encodeCursor(sortValue: string | number, id: string): string {
@@ -112,7 +118,12 @@ function buildCursorWhere(
 // ---------------------------------------------------------------------------
 
 export class PostgresSearchService implements ISearchService {
-  async searchModels(params: ModelSearchParams, libraryId: string): Promise<SearchResult> {
+  async searchModels(
+    params: ModelSearchParams,
+    libraryId: string,
+    options: SearchModelsOptions = {},
+  ): Promise<SearchResult> {
+    const { ruleWhere, applyDefaultStatus = true } = options;
     const pageSize = Math.min(params.pageSize ?? DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE);
     const sortField = params.sort ?? 'createdAt';
     const sortDir = params.sortDir ?? 'desc';
@@ -155,63 +166,46 @@ export class PostgresSearchService implements ISearchService {
       }
     }
 
-    // Status filter — default to 'ready' to exclude processing/error models
+    // Status filter — default to 'ready' to exclude processing/error models.
+    // The default is suppressed when a smart-collection rule tree already
+    // constrains status (applyDefaultStatus=false), to avoid a contradiction.
     if (params.status) {
-      conditions.push(sql`${models.status} = ${params.status}`);
-    } else {
-      conditions.push(sql`${models.status} = 'ready'`);
+      conditions.push(leaf({ source: 'builtin', field: 'status' }, 'is', params.status));
+    } else if (applyDefaultStatus) {
+      conditions.push(leaf({ source: 'builtin', field: 'status' }, 'is', 'ready'));
     }
 
     // File type filter — EXISTS subquery
     if (params.fileType) {
-      conditions.push(
-        sql`EXISTS (
-          SELECT 1 FROM model_files mf
-          WHERE mf.model_id = ${models.id}
-            AND mf.file_type = ${params.fileType}
-        )`,
-      );
+      conditions.push(leaf({ source: 'builtin', field: 'fileType' }, 'has', params.fileType));
     }
 
     // Collection filter
     if (params.collectionId) {
       conditions.push(
-        sql`${models.id} IN (
-          SELECT cm.model_id FROM collection_models cm
-          WHERE cm.collection_id = ${params.collectionId}
-        )`,
+        leaf({ source: 'builtin', field: 'collection' }, 'inCollection', params.collectionId),
       );
     }
 
-    // Tags filter — ALL semantics (model must have every listed tag)
-    // Matches by tag name (case-insensitive) because listFieldValues returns tag names as values.
+    // Tags filter — ALL semantics (model must have every listed tag).
+    // Matches by tag name (case-insensitive); one membership leaf per tag.
     if (params.tags) {
       const tagNames = params.tags.split(',').map((s) => s.trim()).filter(Boolean);
-      if (tagNames.length > 0) {
-        for (const name of tagNames) {
-          conditions.push(
-            sql`${models.id} IN (
-              SELECT mt.model_id FROM model_tags mt
-              INNER JOIN tags t ON t.id = mt.tag_id
-              WHERE lower(t.name) = lower(${name})
-            )`,
-          );
-        }
+      for (const name of tagNames) {
+        conditions.push(leaf({ source: 'builtin', field: 'tag' }, 'hasTag', name));
       }
     }
 
-    // Generic metadata filters
+    // Generic metadata filters — exact value match per field slug
     if (params.metadataFilters && Object.keys(params.metadataFilters).length > 0) {
       for (const [fieldSlug, value] of Object.entries(params.metadataFilters)) {
-        conditions.push(
-          sql`${models.id} IN (
-            SELECT mm.model_id FROM model_metadata mm
-            INNER JOIN metadata_field_definitions fd ON fd.id = mm.field_definition_id
-            WHERE fd.slug = ${fieldSlug}
-              AND mm.value = ${value}
-          )`,
-        );
+        conditions.push(leaf({ source: 'metadata', slug: fieldSlug }, 'equals', value));
       }
+    }
+
+    // Smart-collection rule tree (pre-compiled by the caller), ANDed in.
+    if (ruleWhere) {
+      conditions.push(ruleWhere);
     }
 
     const whereClause = conditions.length > 0 ? and(...conditions) : undefined;

--- a/apps/backend/src/services/smart-collection.service.ts
+++ b/apps/backend/src/services/smart-collection.service.ts
@@ -87,6 +87,15 @@ export class SmartCollectionService {
       const fields = await metadataService.listFields();
       const bySlug = new Map(fields.map((f) => [f.slug, f]));
       for (const leaf of metadataLeaves) {
+        // Tags are stored in the dedicated model_tags/tags tables (per D3), not
+        // model_metadata, so a metadata rule on the 'tags' field would silently
+        // match nothing. Direct callers to the builtin `tag` dimension instead.
+        if (leaf.field.slug === 'tags') {
+          throw validationError(
+            "Use the 'tag' field instead of the Tags metadata field",
+            'definition',
+          );
+        }
         const def = bySlug.get(leaf.field.slug);
         if (!def) {
           throw validationError(`Unknown metadata field: ${leaf.field.slug}`, 'definition');

--- a/apps/backend/src/services/smart-collection.service.ts
+++ b/apps/backend/src/services/smart-collection.service.ts
@@ -1,0 +1,256 @@
+import { and, eq, SQL } from 'drizzle-orm';
+import type {
+  SmartCollection,
+  SmartCollectionDetail,
+  CreateSmartCollectionRequest,
+  UpdateSmartCollectionRequest,
+  RuleNode,
+  ModelSearchParams,
+} from '@alexandria/shared';
+import { LEGAL_OPERATORS_BY_METADATA_TYPE } from '@alexandria/shared';
+import { db } from '../db/index.js';
+import { smartCollections } from '../db/schema/index.js';
+import type { SmartCollection as SmartCollectionRow } from '../db/schema/smart-collection.js';
+import { searchService, type SearchResult } from './search.service.js';
+import { metadataService } from './metadata.service.js';
+import { compileRuleTree, collectConditions } from './rule-engine.js';
+import { createLogger } from '../utils/logger.js';
+import { generateSlug } from '../utils/slug.js';
+import { notFound, validationError } from '../utils/errors.js';
+
+const logger = createLogger('SmartCollectionService');
+
+/** The result of validating + compiling a rule tree, ready for searchModels. */
+interface CompiledRules {
+  ruleWhere: SQL | undefined;
+  /** False when the tree references status, so searchModels skips its ready default. */
+  applyDefaultStatus: boolean;
+}
+
+function toEntity(row: SmartCollectionRow): SmartCollection {
+  return {
+    id: row.id,
+    name: row.name,
+    slug: row.slug,
+    description: row.description,
+    definition: row.definition,
+    userId: row.userId,
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+  };
+}
+
+export class SmartCollectionService {
+  /**
+   * Verify a smart collection exists, belongs to the user, and is in the
+   * library. Returns the row. Throws NOT_FOUND if any check fails — same error
+   * shape regardless of which, so IDs cannot be enumerated.
+   */
+  async requireOwnedSmartCollection(
+    id: string,
+    userId: string,
+    libraryId: string,
+  ): Promise<SmartCollectionRow> {
+    const [row] = await db
+      .select()
+      .from(smartCollections)
+      .where(
+        and(
+          eq(smartCollections.id, id),
+          eq(smartCollections.userId, userId),
+          eq(smartCollections.libraryId, libraryId),
+        ),
+      )
+      .limit(1);
+
+    if (!row) {
+      throw notFound('Smart collection not found');
+    }
+    return row;
+  }
+
+  /**
+   * Validate a rule tree against the live metadata field definitions and
+   * compile it to SQL. Builtin field/operator legality is already enforced by
+   * the shared schema and rule engine; this adds the checks that need DB state:
+   * metadata slugs must exist and their operator must be legal for the field's
+   * type. Also decides whether searchModels should apply its status default.
+   */
+  private async resolveAndCompile(definition: RuleNode): Promise<CompiledRules> {
+    const conditions = collectConditions(definition);
+
+    const metadataLeaves = conditions.filter(
+      (c): c is typeof c & { field: { source: 'metadata'; slug: string } } =>
+        c.field.source === 'metadata',
+    );
+    if (metadataLeaves.length > 0) {
+      const fields = await metadataService.listFields();
+      const bySlug = new Map(fields.map((f) => [f.slug, f]));
+      for (const leaf of metadataLeaves) {
+        const def = bySlug.get(leaf.field.slug);
+        if (!def) {
+          throw validationError(`Unknown metadata field: ${leaf.field.slug}`, 'definition');
+        }
+        const legal = LEGAL_OPERATORS_BY_METADATA_TYPE[def.type];
+        if (!legal.includes(leaf.operator)) {
+          throw validationError(
+            `Operator '${leaf.operator}' is not valid for field '${leaf.field.slug}'`,
+            'definition',
+          );
+        }
+      }
+    }
+
+    const hasStatusLeaf = conditions.some(
+      (c) => c.field.source === 'builtin' && c.field.field === 'status',
+    );
+
+    return { ruleWhere: compileRuleTree(definition), applyDefaultStatus: !hasStatusLeaf };
+  }
+
+  /** Count of models the tree currently matches (derived via searchModels). */
+  private async countModels(compiled: CompiledRules, libraryId: string): Promise<number> {
+    const result = await searchService.searchModels({ pageSize: 1 }, libraryId, compiled);
+    return result.total;
+  }
+
+  private async toDetail(row: SmartCollectionRow, libraryId: string): Promise<SmartCollectionDetail> {
+    const compiled = await this.resolveAndCompile(row.definition);
+    const modelCount = await this.countModels(compiled, libraryId);
+    return {
+      id: row.id,
+      name: row.name,
+      slug: row.slug,
+      description: row.description,
+      definition: row.definition,
+      modelCount,
+      createdAt: row.createdAt.toISOString(),
+      updatedAt: row.updatedAt.toISOString(),
+    };
+  }
+
+  async create(
+    data: CreateSmartCollectionRequest,
+    userId: string,
+    libraryId: string,
+  ): Promise<SmartCollectionDetail> {
+    // Validate the tree before insert so a bad definition is a 4xx, not a row.
+    await this.resolveAndCompile(data.definition);
+
+    const slug = generateSlug(data.name);
+    const [row] = await db
+      .insert(smartCollections)
+      .values({
+        name: data.name,
+        slug,
+        description: data.description ?? null,
+        definition: data.definition,
+        userId,
+        libraryId,
+      })
+      .returning();
+
+    logger.info(
+      { service: 'SmartCollectionService', smartCollectionId: row.id, name: row.name, slug },
+      'Smart collection created',
+    );
+
+    return this.toDetail(row, libraryId);
+  }
+
+  async getById(id: string, userId: string, libraryId: string): Promise<SmartCollectionDetail> {
+    const row = await this.requireOwnedSmartCollection(id, userId, libraryId);
+    return this.toDetail(row, libraryId);
+  }
+
+  /** List smart collections for a user+library (no result counts — kept cheap). */
+  async list(userId: string, libraryId: string): Promise<SmartCollection[]> {
+    const rows = await db
+      .select()
+      .from(smartCollections)
+      .where(and(eq(smartCollections.userId, userId), eq(smartCollections.libraryId, libraryId)))
+      .orderBy(smartCollections.createdAt);
+    return rows.map(toEntity);
+  }
+
+  async update(
+    id: string,
+    data: UpdateSmartCollectionRequest,
+    userId: string,
+    libraryId: string,
+  ): Promise<SmartCollectionDetail> {
+    await this.requireOwnedSmartCollection(id, userId, libraryId);
+
+    if (data.definition !== undefined) {
+      await this.resolveAndCompile(data.definition);
+    }
+
+    const updateValues: Partial<{
+      name: string;
+      slug: string;
+      description: string | null;
+      definition: RuleNode;
+      updatedAt: Date;
+    }> = { updatedAt: new Date() };
+
+    if (data.name !== undefined) {
+      updateValues.name = data.name;
+      updateValues.slug = generateSlug(data.name);
+    }
+    if (data.description !== undefined) {
+      updateValues.description = data.description;
+    }
+    if (data.definition !== undefined) {
+      updateValues.definition = data.definition;
+    }
+
+    const [updated] = await db
+      .update(smartCollections)
+      .set(updateValues)
+      .where(eq(smartCollections.id, id))
+      .returning();
+
+    logger.info(
+      { service: 'SmartCollectionService', smartCollectionId: id },
+      'Smart collection updated',
+    );
+
+    return this.toDetail(updated, libraryId);
+  }
+
+  async delete(id: string, userId: string, libraryId: string): Promise<void> {
+    await this.requireOwnedSmartCollection(id, userId, libraryId);
+    await db.delete(smartCollections).where(eq(smartCollections.id, id));
+    logger.info(
+      { service: 'SmartCollectionService', smartCollectionId: id },
+      'Smart collection deleted',
+    );
+  }
+
+  /**
+   * The derived result set for a saved smart collection. Ad-hoc params (extra
+   * tags, sort, pagination) are ANDed onto the compiled rule tree by searchModels.
+   */
+  async getModels(
+    id: string,
+    params: ModelSearchParams,
+    userId: string,
+    libraryId: string,
+  ): Promise<SearchResult> {
+    const row = await this.requireOwnedSmartCollection(id, userId, libraryId);
+    const compiled = await this.resolveAndCompile(row.definition);
+    return searchService.searchModels(params, libraryId, compiled);
+  }
+
+  /** Dry-run an unsaved rule tree — used by the composer's live preview. */
+  async preview(
+    definition: RuleNode,
+    params: ModelSearchParams,
+    libraryId: string,
+  ): Promise<SearchResult> {
+    const compiled = await this.resolveAndCompile(definition);
+    return searchService.searchModels(params, libraryId, compiled);
+  }
+}
+
+export const smartCollectionService = new SmartCollectionService();

--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import { CollectionDetailPage } from './pages/CollectionDetailPage';
 import { SettingsPage } from './pages/SettingsPage';
 import { UploadPage } from './pages/UploadPage';
 import { SearchPage } from './pages/SearchPage';
+import { SmartCollectionComposerPage } from './pages/SmartCollectionComposerPage';
 import { DesignSystemPage } from './pages/DesignSystemPage';
 
 function ProtectedRoute({ children }: { children: React.ReactNode }) {
@@ -47,6 +48,8 @@ export default function App() {
         <Route path="collections" element={<CollectionsPage />} />
         <Route path="collections/:id" element={<CollectionDetailPage />} />
         <Route path="upload" element={<UploadPage />} />
+        <Route path="smart-collections/new" element={<SmartCollectionComposerPage />} />
+        <Route path="smart-collections/:id/edit" element={<SmartCollectionComposerPage />} />
         <Route path="settings" element={<SettingsPage />} />
         <Route path="search" element={<SearchPage />} />
       </Route>

--- a/apps/frontend/src/api/smart-collections.ts
+++ b/apps/frontend/src/api/smart-collections.ts
@@ -1,0 +1,55 @@
+import type {
+  ApiResponse,
+  SmartCollection,
+  SmartCollectionDetail,
+  CreateSmartCollectionRequest,
+  UpdateSmartCollectionRequest,
+  PreviewSmartCollectionRequest,
+  ModelCard,
+  ModelSearchParams,
+} from '@alexandria/shared';
+import { get, post, patch, del } from './client';
+import { buildQueryString } from '../lib/query';
+
+export async function getSmartCollections(): Promise<ApiResponse<SmartCollection[]>> {
+  return get<SmartCollection[]>('/smart-collections');
+}
+
+export async function getSmartCollection(id: string): Promise<SmartCollectionDetail> {
+  const response = await get<SmartCollectionDetail>(`/smart-collections/${id}`);
+  return response.data;
+}
+
+export async function getSmartCollectionModels(
+  id: string,
+  params?: ModelSearchParams
+): Promise<ApiResponse<ModelCard[]>> {
+  const qs = params ? buildQueryString(params as Record<string, unknown>) : '';
+  return get<ModelCard[]>(`/smart-collections/${id}/models${qs}`);
+}
+
+export async function createSmartCollection(
+  data: CreateSmartCollectionRequest
+): Promise<SmartCollectionDetail> {
+  const response = await post<SmartCollectionDetail>('/smart-collections', data);
+  return response.data;
+}
+
+export async function updateSmartCollection(
+  id: string,
+  data: UpdateSmartCollectionRequest
+): Promise<SmartCollectionDetail> {
+  const response = await patch<SmartCollectionDetail>(`/smart-collections/${id}`, data);
+  return response.data;
+}
+
+export async function deleteSmartCollection(id: string): Promise<void> {
+  await del(`/smart-collections/${id}`);
+}
+
+/** Dry-run an unsaved rule tree for the composer's live preview. */
+export async function previewSmartCollection(
+  data: PreviewSmartCollectionRequest
+): Promise<ApiResponse<ModelCard[]>> {
+  return post<ModelCard[]>('/smart-collections/preview', data);
+}

--- a/apps/frontend/src/components/models/ModelGroupView.test.tsx
+++ b/apps/frontend/src/components/models/ModelGroupView.test.tsx
@@ -81,7 +81,7 @@ function wrapper({ children }: { children: React.ReactNode }) {
   );
 }
 
-const DEFAULT_AXIS_VALUE = { collectionId: undefined, artist: undefined, tags: [] };
+const DEFAULT_AXIS_VALUE = { collectionId: undefined, artist: undefined, tags: [], smartCollectionId: undefined };
 
 // ---------------------------------------------------------------------------
 // Tests

--- a/apps/frontend/src/components/pivot/AxisFacetBody.tsx
+++ b/apps/frontend/src/components/pivot/AxisFacetBody.tsx
@@ -1,10 +1,13 @@
 import { useQuery } from '@tanstack/react-query';
+import { Link } from 'react-router-dom';
+import { Plus } from 'lucide-react';
 import { getCollections } from '../../api/collections';
 import { getFieldValues } from '../../api/metadata';
+import { getSmartCollections } from '../../api/smart-collections';
 import { useModelFilters } from '../../hooks/use-model-filters';
 import type { PivotAxis } from '../../hooks/use-model-filters';
 import { CollectionTree } from '../collections/CollectionTree';
-import { ArtistIcon, TagIcon } from '../icons';
+import { ArtistIcon, TagIcon, SmartIcon } from '../icons';
 import { FacetItem } from './FacetItem';
 
 interface AxisFacetBodyProps {
@@ -121,6 +124,44 @@ function TagsAxis() {
   );
 }
 
+function SmartAxis() {
+  const { smartCollectionId, setSmartCollectionId } = useModelFilters();
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['smart-collections'],
+    queryFn: () => getSmartCollections().then((r) => r.data),
+  });
+
+  return (
+    <div className="flex flex-col gap-px px-1">
+      <Link
+        to="/smart-collections/new"
+        className="flex items-center gap-1.5 mx-1 my-1 rounded-md px-2 py-1.5 text-xs font-medium transition-colors hover:bg-[var(--ax-rail-hover)]"
+        style={{ color: 'var(--ax-rail-fg)' }}
+      >
+        <Plus className="h-3.5 w-3.5" aria-hidden />
+        New smart collection
+      </Link>
+
+      {isLoading && <LoadingRows />}
+
+      {!isLoading && (!data || data.length === 0) && (
+        <p className="px-3 py-2 text-xs text-[var(--ax-rail-fg-muted)]">No smart collections yet.</p>
+      )}
+
+      {data?.map((sc) => (
+        <FacetItem
+          key={sc.id}
+          icon={SmartIcon}
+          label={sc.name}
+          active={smartCollectionId === sc.id}
+          onClick={() => setSmartCollectionId(smartCollectionId === sc.id ? undefined : sc.id)}
+        />
+      ))}
+    </div>
+  );
+}
+
 /**
  * Renders the facet list body for the currently active pivot axis.
  * Fetches its own data via React Query; uses setters from useModelFilters
@@ -132,6 +173,7 @@ export function AxisFacetBody({ axis }: AxisFacetBodyProps) {
       {axis === 'collections' && <CollectionsAxis />}
       {axis === 'artists' && <ArtistsAxis />}
       {axis === 'tags' && <TagsAxis />}
+      {axis === 'smart' && <SmartAxis />}
     </div>
   );
 }

--- a/apps/frontend/src/components/pivot/AxisPicker.tsx
+++ b/apps/frontend/src/components/pivot/AxisPicker.tsx
@@ -1,6 +1,6 @@
 import { cn } from '../../lib/utils';
 import { useModelFilters, type PivotAxis } from '../../hooks/use-model-filters';
-import { CollectionsIcon, ArtistIcon, TagIcon } from '../icons';
+import { CollectionsIcon, ArtistIcon, TagIcon, SmartIcon } from '../icons';
 
 interface AxisOption {
   id: PivotAxis;
@@ -12,6 +12,7 @@ const AXIS_OPTIONS: AxisOption[] = [
   { id: 'collections', label: 'Collections', icon: CollectionsIcon },
   { id: 'artists', label: 'Artists', icon: ArtistIcon },
   { id: 'tags', label: 'Tags', icon: TagIcon },
+  { id: 'smart', label: 'Smart', icon: SmartIcon },
 ];
 
 /**

--- a/apps/frontend/src/components/pivot/Breadcrumb.test.tsx
+++ b/apps/frontend/src/components/pivot/Breadcrumb.test.tsx
@@ -7,6 +7,7 @@ const EMPTY_AXIS_VALUE: ActiveAxisValue = {
   collectionId: undefined,
   artist: undefined,
   tags: [],
+  smartCollectionId: undefined,
 };
 
 describe('Breadcrumb', () => {

--- a/apps/frontend/src/components/pivot/Breadcrumb.tsx
+++ b/apps/frontend/src/components/pivot/Breadcrumb.tsx
@@ -3,6 +3,7 @@ import {
   CollectionsIcon,
   ArtistIcon,
   TagIcon,
+  SmartIcon,
   ChevronRightIcon,
 } from '../icons';
 
@@ -15,12 +16,14 @@ const AXIS_LABELS: Record<PivotAxis, string> = {
   collections: 'Collections',
   artists: 'Artists',
   tags: 'Tags',
+  smart: 'Smart Collections',
 };
 
 const AXIS_ICONS: Record<PivotAxis, React.ReactNode> = {
   collections: <CollectionsIcon className="h-3.5 w-3.5" />,
   artists: <ArtistIcon className="h-3.5 w-3.5" />,
   tags: <TagIcon className="h-3.5 w-3.5" />,
+  smart: <SmartIcon className="h-3.5 w-3.5" />,
 };
 
 /**

--- a/apps/frontend/src/components/pivot/PivotMain.tsx
+++ b/apps/frontend/src/components/pivot/PivotMain.tsx
@@ -1,8 +1,10 @@
 import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { Loader2 } from 'lucide-react';
+import { Loader2, Pencil } from 'lucide-react';
+import { useQuery } from '@tanstack/react-query';
 import { useModelFilters } from '../../hooks/use-model-filters';
 import { useModelResults } from '../../hooks/use-model-results';
+import { getSmartCollections, getSmartCollectionModels } from '../../api/smart-collections';
 import { useDisplayPreferences } from '../../hooks/use-display-preferences';
 import { useBulkSelection } from '../../hooks/use-bulk-selection';
 import { ModelCard } from '../models/ModelCard';
@@ -18,6 +20,7 @@ import {
   CollectionsIcon,
   ArtistIcon,
   TagIcon,
+  SmartIcon,
 } from '../icons';
 import type { PivotAxis } from '../../hooks/use-model-filters';
 
@@ -25,12 +28,14 @@ const AXIS_ICONS: Record<PivotAxis, React.ComponentType<{ className?: string }>>
   collections: CollectionsIcon,
   artists: ArtistIcon,
   tags: TagIcon,
+  smart: SmartIcon,
 };
 
 const AXIS_LABELS: Record<PivotAxis, string> = {
   collections: 'Collections',
   artists: 'Artists',
   tags: 'Tags',
+  smart: 'Smart Collections',
 };
 
 /** Derive a human-readable context title from the active axis + selection. */
@@ -65,12 +70,22 @@ function deriveContextTitle(
  */
 export function PivotMain() {
   const navigate = useNavigate();
-  const { filters, toApiParams, setQ, axis, activeAxisValue, hasActiveFilters } =
+  const { filters, toApiParams, setQ, axis, activeAxisValue, hasActiveFilters, smartCollectionId } =
     useModelFilters();
   const { view, showThumbnails } = useDisplayPreferences();
 
   const [bulkMode, setBulkMode] = useState(false);
   const { selected, toggle, selectAll, clear, isSelected, count } = useBulkSelection();
+
+  // Smart axis: drive the grid from a selected smart collection's derived set.
+  const isSmart = axis === 'smart';
+  const smartActive = isSmart && !!smartCollectionId;
+  const { data: smartList } = useQuery({
+    queryKey: ['smart-collections'],
+    queryFn: () => getSmartCollections().then((r) => r.data),
+    enabled: isSmart,
+  });
+  const activeSmart = smartList?.find((s) => s.id === smartCollectionId);
 
   const {
     models,
@@ -80,7 +95,13 @@ export function PivotMain() {
     isFetchingNextPage,
     hasNextPage,
     sentinelRef,
-  } = useModelResults({ filters, toApiParams });
+  } = useModelResults({
+    filters,
+    toApiParams,
+    fetcher: smartActive ? (params) => getSmartCollectionModels(smartCollectionId, params) : undefined,
+    queryKeyExtra: smartActive ? ['smart', smartCollectionId] : [],
+    enabled: !isSmart || smartActive,
+  });
 
   function handleSelectAll() {
     selectAll(models.map((m) => m.id));
@@ -92,13 +113,16 @@ export function PivotMain() {
   }
 
   const AxisIcon = AXIS_ICONS[axis];
-  const contextTitle = deriveContextTitle(axis, activeAxisValue);
+  const contextTitle = isSmart
+    ? activeSmart?.name ?? 'Smart Collections'
+    : deriveContextTitle(axis, activeAxisValue);
 
   // Axis icon badge background per axis
   const AXIS_BG: Record<PivotAxis, string> = {
     collections: 'linear-gradient(135deg, var(--ax-amber), var(--ax-amber-deep, #b45309))',
     artists: 'linear-gradient(135deg, var(--ax-teal, #0d9488), #0f766e)',
     tags: 'linear-gradient(135deg, var(--ax-teal, #0d9488), #0f766e)',
+    smart: 'linear-gradient(135deg, var(--ax-violet, #7c3aed), #6d28d9)',
   };
 
   return (
@@ -208,6 +232,16 @@ export function PivotMain() {
 
         {/* View switch + bulk mode toggle */}
         <div className="flex items-center gap-2 flex-shrink-0">
+          {smartActive && (
+            <Link
+              to={`/smart-collections/${smartCollectionId}/edit`}
+              className="flex items-center gap-1.5 h-8 rounded-lg px-3 text-sm font-medium transition-colors"
+              style={{ background: 'var(--ax-bg-elev)', border: '1px solid var(--ax-border)', color: 'var(--ax-fg)', textDecoration: 'none' }}
+            >
+              <Pencil className="h-3.5 w-3.5" aria-hidden />
+              Edit rules
+            </Link>
+          )}
           {models.length > 0 && (
             <button
               type="button"
@@ -331,9 +365,29 @@ export function PivotMain() {
           </>
         )}
 
+        {/* Smart axis with nothing selected — prompt to pick or create one */}
+        {isSmart && !smartActive && !isLoading && (
+          <div className="flex flex-col items-center justify-center gap-3 py-16 text-center">
+            <SmartIcon className="h-8 w-8" style={{ color: 'var(--ax-fg-muted)' }} />
+            <p className="text-sm" style={{ color: 'var(--ax-fg-muted)' }}>
+              Select a smart collection from the rail, or
+            </p>
+            <Link
+              to="/smart-collections/new"
+              className="rounded-lg px-3 h-8 flex items-center text-sm font-medium"
+              style={{ background: 'var(--ax-amber)', color: 'var(--ax-amber-fg, white)', textDecoration: 'none' }}
+            >
+              Create a smart collection
+            </Link>
+          </div>
+        )}
+
         {/* Empty state */}
-        {!isLoading && !isError && models.length === 0 && (
+        {!isSmart && !isLoading && !isError && models.length === 0 && (
           <EmptyLibrary hasFilters={hasActiveFilters} />
+        )}
+        {smartActive && !isLoading && !isError && models.length === 0 && (
+          <EmptyLibrary hasFilters />
         )}
 
         {/* Infinite scroll sentinel */}

--- a/apps/frontend/src/components/smart/ConditionRow.tsx
+++ b/apps/frontend/src/components/smart/ConditionRow.tsx
@@ -76,6 +76,10 @@ export function ConditionRow({ node, fields, onChange, onRemove }: Props) {
   const field = node.field;
   const metaDef = field.source === 'metadata' ? fields.find((f) => f.slug === field.slug) : undefined;
 
+  // The 'tags' field is stored in dedicated tables, not model_metadata, so a
+  // metadata rule on it matches nothing — the builtin "Tag" field covers it.
+  const metadataFieldOptions = fields.filter((f) => f.slug !== 'tags');
+
   const operators = legalOperators(field, metaDef);
   const valueless = VALUELESS_OPERATORS.includes(node.operator);
 
@@ -107,9 +111,9 @@ export function ConditionRow({ node, fields, onChange, onRemove }: Props) {
             </option>
           ))}
         </optgroup>
-        {fields.length > 0 && (
+        {metadataFieldOptions.length > 0 && (
           <optgroup label="Metadata">
-            {fields.map((f) => (
+            {metadataFieldOptions.map((f) => (
               <option key={f.slug} value={`metadata:${f.slug}`}>
                 {f.name}
               </option>

--- a/apps/frontend/src/components/smart/ConditionRow.tsx
+++ b/apps/frontend/src/components/smart/ConditionRow.tsx
@@ -1,0 +1,243 @@
+import { useQuery } from '@tanstack/react-query';
+import { Trash2 } from 'lucide-react';
+import type {
+  MetadataFieldDetail,
+  RuleFieldRef,
+  RuleOperator,
+  BuiltinRuleField,
+} from '@alexandria/shared';
+import {
+  LEGAL_OPERATORS_BY_BUILTIN,
+  LEGAL_OPERATORS_BY_METADATA_TYPE,
+  VALUELESS_OPERATORS,
+} from '@alexandria/shared';
+import { Select } from '../ui/select';
+import { Input } from '../ui/input';
+import { Button } from '../ui/button';
+import { getFieldValues } from '../../api/metadata';
+import type { DraftCondition } from '../../hooks/use-smart-collection-draft';
+
+// Builtin fields exposed in the composer. `collection` is supported by the rule
+// engine but omitted here in v1 (it needs a collection picker, not a raw id).
+const BUILTIN_FIELD_OPTIONS: { field: string; label: string }[] = [
+  { field: 'name', label: 'Name' },
+  { field: 'description', label: 'Description' },
+  { field: 'tag', label: 'Tag' },
+  { field: 'status', label: 'Status' },
+  { field: 'fileType', label: 'File type' },
+];
+
+const OPERATOR_LABELS: Record<RuleOperator, string> = {
+  contains: 'contains',
+  equals: 'is',
+  notEquals: 'is not',
+  is: 'is',
+  isNot: 'is not',
+  has: 'has',
+  notHas: 'does not have',
+  hasTag: 'has tag',
+  notHasTag: 'lacks tag',
+  inCollection: 'in collection',
+  notInCollection: 'not in collection',
+  exists: 'is set',
+  notExists: 'is not set',
+};
+
+const STATUS_OPTIONS = ['ready', 'processing', 'error'];
+const FILE_TYPE_OPTIONS = ['stl', 'image', 'document', 'other'];
+
+function fieldKey(f: RuleFieldRef): string {
+  return f.source === 'builtin' ? `builtin:${f.field}` : `metadata:${f.slug}`;
+}
+
+function parseFieldKey(key: string): RuleFieldRef {
+  const [source, rest] = [key.slice(0, key.indexOf(':')), key.slice(key.indexOf(':') + 1)];
+  return source === 'metadata'
+    ? { source: 'metadata', slug: rest }
+    : { source: 'builtin', field: rest as BuiltinRuleField };
+}
+
+function legalOperators(field: RuleFieldRef, def?: MetadataFieldDetail): readonly RuleOperator[] {
+  if (field.source === 'builtin') {
+    return LEGAL_OPERATORS_BY_BUILTIN[field.field] ?? [];
+  }
+  return def ? LEGAL_OPERATORS_BY_METADATA_TYPE[def.type] : ['equals', 'contains', 'exists', 'notExists'];
+}
+
+interface Props {
+  node: DraftCondition;
+  fields: MetadataFieldDetail[];
+  onChange: (patch: Partial<Omit<DraftCondition, '_id' | 'kind'>>) => void;
+  onRemove: () => void;
+}
+
+/** A single rule row: field → operator → value, plus a remove button. */
+export function ConditionRow({ node, fields, onChange, onRemove }: Props) {
+  const field = node.field;
+  const metaDef = field.source === 'metadata' ? fields.find((f) => f.slug === field.slug) : undefined;
+
+  const operators = legalOperators(field, metaDef);
+  const valueless = VALUELESS_OPERATORS.includes(node.operator);
+
+  // When the field changes, snap the operator to the first legal one and clear value.
+  function handleFieldChange(key: string) {
+    const field = parseFieldKey(key);
+    const nextDef = field.source === 'metadata' ? fields.find((f) => f.slug === field.slug) : undefined;
+    const ops = legalOperators(field, nextDef);
+    const operator = ops[0] ?? 'equals';
+    onChange({ field, operator, value: VALUELESS_OPERATORS.includes(operator) ? null : '' });
+  }
+
+  function handleOperatorChange(op: RuleOperator) {
+    onChange({ operator: op, value: VALUELESS_OPERATORS.includes(op) ? null : (node.value ?? '') });
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      <Select
+        className="w-40"
+        value={fieldKey(node.field)}
+        onChange={(e) => handleFieldChange(e.target.value)}
+        aria-label="Field"
+      >
+        <optgroup label="Built-in">
+          {BUILTIN_FIELD_OPTIONS.map((o) => (
+            <option key={o.field} value={`builtin:${o.field}`}>
+              {o.label}
+            </option>
+          ))}
+        </optgroup>
+        {fields.length > 0 && (
+          <optgroup label="Metadata">
+            {fields.map((f) => (
+              <option key={f.slug} value={`metadata:${f.slug}`}>
+                {f.name}
+              </option>
+            ))}
+          </optgroup>
+        )}
+      </Select>
+
+      <Select
+        className="w-36"
+        value={node.operator}
+        onChange={(e) => handleOperatorChange(e.target.value as RuleOperator)}
+        aria-label="Operator"
+      >
+        {operators.map((op) => (
+          <option key={op} value={op}>
+            {OPERATOR_LABELS[op]}
+          </option>
+        ))}
+      </Select>
+
+      {!valueless && (
+        <ValueInput
+          field={node.field}
+          def={metaDef}
+          value={node.value ?? ''}
+          onChange={(v) => onChange({ value: v })}
+        />
+      )}
+
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        onClick={onRemove}
+        aria-label="Remove condition"
+        className="flex-shrink-0 text-muted-foreground hover:text-destructive"
+      >
+        <Trash2 className="h-4 w-4" />
+      </Button>
+    </div>
+  );
+}
+
+function ValueInput({
+  field,
+  def,
+  value,
+  onChange,
+}: {
+  field: RuleFieldRef;
+  def?: MetadataFieldDetail;
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  // Status / file type — fixed enums
+  if (field.source === 'builtin' && field.field === 'status') {
+    return <EnumSelect options={STATUS_OPTIONS} value={value} onChange={onChange} />;
+  }
+  if (field.source === 'builtin' && field.field === 'fileType') {
+    return <EnumSelect options={FILE_TYPE_OPTIONS} value={value} onChange={onChange} />;
+  }
+  // Metadata enum / boolean
+  if (def?.type === 'boolean') {
+    return <EnumSelect options={['true', 'false']} value={value} onChange={onChange} />;
+  }
+  if (def?.type === 'enum' && def.config?.enumOptions?.length) {
+    return <EnumSelect options={def.config.enumOptions} value={value} onChange={onChange} />;
+  }
+  // Tag — free text with a datalist of known tag values
+  if (field.source === 'builtin' && field.field === 'tag') {
+    return <TagValueInput value={value} onChange={onChange} />;
+  }
+  return (
+    <Input
+      className="w-48"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      placeholder="value"
+      aria-label="Value"
+    />
+  );
+}
+
+function EnumSelect({
+  options,
+  value,
+  onChange,
+}: {
+  options: string[];
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  return (
+    <Select className="w-48" value={value} onChange={(e) => onChange(e.target.value)} aria-label="Value">
+      <option value="" disabled>
+        Select…
+      </option>
+      {options.map((o) => (
+        <option key={o} value={o}>
+          {o}
+        </option>
+      ))}
+    </Select>
+  );
+}
+
+function TagValueInput({ value, onChange }: { value: string; onChange: (v: string) => void }) {
+  const { data } = useQuery({
+    queryKey: ['field-values', 'tags'],
+    queryFn: () => getFieldValues('tags'),
+    staleTime: 60_000,
+  });
+  return (
+    <>
+      <Input
+        className="w-48"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="tag name"
+        list="smart-tag-values"
+        aria-label="Value"
+      />
+      <datalist id="smart-tag-values">
+        {(data ?? []).map((v) => (
+          <option key={v.value} value={v.value} />
+        ))}
+      </datalist>
+    </>
+  );
+}

--- a/apps/frontend/src/components/smart/PreviewPane.tsx
+++ b/apps/frontend/src/components/smart/PreviewPane.tsx
@@ -1,0 +1,71 @@
+import { useEffect, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Loader2, AlertCircle } from 'lucide-react';
+import type { RuleNode } from '@alexandria/shared';
+import { ModelCard } from '../models/ModelCard';
+import { previewSmartCollection } from '../../api/smart-collections';
+import { ApiRequestError } from '../../api/client';
+
+/** Debounce a value so the preview doesn't refetch on every keystroke. */
+function useDebounced<T>(value: T, ms: number): T {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const t = setTimeout(() => setDebounced(value), ms);
+    return () => clearTimeout(t);
+  }, [value, ms]);
+  return debounced;
+}
+
+interface Props {
+  definition: RuleNode;
+}
+
+/** Live preview of the models a rule tree matches, used by the composer. */
+export function PreviewPane({ definition }: Props) {
+  const serialized = JSON.stringify(definition);
+  const debounced = useDebounced(serialized, 400);
+
+  const query = useQuery({
+    queryKey: ['smart-preview', debounced],
+    queryFn: () => previewSmartCollection({ definition: JSON.parse(debounced) as RuleNode }),
+    staleTime: 10_000,
+    retry: false,
+  });
+
+  const total = query.data?.meta?.total ?? 0;
+  const models = query.data?.data ?? [];
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="mb-3 flex items-center justify-between">
+        <h2 className="text-sm font-semibold">Preview</h2>
+        <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
+          {query.isFetching && <Loader2 className="h-3 w-3 animate-spin" />}
+          {!query.isError && `${total} model${total === 1 ? '' : 's'}`}
+        </span>
+      </div>
+
+      {query.isError ? (
+        <div className="flex items-start gap-2 rounded-md border border-destructive/40 bg-destructive/5 p-3 text-sm text-destructive">
+          <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0" />
+          <span>
+            {query.error instanceof ApiRequestError
+              ? query.error.message
+              : 'Could not preview this rule.'}
+          </span>
+        </div>
+      ) : models.length === 0 && !query.isFetching ? (
+        <p className="text-sm text-muted-foreground">No models match these rules yet.</p>
+      ) : (
+        <div
+          className="grid flex-1 content-start gap-3 overflow-y-auto"
+          style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(160px, 1fr))' }}
+        >
+          {models.map((model) => (
+            <ModelCard key={model.id} model={model} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/src/components/smart/RuleGroupEditor.tsx
+++ b/apps/frontend/src/components/smart/RuleGroupEditor.tsx
@@ -1,0 +1,117 @@
+import { Plus, FolderPlus, Trash2 } from 'lucide-react';
+import type { MetadataFieldDetail } from '@alexandria/shared';
+import { SMART_COLLECTION_MAX_DEPTH } from '@alexandria/shared';
+import { cn } from '../../lib/utils';
+import { Button } from '../ui/button';
+import { ConditionRow } from './ConditionRow';
+import type { DraftGroup, useSmartCollectionDraft } from '../../hooks/use-smart-collection-draft';
+
+type Draft = ReturnType<typeof useSmartCollectionDraft>;
+
+interface Props {
+  node: DraftGroup;
+  fields: MetadataFieldDetail[];
+  draft: Draft;
+  depth: number;
+  isRoot?: boolean;
+  onRemove?: () => void;
+}
+
+/** Recursive editor for one rule group (AND/OR over its children). */
+export function RuleGroupEditor({ node, fields, draft, depth, isRoot = false, onRemove }: Props) {
+  const canNest = depth < SMART_COLLECTION_MAX_DEPTH;
+
+  return (
+    <div
+      className={cn(
+        'rounded-lg border p-3',
+        isRoot ? 'border-border bg-card' : 'border-dashed border-border/70 bg-muted/30',
+      )}
+    >
+      <div className="mb-3 flex items-center gap-2">
+        <MatchToggle op={node.op} onChange={(op) => draft.setGroupOp(node._id, op)} />
+        <span className="text-xs text-muted-foreground">
+          Match {node.op === 'and' ? 'all' : 'any'} of the following
+        </span>
+        <div className="flex-1" />
+        {!isRoot && onRemove && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            onClick={onRemove}
+            aria-label="Remove group"
+            className="text-muted-foreground hover:text-destructive"
+          >
+            <Trash2 className="h-4 w-4" />
+          </Button>
+        )}
+      </div>
+
+      <div className="flex flex-col gap-2">
+        {node.children.length === 0 && (
+          <p className="px-1 py-2 text-sm text-muted-foreground">
+            No rules yet — this {isRoot ? 'collection matches every model' : 'group is empty'}.
+          </p>
+        )}
+        {node.children.map((child) =>
+          child.kind === 'group' ? (
+            <RuleGroupEditor
+              key={child._id}
+              node={child}
+              fields={fields}
+              draft={draft}
+              depth={depth + 1}
+              onRemove={() => draft.remove(child._id)}
+            />
+          ) : (
+            <ConditionRow
+              key={child._id}
+              node={child}
+              fields={fields}
+              onChange={(patch) => draft.updateCondition(child._id, patch)}
+              onRemove={() => draft.remove(child._id)}
+            />
+          ),
+        )}
+      </div>
+
+      <div className="mt-3 flex gap-2">
+        <Button type="button" variant="outline" size="sm" onClick={() => draft.addCondition(node._id)}>
+          <Plus className="mr-1 h-3.5 w-3.5" /> Add rule
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => draft.addGroup(node._id)}
+          disabled={!canNest}
+          title={canNest ? undefined : `Maximum nesting depth is ${SMART_COLLECTION_MAX_DEPTH}`}
+        >
+          <FolderPlus className="mr-1 h-3.5 w-3.5" /> Add group
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function MatchToggle({ op, onChange }: { op: 'and' | 'or'; onChange: (op: 'and' | 'or') => void }) {
+  return (
+    <div className="inline-flex overflow-hidden rounded-md border border-input">
+      {(['and', 'or'] as const).map((value) => (
+        <button
+          key={value}
+          type="button"
+          aria-pressed={op === value}
+          onClick={() => onChange(value)}
+          className={cn(
+            'px-2.5 py-1 text-xs font-medium transition-colors',
+            op === value ? 'bg-primary text-primary-foreground' : 'bg-background hover:bg-accent',
+          )}
+        >
+          {value.toUpperCase()}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/apps/frontend/src/hooks/use-model-filters.ts
+++ b/apps/frontend/src/hooks/use-model-filters.ts
@@ -12,9 +12,9 @@ export interface ModelFilters {
   metadataFilters: Record<string, string>;
 }
 
-export type PivotAxis = 'collections' | 'artists' | 'tags';
+export type PivotAxis = 'collections' | 'artists' | 'tags' | 'smart';
 
-const VALID_AXES: PivotAxis[] = ['collections', 'artists', 'tags'];
+const VALID_AXES: PivotAxis[] = ['collections', 'artists', 'tags', 'smart'];
 const DEFAULT_AXIS: PivotAxis = 'collections';
 
 /**
@@ -22,11 +22,13 @@ const DEFAULT_AXIS: PivotAxis = 'collections';
  * - axis 'collections': collectionId (string | undefined)
  * - axis 'artists': the value of metadataFilters['artist'] (string | undefined)
  * - axis 'tags': the selected tag names (string[])
+ * - axis 'smart': smartCollectionId (string | undefined)
  */
 export interface ActiveAxisValue {
   collectionId: string | undefined;
   artist: string | undefined;
   tags: string[];
+  smartCollectionId: string | undefined;
 }
 
 function parseMetaFilters(params: URLSearchParams): Record<string, string> {
@@ -60,11 +62,16 @@ export function useModelFilters() {
       ? (rawAxis as PivotAxis)
       : DEFAULT_AXIS;
 
+  // smartCollectionId is pure UI selection (which smart collection to view) —
+  // like axis, it is NOT a model filter and not in toApiParams/the query key.
+  const smartCollectionId = searchParams.get('smartCollectionId') ?? undefined;
+
   // activeAxisValue reflects what is selected for the current axis
   const activeAxisValue: ActiveAxisValue = {
     collectionId: axis === 'collections' ? filters.collectionId : undefined,
     artist: axis === 'artists' ? filters.metadataFilters['artist'] : undefined,
     tags: axis === 'tags' ? filters.tags : [],
+    smartCollectionId: axis === 'smart' ? smartCollectionId : undefined,
   };
 
   const toApiParams = useCallback(
@@ -205,6 +212,21 @@ export function useModelFilters() {
     filters.collectionId !== undefined ||
     Object.keys(filters.metadataFilters).length > 0;
 
+  const setSmartCollectionId = useCallback(
+    (id: string | undefined) => {
+      setSearchParams((prev) => {
+        const next = new URLSearchParams(prev);
+        if (id) {
+          next.set('smartCollectionId', id);
+        } else {
+          next.delete('smartCollectionId');
+        }
+        return next;
+      });
+    },
+    [setSearchParams]
+  );
+
   // setAxis writes ?axis= to the URL while preserving all other params.
   // The default axis ('collections') is omitted from the URL for cleaner links.
   const setAxis = useCallback(
@@ -238,5 +260,7 @@ export function useModelFilters() {
     axis,
     setAxis,
     activeAxisValue,
+    smartCollectionId,
+    setSmartCollectionId,
   };
 }

--- a/apps/frontend/src/hooks/use-model-results.ts
+++ b/apps/frontend/src/hooks/use-model-results.ts
@@ -1,12 +1,18 @@
 import { useCallback, useEffect, useRef } from 'react';
 import { useInfiniteQuery } from '@tanstack/react-query';
-import type { ModelCard, ModelSearchParams } from '@alexandria/shared';
+import type { ApiResponse, ModelCard, ModelSearchParams } from '@alexandria/shared';
 import { getModels } from '../api/models';
 import type { ModelFilters } from './use-model-filters';
 
 export interface UseModelResultsInput {
   filters: ModelFilters;
   toApiParams: (cursor?: string) => ModelSearchParams;
+  /** Override the fetch source (e.g. a smart collection's derived models). */
+  fetcher?: (params: ModelSearchParams) => Promise<ApiResponse<ModelCard[]>>;
+  /** Extra query-key segments distinguishing this fetch source from the default. */
+  queryKeyExtra?: unknown[];
+  /** When false, the query does not run (e.g. smart axis with nothing selected). */
+  enabled?: boolean;
 }
 
 export interface UseModelResultsOutput {
@@ -32,6 +38,9 @@ export interface UseModelResultsOutput {
 export function useModelResults({
   filters,
   toApiParams,
+  fetcher = getModels,
+  queryKeyExtra = [],
+  enabled = true,
 }: UseModelResultsInput): UseModelResultsOutput {
   const sentinelRef = useRef<HTMLDivElement>(null);
 
@@ -44,14 +53,15 @@ export function useModelResults({
     isError,
     error,
   } = useInfiniteQuery({
-    queryKey: ['models', filters],
+    queryKey: ['models', ...queryKeyExtra, filters],
     queryFn: async ({ pageParam }: { pageParam: string | undefined }) => {
       const params: ModelSearchParams = toApiParams(pageParam);
-      return getModels(params);
+      return fetcher(params);
     },
     getNextPageParam: (lastPage) => lastPage.meta?.cursor ?? undefined,
     initialPageParam: undefined as string | undefined,
     staleTime: 30_000,
+    enabled,
   });
 
   const handleIntersect = useCallback(

--- a/apps/frontend/src/hooks/use-smart-collection-draft.ts
+++ b/apps/frontend/src/hooks/use-smart-collection-draft.ts
@@ -1,0 +1,154 @@
+import { useMemo, useReducer } from 'react';
+import type { RuleNode, RuleCondition, RuleFieldRef, RuleOperator } from '@alexandria/shared';
+
+// ---------------------------------------------------------------------------
+// Draft tree — the same shape as the persisted RuleNode plus a stable `_id` on
+// every node for React keys and id-keyed edits. `_id` is ephemeral and stripped
+// by toDefinition() before the tree is sent to the API.
+// ---------------------------------------------------------------------------
+
+export interface DraftCondition {
+  _id: string;
+  kind: 'condition';
+  field: RuleFieldRef;
+  operator: RuleOperator;
+  value: string | null;
+}
+
+export interface DraftGroup {
+  _id: string;
+  kind: 'group';
+  op: 'and' | 'or';
+  children: DraftNode[];
+}
+
+export type DraftNode = DraftGroup | DraftCondition;
+
+function newId(): string {
+  return crypto.randomUUID();
+}
+
+/** A sensible default condition for a freshly added row. */
+function defaultCondition(): DraftCondition {
+  return { _id: newId(), kind: 'condition', field: { source: 'builtin', field: 'name' }, operator: 'contains', value: '' };
+}
+
+function toDraft(node: RuleNode): DraftNode {
+  if (node.kind === 'condition') {
+    return { _id: newId(), ...node };
+  }
+  return { _id: newId(), kind: 'group', op: node.op, children: node.children.map(toDraft) };
+}
+
+function stripNode(node: DraftNode): RuleNode {
+  if (node.kind === 'condition') {
+    return { kind: 'condition', field: node.field, operator: node.operator, value: node.value };
+  }
+  return { kind: 'group', op: node.op, children: node.children.map(stripNode) };
+}
+
+/** The group-nesting depth of a node (root group = 1), keyed by id. */
+export function depthOf(root: DraftGroup, id: string): number {
+  const find = (node: DraftNode, groupDepth: number): number | null => {
+    if (node._id === id) return groupDepth;
+    if (node.kind === 'group') {
+      for (const child of node.children) {
+        const r = find(child, child.kind === 'group' ? groupDepth + 1 : groupDepth);
+        if (r !== null) return r;
+      }
+    }
+    return null;
+  };
+  return find(root, 1) ?? 1;
+}
+
+// ---------------------------------------------------------------------------
+// Reducer
+// ---------------------------------------------------------------------------
+
+type Action =
+  | { type: 'updateCondition'; id: string; patch: Partial<Omit<DraftCondition, '_id' | 'kind'>> }
+  | { type: 'setGroupOp'; id: string; op: 'and' | 'or' }
+  | { type: 'addCondition'; groupId: string }
+  | { type: 'addGroup'; groupId: string }
+  | { type: 'remove'; id: string }
+  | { type: 'reset'; tree: DraftGroup };
+
+/** Recursively map a node, applying fn to the node with matching id. */
+function mapNode(node: DraftNode, id: string, fn: (n: DraftNode) => DraftNode): DraftNode {
+  if (node._id === id) return fn(node);
+  if (node.kind === 'group') {
+    return { ...node, children: node.children.map((c) => mapNode(c, id, fn)) };
+  }
+  return node;
+}
+
+/** Recursively remove the node with matching id (never removes the root). */
+function removeNode(node: DraftGroup, id: string): DraftGroup {
+  return {
+    ...node,
+    children: node.children
+      .filter((c) => c._id !== id)
+      .map((c) => (c.kind === 'group' ? removeNode(c, id) : c)),
+  };
+}
+
+function reducer(state: DraftGroup, action: Action): DraftGroup {
+  switch (action.type) {
+    case 'reset':
+      return action.tree;
+    case 'updateCondition':
+      return mapNode(state, action.id, (n) =>
+        n.kind === 'condition' ? { ...n, ...action.patch } : n,
+      ) as DraftGroup;
+    case 'setGroupOp':
+      return mapNode(state, action.id, (n) => (n.kind === 'group' ? { ...n, op: action.op } : n)) as DraftGroup;
+    case 'addCondition':
+      return mapNode(state, action.groupId, (n) =>
+        n.kind === 'group' ? { ...n, children: [...n.children, defaultCondition()] } : n,
+      ) as DraftGroup;
+    case 'addGroup':
+      return mapNode(state, action.groupId, (n) =>
+        n.kind === 'group'
+          ? { ...n, children: [...n.children, { _id: newId(), kind: 'group', op: 'and', children: [defaultCondition()] }] }
+          : n,
+      ) as DraftGroup;
+    case 'remove':
+      return removeNode(state, action.id);
+    default:
+      return state;
+  }
+}
+
+function initRoot(initial?: RuleNode): DraftGroup {
+  if (initial && initial.kind === 'group') return toDraft(initial) as DraftGroup;
+  if (initial && initial.kind === 'condition') {
+    return { _id: newId(), kind: 'group', op: 'and', children: [toDraft(initial)] };
+  }
+  return { _id: newId(), kind: 'group', op: 'and', children: [] };
+}
+
+/**
+ * Local draft state for the smart-collection composer. The rule tree is too
+ * nested for the URL, so it lives here; the persisted definition is derived via
+ * `definition`.
+ */
+export function useSmartCollectionDraft(initial?: RuleNode) {
+  const [tree, dispatch] = useReducer(reducer, initial, initRoot);
+
+  const definition = useMemo<RuleNode>(() => stripNode(tree), [tree]);
+
+  return {
+    tree,
+    definition,
+    updateCondition: (id: string, patch: Partial<Omit<DraftCondition, '_id' | 'kind'>>) =>
+      dispatch({ type: 'updateCondition', id, patch }),
+    setGroupOp: (id: string, op: 'and' | 'or') => dispatch({ type: 'setGroupOp', id, op }),
+    addCondition: (groupId: string) => dispatch({ type: 'addCondition', groupId }),
+    addGroup: (groupId: string) => dispatch({ type: 'addGroup', groupId }),
+    remove: (id: string) => dispatch({ type: 'remove', id }),
+    reset: (node: RuleNode) => dispatch({ type: 'reset', tree: initRoot(node) }),
+  };
+}
+
+export { defaultCondition, stripNode as draftToDefinition };

--- a/apps/frontend/src/pages/SearchPage.tsx
+++ b/apps/frontend/src/pages/SearchPage.tsx
@@ -194,13 +194,50 @@ export function SearchPage() {
             </label>
           </form>
 
-          {/* Right: Save as Smart Collection (disabled) */}
+          {/* Right: Save as Smart Collection — seeds the composer from this search */}
           <div className="flex-shrink-0">
-            <DisabledPill
-              icon={<Zap size={12} />}
-              label="Save as Smart Collection"
-              tooltip="Available in a later update"
-            />
+            {q ? (
+              <button
+                type="button"
+                onClick={() =>
+                  navigate('/smart-collections/new', {
+                    state: {
+                      name: q,
+                      definition: {
+                        kind: 'group',
+                        op: 'and',
+                        children: [
+                          { kind: 'condition', field: { source: 'builtin', field: 'name' }, operator: 'contains', value: q },
+                        ],
+                      },
+                    },
+                  })
+                }
+                style={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: 6,
+                  padding: '5px 12px',
+                  borderRadius: 999,
+                  background: 'var(--ax-bg-elev)',
+                  border: '1px solid var(--ax-border)',
+                  color: 'var(--ax-fg)',
+                  fontSize: 12,
+                  fontWeight: 500,
+                  cursor: 'pointer',
+                  fontFamily: 'inherit',
+                }}
+              >
+                <Zap size={12} />
+                Save as Smart Collection
+              </button>
+            ) : (
+              <DisabledPill
+                icon={<Zap size={12} />}
+                label="Save as Smart Collection"
+                tooltip="Enter a search to save it"
+              />
+            )}
           </div>
         </div>
 

--- a/apps/frontend/src/pages/SmartCollectionComposerPage.tsx
+++ b/apps/frontend/src/pages/SmartCollectionComposerPage.tsx
@@ -1,0 +1,136 @@
+import { useEffect, useRef, useState } from 'react';
+import { useNavigate, useParams, useLocation } from 'react-router-dom';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { ArrowLeft, Loader2 } from 'lucide-react';
+import type { RuleNode, SmartCollectionDetail } from '@alexandria/shared';
+import { Button } from '../components/ui/button';
+import { Input } from '../components/ui/input';
+import { Label } from '../components/ui/label';
+import { Textarea } from '../components/ui/textarea';
+import { RuleGroupEditor } from '../components/smart/RuleGroupEditor';
+import { PreviewPane } from '../components/smart/PreviewPane';
+import { useSmartCollectionDraft } from '../hooks/use-smart-collection-draft';
+import {
+  getSmartCollection,
+  createSmartCollection,
+  updateSmartCollection,
+} from '../api/smart-collections';
+import { getFields } from '../api/metadata';
+import { useToast } from '../hooks/use-toast';
+import { ApiRequestError } from '../api/client';
+
+/** Router state passed from the search page's "Save as Smart Collection" button. */
+interface ComposerSeed {
+  name?: string;
+  definition?: RuleNode;
+}
+
+export function SmartCollectionComposerPage() {
+  const { id } = useParams<{ id: string }>();
+  const isEdit = Boolean(id);
+  const navigate = useNavigate();
+  const location = useLocation();
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  const seed = (location.state as ComposerSeed | null) ?? {};
+
+  const [name, setName] = useState(seed.name ?? '');
+  const [description, setDescription] = useState('');
+  const draft = useSmartCollectionDraft(seed.definition);
+
+  const { data: fields = [] } = useQuery({ queryKey: ['metadata-fields'], queryFn: getFields });
+
+  // Edit mode: load the existing collection and seed the form once.
+  const existing = useQuery({
+    queryKey: ['smart-collection', id],
+    queryFn: () => getSmartCollection(id!),
+    enabled: isEdit,
+  });
+  const seededRef = useRef(false);
+  useEffect(() => {
+    if (existing.data && !seededRef.current) {
+      seededRef.current = true;
+      setName(existing.data.name);
+      setDescription(existing.data.description ?? '');
+      draft.reset(existing.data.definition);
+    }
+  }, [existing.data, draft]);
+
+  const save = useMutation({
+    mutationFn: async (): Promise<SmartCollectionDetail> => {
+      const payload = { name: name.trim(), description: description.trim() || undefined, definition: draft.definition };
+      return isEdit
+        ? updateSmartCollection(id!, payload)
+        : createSmartCollection(payload);
+    },
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ['smart-collections'] });
+      queryClient.invalidateQueries({ queryKey: ['smart-collection', data.id] });
+      toast({ title: isEdit ? 'Smart collection updated' : 'Smart collection created' });
+      navigate(`/?axis=smart&smartCollectionId=${data.id}`);
+    },
+    onError: (err) => {
+      toast({
+        title: err instanceof ApiRequestError ? err.message : 'Failed to save smart collection',
+        variant: 'destructive',
+      });
+    },
+  });
+
+  const canSave = name.trim().length > 0 && !save.isPending;
+
+  return (
+    <div className="flex h-screen flex-col">
+      {/* Header */}
+      <header className="flex items-center gap-3 border-b border-border px-6 py-3">
+        <Button variant="ghost" size="icon" onClick={() => navigate(-1)} aria-label="Back">
+          <ArrowLeft className="h-4 w-4" />
+        </Button>
+        <h1 className="text-base font-semibold">
+          {isEdit ? 'Edit smart collection' : 'New smart collection'}
+        </h1>
+        <div className="flex-1" />
+        <Button onClick={() => save.mutate()} disabled={!canSave}>
+          {save.isPending && <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />}
+          {isEdit ? 'Save changes' : 'Create'}
+        </Button>
+      </header>
+
+      {/* Two-pane body */}
+      <div className="grid flex-1 grid-cols-2 gap-6 overflow-hidden p-6">
+        {/* Left: definition */}
+        <div className="flex flex-col gap-4 overflow-y-auto pr-2">
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="sc-name">Name</Label>
+            <Input
+              id="sc-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="e.g. Pre-supported dragons"
+            />
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="sc-desc">Description</Label>
+            <Textarea
+              id="sc-desc"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Optional"
+              rows={2}
+            />
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <Label>Rules</Label>
+            <RuleGroupEditor node={draft.tree} fields={fields} draft={draft} depth={1} isRoot />
+          </div>
+        </div>
+
+        {/* Right: live preview */}
+        <div className="overflow-hidden rounded-lg border border-border p-4">
+          <PreviewPane definition={draft.definition} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/docs/API.md
+++ b/docs/API.md
@@ -1067,6 +1067,281 @@ Remove a single model from a collection without deleting the model.
 
 ---
 
+## Smart Collections
+
+Smart collections are dynamic, rule-based collections. Instead of managing explicit membership, a smart collection stores a rule tree (`definition`) that is compiled into SQL and executed on every read. The result set is derived — never persisted. There is no join table.
+
+The `definition` field is a `RuleNode` — a recursive tree of groups (AND/OR) and leaf conditions. See `docs/TYPES.md` for the full type hierarchy.
+
+### GET /smart-collections
+
+List smart collections in the authenticated user's default library. Model counts are omitted from the list response to keep it cheap; use `GET /smart-collections/:id` for a live count.
+
+**Auth required:** Yes
+
+**Library scope:** Results are scoped to the authenticated user's default library, resolved server-side from the session. Clients do not pass a `libraryId`.
+
+**Response (200):**
+
+```json
+{
+  "data": [
+    {
+      "id": "uuid",
+      "name": "Ready Fantasy Models",
+      "slug": "ready-fantasy-models-a3f2",
+      "description": "All ready models tagged fantasy",
+      "definition": {
+        "kind": "group",
+        "op": "and",
+        "children": [
+          { "kind": "condition", "field": { "source": "builtin", "field": "tag" }, "operator": "hasTag", "value": "fantasy" },
+          { "kind": "condition", "field": { "source": "builtin", "field": "status" }, "operator": "is", "value": "ready" }
+        ]
+      },
+      "userId": "uuid",
+      "createdAt": "2026-05-01T10:00:00.000Z",
+      "updatedAt": "2026-05-01T10:00:00.000Z"
+    }
+  ],
+  "meta": { "total": 1, "cursor": null, "pageSize": 1 },
+  "errors": null
+}
+```
+
+`data` is an array of `SmartCollection`. The `meta.cursor` is always `null`; this endpoint returns all smart collections for the library without cursor pagination.
+
+---
+
+### POST /smart-collections
+
+Create a smart collection.
+
+**Auth required:** Yes
+
+**Library scope:** The new smart collection is created in the authenticated user's default library, resolved server-side from the session.
+
+**Request body:**
+
+```json
+{
+  "name": "Ready Fantasy Models",
+  "description": "All ready models tagged fantasy",
+  "definition": {
+    "kind": "group",
+    "op": "and",
+    "children": [
+      { "kind": "condition", "field": { "source": "builtin", "field": "tag" }, "operator": "hasTag", "value": "fantasy" },
+      { "kind": "condition", "field": { "source": "builtin", "field": "status" }, "operator": "is", "value": "ready" }
+    ]
+  }
+}
+```
+
+| Field | Type | Constraints |
+|-------|------|-------------|
+| `name` | string | Required; 1–255 characters |
+| `description` | string (optional) | Maximum 2000 characters |
+| `definition` | RuleNode | Required; a valid rule tree (see below) |
+
+**Rule tree validation:** The tree must not exceed depth 3 (group nesting), 50 total nodes, or 20 children per group. A bare condition or an empty root group (`{ kind: "group", op: "and", children: [] }`) is valid. For leaf conditions: the operator must be legal for the field (e.g., `contains` and `equals` for `name`; `hasTag`/`notHasTag` for `tag`). Operators `exists` and `notExists` take a null value; all others require a non-empty string. Metadata field slugs are validated server-side against the live field definitions; unknown slugs return `400`.
+
+**Response (201):** Returns the created `SmartCollectionDetail` (includes a live `modelCount`).
+
+```json
+{
+  "data": {
+    "id": "uuid",
+    "name": "Ready Fantasy Models",
+    "slug": "ready-fantasy-models-a3f2",
+    "description": "All ready models tagged fantasy",
+    "definition": { ... },
+    "modelCount": 7,
+    "createdAt": "2026-05-01T10:00:00.000Z",
+    "updatedAt": "2026-05-01T10:00:00.000Z"
+  },
+  "meta": null,
+  "errors": null
+}
+```
+
+**Error cases:**
+
+| Code | Status | When |
+|------|--------|------|
+| `VALIDATION_ERROR` | 400 | Tree fails structural validation (depth, node count, illegal operator for field) |
+| `VALIDATION_ERROR` | 400 | A `metadata` leaf references an unknown field slug |
+| `VALIDATION_ERROR` | 400 | A `metadata` leaf uses an operator that is illegal for the field's type |
+
+---
+
+### GET /smart-collections/:id
+
+Retrieve a single smart collection, including a live count of models the rule tree currently matches.
+
+**Auth required:** Yes
+
+**Library scope:** The smart collection must belong to the authenticated user's default library. Mismatches return `404`.
+
+**Path parameter:** `id` — smart collection UUID
+
+**Response (200):** Returns a `SmartCollectionDetail`.
+
+```json
+{
+  "data": {
+    "id": "uuid",
+    "name": "Ready Fantasy Models",
+    "slug": "ready-fantasy-models-a3f2",
+    "description": "All ready models tagged fantasy",
+    "definition": { ... },
+    "modelCount": 7,
+    "createdAt": "2026-05-01T10:00:00.000Z",
+    "updatedAt": "2026-05-01T10:00:00.000Z"
+  },
+  "meta": null,
+  "errors": null
+}
+```
+
+`modelCount` is derived live by running the rule tree against the library — it reflects the current state of the model set.
+
+---
+
+### PATCH /smart-collections/:id
+
+Update a smart collection's name, description, or rule tree. All fields are optional; at least one must be provided.
+
+**Auth required:** Yes
+
+**Library scope:** The smart collection must belong to the authenticated user's default library. Mismatches return `404`.
+
+**Path parameter:** `id` — smart collection UUID
+
+**Request body:**
+
+```json
+{
+  "name": "Renamed Collection",
+  "description": null,
+  "definition": {
+    "kind": "condition",
+    "field": { "source": "builtin", "field": "tag" },
+    "operator": "hasTag",
+    "value": "sci-fi"
+  }
+}
+```
+
+| Field | Type | Constraints |
+|-------|------|-------------|
+| `name` | string (optional) | 1–255 characters |
+| `description` | string or null (optional) | Maximum 2000 characters; `null` clears the description |
+| `definition` | RuleNode (optional) | Must pass the same validation as `POST /smart-collections` |
+
+When `name` is updated the slug is regenerated. If `definition` is provided, `resolveAndCompile` runs the full validation before the update is written to the database.
+
+**Response (200):** Returns the updated `SmartCollectionDetail`.
+
+---
+
+### DELETE /smart-collections/:id
+
+Delete a smart collection. Models are not affected — only the rule tree and its metadata are removed.
+
+**Auth required:** Yes
+
+**Library scope:** The smart collection must belong to the authenticated user's default library. Mismatches return `404`.
+
+**Path parameter:** `id` — smart collection UUID
+
+**Response (200):**
+
+```json
+{
+  "data": null,
+  "meta": null,
+  "errors": null
+}
+```
+
+---
+
+### GET /smart-collections/:id/models
+
+Execute the rule tree and return the derived model result set. Supports the same filtering, sorting, and pagination as `GET /models` — these parameters are ANDed on top of the compiled rule tree.
+
+**Auth required:** Yes
+
+**Library scope:** Results are scoped to the authenticated user's default library in addition to the rule tree's constraints. The library is resolved server-side; clients do not pass a `libraryId`.
+
+**Path parameter:** `id` — smart collection UUID
+
+**Query parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `q` | string | Full-text search within the rule-derived set |
+| `tags` | string | Comma-separated tag slugs to further filter by |
+| `fileType` | `stl` \| `image` \| `document` \| `other` | Filter by presence of this file type |
+| `status` | `processing` \| `ready` \| `error` | Filter by processing status |
+| `sort` | `name` \| `createdAt` \| `totalSizeBytes` | Sort field |
+| `sortDir` | `asc` \| `desc` | Sort direction |
+| `cursor` | string | Pagination cursor |
+| `pageSize` | integer | Results per page (1–200, default 50) |
+| `metadata.<fieldSlug>` | string | Filter by a metadata field value |
+
+**Response (200):** Same envelope shape as `GET /models`. `data` is an array of `ModelCard`.
+
+---
+
+### POST /smart-collections/preview
+
+Dry-run an unsaved rule tree against the authenticated user's library. Useful for live feedback in the rule composer before creating or saving a smart collection.
+
+**Auth required:** Yes
+
+**Library scope:** Results are scoped to the authenticated user's default library, resolved server-side from the session.
+
+**Request body:**
+
+```json
+{
+  "definition": {
+    "kind": "group",
+    "op": "or",
+    "children": [
+      { "kind": "condition", "field": { "source": "builtin", "field": "tag" }, "operator": "hasTag", "value": "fantasy" },
+      { "kind": "condition", "field": { "source": "builtin", "field": "tag" }, "operator": "hasTag", "value": "sci-fi" }
+    ]
+  },
+  "sort": "name",
+  "sortDir": "asc",
+  "pageSize": 20
+}
+```
+
+| Field | Type | Constraints |
+|-------|------|-------------|
+| `definition` | RuleNode | Required; same validation as `POST /smart-collections` |
+| `status` | `processing` \| `ready` \| `error` (optional) | Additional status filter |
+| `fileType` | `stl` \| `image` \| `document` \| `other` (optional) | Additional file-type filter |
+| `sort` | `name` \| `createdAt` \| `totalSizeBytes` (optional) | Sort field |
+| `sortDir` | `asc` \| `desc` (optional) | Sort direction |
+| `cursor` | string (optional) | Pagination cursor |
+| `pageSize` | integer (optional) | Results per page (1–200, default 50) |
+
+**Response (200):** Same envelope shape as `GET /models`. `data` is an array of `ModelCard`.
+
+**Error cases:**
+
+| Code | Status | When |
+|------|--------|------|
+| `VALIDATION_ERROR` | 400 | Tree fails structural validation |
+| `VALIDATION_ERROR` | 400 | Unknown metadata slug or illegal operator for field's type |
+
+---
+
 ## Metadata
 
 Metadata is the system for attaching typed attributes to models. Field definitions describe the available fields; values are the per-model assignments.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -125,7 +125,7 @@ The seed (`runSeed`) calls this method for the admin user on startup, so the adm
 
 **Security invariant:** `libraryId` is server-injected only. No route accepts a `libraryId` from the client in the query string, path, or request body. The value is always derived from the authenticated session. This prevents one user from accessing another user's library by supplying a different `libraryId`.
 
-Routes that apply `requireLibrary` (as of P3):
+Routes that apply `requireLibrary` (as of P4):
 
 - `GET /models`
 - `GET /collections`, `POST /collections`
@@ -134,14 +134,23 @@ Routes that apply `requireLibrary` (as of P3):
 - `POST /models/upload`, `POST /models/upload/:uploadId/complete`, `POST /models/import`
 - `GET /models/import-sessions`, `POST /models/import-sessions/:id/commit`
 - `GET /search`
+- All `/smart-collections` routes
 
 By-id detail routes (`GET /models/:id`, `GET /collections/:id`, `PATCH /models/:id`, etc.) remain owned by `userId` and are not yet library-scoped. Library scoping for detail routes is deferred to P5 multi-library.
 
-### P4 Deferrals
+### P4: Smart Collections (shipped)
 
-The following are deferred to the Smart Collections phase:
+Smart collections were implemented in P4. Key architectural facts:
 
-- Smart (rule-based) collections entity and rule engine. `SearchService.searchAll` returns only manual collections. When smart collections ship, `searchAll` will need to union both types.
+- **Entity**: The `smart_collections` table (`apps/backend/src/db/schema/smart-collection.ts`, migration `0009_add_smart_collections.sql`) stores `id`, `name`, `slug` (globally unique), `description`, `definition` (JSONB rule tree typed as `RuleNode`), `userId`, `libraryId`, and timestamps. There is no membership join table — results are derived on read, never materialized.
+
+- **Rule engine**: `apps/backend/src/services/rule-engine.ts` compiles a nested `RuleNode` tree into a Drizzle `SQL` condition. The engine is pure (no I/O). It exports `buildLeafCondition`, which `search.service.ts` also uses for its own flat filter logic — this is the single source of truth for "what SQL a filter on dimension X looks like." Both code paths are guaranteed to produce identical results for equivalent criteria.
+
+- **`applyDefaultStatus` seam**: `searchModels` normally applies an implicit `status = 'ready'` filter. When a smart collection's rule tree contains a `status` condition, `SmartCollectionService.resolveAndCompile` sets `applyDefaultStatus: false`, suppressing the default so it does not contradict the rule. This flag travels through `SearchModelsOptions` into `searchModels`.
+
+- **Cross-tenant guard**: Every by-id route goes through `SmartCollectionService.requireOwnedSmartCollection`, which verifies the row exists, belongs to the requesting user, and belongs to the library. A mismatch on any check returns `NOT_FOUND` — the same error shape regardless of which check failed, so IDs cannot be enumerated across tenants.
+
+- **`searchAll` global-search union still deferred**: `SearchService.searchAll` returns only manual collections. Unioning smart collections into global search results is a fast-follow that was explicitly deferred from this phase.
 
 ### P5 Deferrals
 
@@ -227,9 +236,9 @@ Uses the **PatternParser** utility (located in `utils/pattern-parser.ts`) — a 
 
 **Behavior:** Two public methods:
 
-- `searchModels(params, libraryId)` — accepts query parameters (text search, metadata filters, collection filter, sort, pagination cursor). Executes against Postgres full-text search. Understands which metadata fields use optimized storage (tags → join table query) vs. generic storage (other fields → model_metadata table query). Returns paginated results as `ModelCard` objects assembled by PresenterService.
+- `searchModels(params, libraryId, options?)` — accepts query parameters (text search, metadata filters, collection filter, sort, pagination cursor) plus an optional `SearchModelsOptions`. `options.ruleWhere` is a pre-compiled smart-collection SQL condition ANDed into the query. `options.applyDefaultStatus` (default `true`) controls the implicit `status = 'ready'` filter — smart collections suppress it when their rule tree already references `status`. Internally, `searchModels` builds its per-dimension filter SQL via `buildLeafCondition` from `rule-engine.ts`, the same function the rule compiler uses, so flat params and compiled rule trees produce identical SQL per dimension.
 
-- `searchAll(params, userId, libraryId)` — cross-entity search. Calls `searchModels` for models (full-text), then filters in-memory against collections (by name substring, sorted by `modelCount`), artist values, and tag values (both by name substring, drawn from `listFieldValues`). Results for each entity type are limited to `params.limit` (default 6). Returns a `GlobalSearchResult`.
+- `searchAll(params, userId, libraryId)` — cross-entity search. Calls `searchModels` for models (full-text), then filters in-memory against collections (by name substring, sorted by `modelCount`), artist values, and tag values (both by name substring, drawn from `listFieldValues`). Results for each entity type are limited to `params.limit` (default 6). Returns a `GlobalSearchResult`. Smart collections are not yet included in `searchAll` results — that union is deferred.
 
 **Abstraction:** The search implementation is behind an interface. Postgres FTS is the MVP implementation. A future MeiliSearch or Typesense implementation can be swapped in without changing any callers.
 
@@ -262,6 +271,16 @@ No other service knows about this routing. To every consumer, tags are just anot
 **Boundary note:** CollectionService owns "add/remove model from collection." ModelService can read "what collections is this model in" for display purposes but does not mutate collection membership.
 
 Collections are an organizational structure, not metadata. A model's relationship to a collection is about where you put it, not what it is. This is why collections remain a separate entity while Artist and Tags moved into the metadata system.
+
+### SmartCollectionService
+
+**Owns:** Smart collection CRUD, rule-tree validation, derived model result sets, unsaved rule-tree preview (dry-run).
+
+**Does not own:** Rule compilation to SQL (delegates to `compileRuleTree` in `rule-engine.ts`), model querying (delegates to `SearchService.searchModels`).
+
+**Behavior:** `create` and `update` call `resolveAndCompile` before any DB write, so a syntactically valid but semantically invalid tree (unknown metadata slug, illegal operator for a field's type) is rejected with a `VALIDATION_ERROR` rather than persisted. `getById` and `getModels` call `requireOwnedSmartCollection` first, which enforces ownership + library in a single query and returns `NOT_FOUND` on any mismatch. The list endpoint omits derived model counts to keep it cheap; `getById` and `create`/`update` compute a live count via `searchModels`.
+
+`resolveAndCompile` resolves all metadata leaf conditions against live field definitions, validates operator/type compatibility using `LEGAL_OPERATORS_BY_METADATA_TYPE`, and decides whether to suppress `searchModels`' implicit `status = 'ready'` default (see `applyDefaultStatus` seam above).
 
 ### AuthService
 
@@ -481,6 +500,19 @@ Because `ModelViewer3DScene` is lazy-loaded, Vite emits three.js as a separate a
 | POST | /collections/:id/models | Add model(s) | CollectionService | No (userId) |
 | DELETE | /collections/:id/models/:modelId | Remove model | CollectionService | No (userId) |
 
+**Smart Collections**
+| Method | Route | Purpose | Service Chain | Library-scoped |
+|--------|-------|---------|---------------|---------------|
+| GET | /smart-collections | List (no model counts) | SmartCollectionService | Yes |
+| POST | /smart-collections | Create | SmartCollectionService | Yes |
+| GET | /smart-collections/:id | Single collection (with model count) | SmartCollectionService → SearchService | Yes |
+| PATCH | /smart-collections/:id | Update name/description/definition | SmartCollectionService | Yes |
+| DELETE | /smart-collections/:id | Delete | SmartCollectionService | Yes |
+| GET | /smart-collections/:id/models | Derived model result set | SmartCollectionService → SearchService | Yes |
+| POST | /smart-collections/preview | Dry-run unsaved rule tree | SmartCollectionService → SearchService | Yes |
+
+All smart-collection by-id routes enforce ownership via `requireOwnedSmartCollection` in addition to the library scope from `requireLibrary`.
+
 **Metadata**
 | Method | Route | Purpose | Service Chain | Library-scoped |
 |--------|-------|---------|---------------|---------------|
@@ -572,6 +604,12 @@ The active pivot axis (`?axis=collections|artists|tags`) is stored in the URL so
 Archive uploads no longer create a model immediately. Instead they create an `ImportSession`, extract the archive, and expose detected metadata for review before the user commits. This gives users a chance to verify and supplement auto-detected artist, tags, and collection assignment before the model record is created. Folder imports retain the existing immediate behavior because they operate on server-side directories where the user has already organized the content.
 
 The consequence is that `POST /models/upload` (and the chunked `complete` endpoint) return `{ sessionId }` rather than `{ modelId, jobId }`. Callers that previously polled `GET /models/:id/status` now poll `GET /models/import-sessions/:id`, then call `POST /models/import-sessions/:id/commit` to get a `{ modelId, jobId }` to track the final ingestion.
+
+### D18: Smart collection results are derived, never materialized
+A smart collection stores only its rule tree (a `RuleNode` JSONB value). The result set is computed on every read by compiling the tree into SQL and running it through `SearchService.searchModels`. This avoids a membership sync problem — a manual collection would need its membership table updated whenever a model is edited — at the cost of per-request query execution. For the expected library sizes (thousands, not millions of models), this is acceptable. Materialized membership can be added later if performance requires it.
+
+### D19: Rule engine is the single source of truth for per-dimension SQL
+`buildLeafCondition` in `rule-engine.ts` is the canonical implementation of "what SQL a filter on dimension X looks like." `searchModels` was refactored to call it for its own flat filter parameters, so flat search and smart-collection compilation are guaranteed to produce identical SQL for equivalent criteria. Any change to how a dimension (e.g., tag membership, metadata value match) is queried must be made in `buildLeafCondition`, not in scattered helpers.
 
 ### D17: Cross-entity global search is in-memory for non-model types
 `SearchService.searchAll` runs Postgres full-text search for models, but for collections, artists, and tags it fetches the full library-scoped list and filters in memory. This is acceptable because these lists are small (hundreds at most), require no dedicated index, and avoids schema complexity. If list sizes grow to a point where in-memory filtering is measurably slow, the internal implementation can be replaced with index-backed queries without changing the API or callers. Smart collections (P4) may warrant a dedicated index at that point.

--- a/docs/TYPES.md
+++ b/docs/TYPES.md
@@ -184,6 +184,118 @@ interface Collection {
 
 Join table `collection_models`: `{ collectionId: string, modelId: string }`
 
+### SmartCollection
+
+A dynamic, rule-based collection. The `definition` field is the sole server state — results are derived on read by compiling the tree into SQL. The database schema is in `apps/backend/src/db/schema/smart-collection.ts` and migration `0009_add_smart_collections.sql`. Shared types are in `packages/shared/src/types/smart-collection.ts`.
+
+```typescript
+interface SmartCollection {
+  id: string;
+  name: string;
+  slug: string;       // globally unique; URL-safe
+  description: string | null;
+  definition: RuleNode; // the rule tree; see below
+  userId: string;
+  createdAt: string;
+  updatedAt: string;
+}
+```
+
+There is no membership join table and no parent/child nesting.
+
+#### Rule Tree Types
+
+A rule tree is a `RuleNode` — either a leaf condition or a group combining children with AND or OR.
+
+```typescript
+// A leaf: one condition targeting one field.
+interface RuleCondition {
+  kind: 'condition';
+  field: RuleFieldRef;
+  operator: RuleOperator;
+  value: string | null; // null only for exists/notExists operators
+}
+
+// A branch: combine children with AND or OR.
+interface RuleGroup {
+  kind: 'group';
+  op: 'and' | 'or';
+  children: RuleNode[];
+}
+
+type RuleNode = RuleGroup | RuleCondition;
+```
+
+`RuleFieldRef` identifies the field a condition targets — either a named built-in dimension or a user-defined metadata field by slug:
+
+```typescript
+type RuleFieldRef =
+  | { source: 'builtin'; field: BuiltinRuleField }
+  | { source: 'metadata'; slug: string };
+
+type BuiltinRuleField =
+  | 'name'         // full-text search / exact match on model name
+  | 'description'  // ILIKE substring match on description
+  | 'status'       // models.status column
+  | 'fileType'     // EXISTS in model_files for the given file_type
+  | 'collection'   // membership in a collection (by UUID value)
+  | 'tag';         // tag membership (by name, case-insensitive)
+```
+
+`RuleOperator` is the set of operators available in v1. All are text-safe — numeric and date comparison operators are deferred because metadata values are stored as untyped text.
+
+```typescript
+type RuleOperator =
+  | 'contains'         // full-text / ILIKE substring
+  | 'equals'           // exact, case-insensitive
+  | 'notEquals'
+  | 'is'               // enum / boolean exact match
+  | 'isNot'
+  | 'has'              // file type present (EXISTS)
+  | 'notHas'
+  | 'hasTag'           // tag membership
+  | 'notHasTag'
+  | 'inCollection'     // collection membership
+  | 'notInCollection'
+  | 'exists'           // metadata field has any value (no value required)
+  | 'notExists';
+```
+
+Legal operator combinations — which operators are valid for which fields — are defined in `LEGAL_OPERATORS_BY_BUILTIN` and `LEGAL_OPERATORS_BY_METADATA_TYPE` in `packages/shared/src/types/smart-collection.ts`. The shared validator enforces built-in legality; metadata legality is checked server-side once the field definition is resolved.
+
+Tree complexity bounds (enforced by the shared Zod schema and re-checked server-side):
+
+| Bound | Value | Constant |
+|-------|-------|----------|
+| Maximum group nesting depth | 3 | `SMART_COLLECTION_MAX_DEPTH` |
+| Maximum total nodes | 50 | `SMART_COLLECTION_MAX_NODES` |
+| Maximum children per group | 20 | `SMART_COLLECTION_MAX_CHILDREN` |
+
+#### Smart Collection Response Types
+
+```typescript
+// Lightweight; used in the list response
+interface SmartCollectionSummary {
+  id: string;
+  name: string;
+  slug: string;
+}
+
+// Full detail; returned by create, update, and GET /:id
+interface SmartCollectionDetail {
+  id: string;
+  name: string;
+  slug: string;
+  description: string | null;
+  definition: RuleNode;
+  modelCount: number; // derived live by executing the rule tree
+  createdAt: string;
+  updatedAt: string;
+}
+```
+
+`modelCount` in `SmartCollectionDetail` is computed by running the compiled rule tree through `SearchService.searchModels` at response time. The list endpoint (`GET /smart-collections`) returns `SmartCollection` (no count) to avoid N+1 queries.
+
 ### ImportSession
 
 A staged archive upload awaiting review and commit. Created by `POST /models/upload` (and the chunked complete endpoint); destroyed by commit or discard. The database schema is in `apps/backend/src/db/schema/import-session.ts` and migration `0008_add_import_sessions.sql`.
@@ -562,6 +674,35 @@ interface AddModelsToCollectionRequest {
 }
 ```
 
+### Smart Collection Requests
+
+```typescript
+interface CreateSmartCollectionRequest {
+  name: string;          // 1–255 characters
+  description?: string;  // maximum 2000 characters
+  definition: RuleNode;  // the rule tree
+}
+
+interface UpdateSmartCollectionRequest {
+  name?: string;
+  description?: string | null; // null clears the description
+  definition?: RuleNode;
+}
+
+// POST /smart-collections/preview — dry-run an unsaved rule tree
+interface PreviewSmartCollectionRequest {
+  definition: RuleNode;
+  status?: ModelStatus;
+  fileType?: FileType;
+  sort?: 'name' | 'createdAt' | 'totalSizeBytes';
+  sortDir?: 'asc' | 'desc';
+  cursor?: string;
+  pageSize?: number; // default 50, max 200
+}
+```
+
+Validation schemas: `createSmartCollectionSchema`, `updateSmartCollectionSchema`, `previewSmartCollectionSchema`, `smartCollectionDefinitionSchema` in `packages/shared/src/validation/smart-collection.ts`.
+
 ### Metadata Requests
 
 ```typescript
@@ -717,14 +858,19 @@ User ──owns──→ Library ──scopes──→ Model ──has many─�
   │               │
   │               ├──scopes──→ Collection
   │               │
+  │               ├──scopes──→ SmartCollection  (definition: RuleNode JSONB;
+  │               │               no membership table; results derived on read)
+  │               │
   │               └──scopes──→ ImportSession ──(on commit)──→ Model
   │                              (staged upload; expires 24h; FK set null on model delete)
   │
   └──owns──→ Collection (via userId, for ownership; libraryId for scope)
+  └──owns──→ SmartCollection (via userId, for ownership; libraryId for scope)
 ```
 
 The key insights:
 
-- Library is the top-level scope for models and collections. Every model and collection has a NOT NULL `libraryId` FK. The API enforces this via the `requireLibrary` preHandler, which injects `request.libraryId` from the session — clients never supply it.
+- Library is the top-level scope for models, collections, and smart collections. Every model, collection, and smart collection has a NOT NULL `libraryId` FK. The API enforces this via the `requireLibrary` preHandler, which injects `request.libraryId` from the session — clients never supply it.
 - Tag and model_tags exist as database-level optimizations. At the API level, tags are just metadata values of type `multi_enum`. MetadataService abstracts the storage routing.
+- `SmartCollection` stores only a rule tree. It has no join table and no parent/child nesting. The model result set is computed on each request by compiling the tree into SQL.
 - `ImportSession` is a transient entity. It exists between `POST /models/upload` (scan enqueued) and `POST /models/import-sessions/:id/commit` (model created). The `modelId` FK is set to null on model deletion; the session row itself is deleted by the discard endpoint or reaped by the expiry cleanup.

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -6,3 +6,4 @@ export * from './library.js';
 export * from './api.js';
 export * from './upload.js';
 export * from './search.js';
+export * from './smart-collection.js';

--- a/packages/shared/src/types/smart-collection.ts
+++ b/packages/shared/src/types/smart-collection.ts
@@ -1,0 +1,194 @@
+import type { MetadataFieldType } from './metadata.js';
+import type { ModelStatus, FileType, ModelSearchParams } from './model.js';
+
+// ---------------------------------------------------------------------------
+// Smart Collections — dynamic, rule-based collections (P4).
+//
+// A smart collection stores a nested boolean RULE TREE (its "definition"). The
+// result set is never materialized; it is derived on read by compiling the
+// tree into a SQL query against the models table (see rule-engine on the
+// backend). The definition is the only server state.
+// ---------------------------------------------------------------------------
+
+/**
+ * Built-in fields a rule can target. Each maps to a fixed column or join in the
+ * existing model search (see search.service `buildLeafCondition`).
+ */
+export type BuiltinRuleField =
+  | 'name' // models.search_vector / models.name
+  | 'description' // models.search_vector
+  | 'status' // models.status
+  | 'fileType' // model_files.file_type (EXISTS)
+  | 'collection' // collection_models membership
+  | 'tag'; // model_tags + tags membership
+
+export const BUILTIN_RULE_FIELDS: readonly BuiltinRuleField[] = [
+  'name',
+  'description',
+  'status',
+  'fileType',
+  'collection',
+  'tag',
+];
+
+/**
+ * A reference to the field a condition targets — either a built-in dimension or
+ * a user-defined metadata field addressed by its slug. Structured (rather than
+ * a colon-prefixed string) so validation and compilation can switch on `source`
+ * without parsing.
+ */
+export type RuleFieldRef =
+  | { source: 'builtin'; field: BuiltinRuleField }
+  | { source: 'metadata'; slug: string };
+
+/**
+ * The operators supported in v1. All are text-safe — numeric/date comparison
+ * operators (gt/lt/before/after) are deliberately deferred because metadata
+ * values are stored as untyped text and a cast would throw on a bad row.
+ * "is A or is B" is expressed with single-value operators under an OR group, so
+ * no multi-value operators are needed.
+ */
+export type RuleOperator =
+  | 'contains' // full-text / substring match
+  | 'equals' // exact (case-insensitive)
+  | 'notEquals'
+  | 'is' // enum/boolean exact
+  | 'isNot'
+  | 'has' // fileType present (EXISTS)
+  | 'notHas'
+  | 'hasTag' // tag membership
+  | 'notHasTag'
+  | 'inCollection'
+  | 'notInCollection'
+  | 'exists' // metadata field has any value
+  | 'notExists';
+
+export const RULE_OPERATORS: readonly RuleOperator[] = [
+  'contains',
+  'equals',
+  'notEquals',
+  'is',
+  'isNot',
+  'has',
+  'notHas',
+  'hasTag',
+  'notHasTag',
+  'inCollection',
+  'notInCollection',
+  'exists',
+  'notExists',
+];
+
+/** A leaf: one condition on one field. `value` is null only for exists/notExists. */
+export interface RuleCondition {
+  kind: 'condition';
+  field: RuleFieldRef;
+  operator: RuleOperator;
+  value: string | null;
+}
+
+/** A branch: combine children with AND or OR. */
+export interface RuleGroup {
+  kind: 'group';
+  op: 'and' | 'or';
+  children: RuleNode[];
+}
+
+export type RuleNode = RuleGroup | RuleCondition;
+
+// ---------------------------------------------------------------------------
+// Legal-operator tables — the single source of truth shared by the backend
+// validator (rejects illegal field/operator pairs) and the frontend
+// OperatorPicker (only offers legal operators). Keep these in sync by deriving
+// both sides from here.
+// ---------------------------------------------------------------------------
+
+export const LEGAL_OPERATORS_BY_BUILTIN: Record<BuiltinRuleField, readonly RuleOperator[]> = {
+  name: ['contains', 'equals'],
+  description: ['contains'],
+  status: ['is', 'isNot'],
+  fileType: ['has', 'notHas'],
+  collection: ['inCollection', 'notInCollection'],
+  tag: ['hasTag', 'notHasTag'],
+};
+
+export const LEGAL_OPERATORS_BY_METADATA_TYPE: Record<MetadataFieldType, readonly RuleOperator[]> = {
+  text: ['equals', 'notEquals', 'contains', 'exists', 'notExists'],
+  url: ['equals', 'notEquals', 'contains', 'exists', 'notExists'],
+  enum: ['is', 'isNot', 'exists', 'notExists'],
+  // multi_enum values are stored as a comma-joined string, so equality is wrong —
+  // only substring (contains) and presence are meaningful in v1.
+  multi_enum: ['contains', 'exists', 'notExists'],
+  boolean: ['is', 'exists', 'notExists'],
+  // number/date: text-safe operators only in v1 (no gt/lt/before/after).
+  number: ['equals', 'notEquals', 'exists', 'notExists'],
+  date: ['equals', 'notEquals', 'exists', 'notExists'],
+};
+
+/** Operators that take no value (the value field must be null). */
+export const VALUELESS_OPERATORS: readonly RuleOperator[] = ['exists', 'notExists'];
+
+// Bounds on tree complexity — enforced by the shared validator and re-checked
+// server-side. They bound query cost (OR fan-out) and protect against abuse.
+export const SMART_COLLECTION_MAX_DEPTH = 3;
+export const SMART_COLLECTION_MAX_NODES = 50;
+export const SMART_COLLECTION_MAX_CHILDREN = 20;
+
+// ---------------------------------------------------------------------------
+// Entity + request shapes
+// ---------------------------------------------------------------------------
+
+export interface SmartCollection {
+  id: string;
+  name: string;
+  slug: string;
+  description: string | null;
+  definition: RuleNode;
+  userId: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface SmartCollectionSummary {
+  id: string;
+  name: string;
+  slug: string;
+}
+
+export interface SmartCollectionDetail {
+  id: string;
+  name: string;
+  slug: string;
+  description: string | null;
+  definition: RuleNode;
+  /** Count of models the rule tree currently matches (derived on read). */
+  modelCount: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateSmartCollectionRequest {
+  name: string;
+  description?: string;
+  definition: RuleNode;
+}
+
+export interface UpdateSmartCollectionRequest {
+  name?: string;
+  description?: string | null;
+  definition?: RuleNode;
+}
+
+/**
+ * Body for the dry-run preview endpoint — an unsaved tree plus the read-time
+ * pagination/sort knobs reused from model search.
+ */
+export interface PreviewSmartCollectionRequest {
+  definition: RuleNode;
+  status?: ModelStatus;
+  fileType?: FileType;
+  sort?: ModelSearchParams['sort'];
+  sortDir?: ModelSearchParams['sortDir'];
+  cursor?: string;
+  pageSize?: number;
+}

--- a/packages/shared/src/validation/index.ts
+++ b/packages/shared/src/validation/index.ts
@@ -5,3 +5,4 @@ export * from './import.js';
 export * from './search.js';
 export * from './collection.js';
 export * from './upload.js';
+export * from './smart-collection.js';

--- a/packages/shared/src/validation/smart-collection.ts
+++ b/packages/shared/src/validation/smart-collection.ts
@@ -1,0 +1,162 @@
+import { z } from 'zod';
+import {
+  RULE_OPERATORS,
+  BUILTIN_RULE_FIELDS,
+  VALUELESS_OPERATORS,
+  LEGAL_OPERATORS_BY_BUILTIN,
+  SMART_COLLECTION_MAX_DEPTH,
+  SMART_COLLECTION_MAX_NODES,
+  SMART_COLLECTION_MAX_CHILDREN,
+  type RuleNode,
+  type RuleGroup,
+  type RuleCondition,
+  type RuleOperator,
+  type BuiltinRuleField,
+} from '../types/smart-collection.js';
+
+const operatorEnum = z.enum(RULE_OPERATORS as unknown as [RuleOperator, ...RuleOperator[]]);
+const builtinFieldEnum = z.enum(
+  BUILTIN_RULE_FIELDS as unknown as [BuiltinRuleField, ...BuiltinRuleField[]],
+);
+
+const ruleFieldRefSchema = z.discriminatedUnion('source', [
+  z.object({ source: z.literal('builtin'), field: builtinFieldEnum }),
+  z.object({ source: z.literal('metadata'), slug: z.string().min(1).max(255) }),
+]);
+
+// Leaf condition. Semantic checks that depend on the operator (value presence,
+// builtin operator legality) are done in the tree walker below, not here, so
+// the node schemas stay plain objects usable inside z.union.
+const ruleConditionSchema = z.object({
+  kind: z.literal('condition'),
+  field: ruleFieldRefSchema,
+  operator: operatorEnum,
+  value: z.string().max(500).nullable(),
+});
+
+// Recursive node schema. Nested groups must be non-empty (min 1) — an empty
+// nested group has an ambiguous AND/OR identity. The only legal empty group is
+// the root (see rootGroupSchema), which means "match everything".
+const ruleNodeSchema: z.ZodType<RuleNode> = z.lazy(() =>
+  z.union([ruleConditionSchema, nestedGroupSchema]),
+);
+
+const nestedGroupSchema: z.ZodType<RuleGroup> = z.object({
+  kind: z.literal('group'),
+  op: z.enum(['and', 'or']),
+  children: z.array(ruleNodeSchema).min(1).max(SMART_COLLECTION_MAX_CHILDREN),
+});
+
+// Root may be a bare condition or a group; the root group may be empty.
+const rootGroupSchema = z.object({
+  kind: z.literal('group'),
+  op: z.enum(['and', 'or']),
+  children: z.array(ruleNodeSchema).max(SMART_COLLECTION_MAX_CHILDREN),
+});
+
+/** Validate one leaf's operator/value/field coherence. */
+function validateCondition(node: RuleCondition, ctx: z.RefinementCtx, path: (string | number)[]): void {
+  const valueless = VALUELESS_OPERATORS.includes(node.operator);
+  if (valueless && node.value !== null) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: `Operator '${node.operator}' takes no value`,
+      path: [...path, 'value'],
+    });
+  }
+  if (!valueless && (node.value === null || node.value.trim() === '')) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: `Operator '${node.operator}' requires a value`,
+      path: [...path, 'value'],
+    });
+  }
+  // Builtin field/operator legality is knowable without a DB. Metadata
+  // field/operator legality depends on the field's type and is checked
+  // server-side once the field definition is resolved.
+  if (node.field.source === 'builtin') {
+    const legal = LEGAL_OPERATORS_BY_BUILTIN[node.field.field];
+    if (!legal.includes(node.operator)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Operator '${node.operator}' is not valid for field '${node.field.field}'`,
+        path: [...path, 'operator'],
+      });
+    }
+  }
+}
+
+/**
+ * Walk the whole tree once: enforce depth and total node count, and run
+ * per-condition semantic checks. `groupDepth` counts group nesting (root group
+ * = 1); conditions do not add depth.
+ */
+function walkTree(
+  node: RuleNode,
+  groupDepth: number,
+  counter: { n: number; flagged: boolean },
+  ctx: z.RefinementCtx,
+  path: (string | number)[],
+): void {
+  counter.n += 1;
+  if (counter.n > SMART_COLLECTION_MAX_NODES && !counter.flagged) {
+    counter.flagged = true;
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: `Rule tree exceeds the maximum of ${SMART_COLLECTION_MAX_NODES} nodes`,
+      path,
+    });
+  }
+
+  if (node.kind === 'group') {
+    if (groupDepth > SMART_COLLECTION_MAX_DEPTH) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Rule tree exceeds the maximum nesting depth of ${SMART_COLLECTION_MAX_DEPTH}`,
+        path,
+      });
+      return;
+    }
+    node.children.forEach((child, i) =>
+      walkTree(child, groupDepth + 1, counter, ctx, [...path, 'children', i]),
+    );
+  } else {
+    validateCondition(node, ctx, path);
+  }
+}
+
+/**
+ * A complete smart-collection rule tree definition. An empty root group means
+ * "match every model in the library".
+ */
+export const smartCollectionDefinitionSchema = z
+  .union([ruleConditionSchema, rootGroupSchema])
+  .superRefine((node, ctx) => {
+    walkTree(node as RuleNode, 1, { n: 0, flagged: false }, ctx, []);
+  });
+
+export const createSmartCollectionSchema = z.object({
+  name: z.string().trim().min(1).max(255),
+  description: z.string().max(2000).optional(),
+  definition: smartCollectionDefinitionSchema,
+});
+
+export const updateSmartCollectionSchema = z
+  .object({
+    name: z.string().trim().min(1).max(255).optional(),
+    description: z.string().max(2000).nullable().optional(),
+    definition: smartCollectionDefinitionSchema.optional(),
+  })
+  .refine((d) => d.name !== undefined || d.description !== undefined || d.definition !== undefined, {
+    message: 'At least one field must be provided',
+  });
+
+export const previewSmartCollectionSchema = z.object({
+  definition: smartCollectionDefinitionSchema,
+  status: z.enum(['processing', 'ready', 'error']).optional(),
+  fileType: z.enum(['stl', 'image', 'document', 'other']).optional(),
+  sort: z.enum(['name', 'createdAt', 'totalSizeBytes']).optional(),
+  sortDir: z.enum(['asc', 'desc']).optional(),
+  cursor: z.string().optional(),
+  pageSize: z.coerce.number().int().min(1).max(200).default(50),
+});


### PR DESCRIPTION
## P4 — Smart Collections

Fourth slice of the Alexandria redesign program (P0 design system, P1 app shell + pivot, P2 model detail + 3D, P3 workflow pages all shipped). Smart Collections are **dynamic, rule-based collections**: the definition is a nested AND/OR **rule tree** stored as JSONB; the result set is *derived on read* by compiling the tree into a model query — nothing is materialized.

Design spec: `docs/superpowers/specs/2026-05-29-design-system-foundation-design.md` (roadmap row P4).

## What's in it

**Backend**
- New `smart_collections` entity + migration `0009` (definition jsonb; no membership join table).
- **Rule engine** (`services/rule-engine.ts`): `compileRuleTree` (recursive AND/OR → SQL) + `buildLeafCondition`. `searchModels` is refactored to build its flat filters through the *same* `buildLeafCondition`, so a flat search and the equivalent rule tree emit identical SQL (proven by an equivalence test).
- `searchModels` gains a `(ruleWhere, applyDefaultStatus)` seam. Smart collections **suppress the implicit `status='ready'` default** when their tree references status — avoiding a silent-empty contradiction.
- Service with a 3-way cross-tenant guard on every `:id` route; validates metadata slugs + operator-for-type before compiling.
- Routes (`/smart-collections`): list, create, get, patch, delete, `:id/models` (derived set), `preview` (unsaved dry-run).

**Frontend**
- Dedicated composer route (`/smart-collections/new`, `/:id/edit`): recursive `RuleGroupEditor` (AND/OR groups, depth-3 cap) + `ConditionRow` (field → operator → value pickers driven by a shared legal-operators table) + debounced live `PreviewPane`.
- **Smart pivot axis** (4th axis): rail lists smart collections + "New"; the workspace grid branches to the selected collection's derived set with an "Edit rules" link.
- The P3 "Save as Smart Collection" search button is now active and seeds the composer from the current query.

## v1 scope cuts (deliberate)
- No numeric/date comparison operators (metadata is stored as untyped text; a cast would throw on a bad row) — text-safe operators only.
- No multi-value operators — nested OR-groups already express "is A or B", so no new chips/multiselect primitive was needed.
- `collection` builtin field is supported by the engine but not yet exposed in the composer UI (needs a collection picker).
- Global-search (`searchAll`) union with smart collections deferred to a fast-follow (ARCHITECTURE.md still notes this).

## Testing
- Backend: **437 tests pass** — rule-engine unit tests (per-field SQL, nested AND/OR, empty-root match-all, flat↔tree equivalence) + route integration tests (CRUD, cross-tenant 404 on every `:id`, pagination, unknown-slug/illegal-op 400, **status-default regression**, library isolation, tags-as-metadata guard).
- Frontend: **159 tests pass**; production build clean.
- A `reviewer` agent pass found **no blockers**; the one should-fix (tags-as-metadata footgun) is fixed in this PR.

Docs updated: `docs/API.md`, `docs/ARCHITECTURE.md` (D18/D19), `docs/TYPES.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)