### PR TITLE
feat(P5): Multi-library — All-Libraries home, switcher, /lib/:id scoping

### DIFF
--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -11,6 +11,7 @@ import { metadataFieldRoutes, modelMetadataRoute } from './routes/metadata.js';
 import { bulkRoutes } from './routes/bulk.js';
 import { collectionRoutes } from './routes/collections.js';
 import { smartCollectionRoutes } from './routes/smart-collections.js';
+import { libraryRoutes } from './routes/libraries.js';
 import { fileRoutes } from './routes/files.js';
 import { searchRoutes } from './routes/search.js';
 import { startIngestionWorker } from './workers/ingestion.worker.js';
@@ -67,6 +68,7 @@ export async function buildApp(): Promise<ReturnType<typeof Fastify>> {
   await app.register(bulkRoutes, { prefix: '/bulk' });
   await app.register(collectionRoutes, { prefix: '/collections' });
   await app.register(smartCollectionRoutes, { prefix: '/smart-collections' });
+  await app.register(libraryRoutes, { prefix: '/libraries' });
   await app.register(fileRoutes, { prefix: '/files' });
   await app.register(searchRoutes, { prefix: '/search' });
 

--- a/apps/backend/src/db/migrations/0010_add_library_color.sql
+++ b/apps/backend/src/db/migrations/0010_add_library_color.sql
@@ -1,0 +1,6 @@
+-- Add a palette-accent color to libraries (P5 multi-library).
+-- Rendered to a gradient badge on the All-Libraries cards and the rail switcher.
+-- Defaulted to 'amber' and NOT NULL, so existing rows backfill automatically with
+-- no separate data-migration step (mirrors the single original library's identity).
+
+ALTER TABLE "libraries" ADD COLUMN "color" varchar(32) DEFAULT 'amber' NOT NULL;

--- a/apps/backend/src/db/migrations/meta/_journal.json
+++ b/apps/backend/src/db/migrations/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1772100003000,
       "tag": "0009_add_smart_collections",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1772100004000,
+      "tag": "0010_add_library_color",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/backend/src/db/schema/library.ts
+++ b/apps/backend/src/db/schema/library.ts
@@ -17,6 +17,10 @@ export const libraries = pgTable(
       .references(() => users.id),
     // Each user has exactly one default library; enforced by a partial unique index below.
     isDefault: boolean('is_default').notNull().default(false),
+    // Palette-accent name (amber|teal|sage|plum|slate) rendered to a gradient badge
+    // in the All-Libraries cards and the rail switcher. Defaulted so existing rows
+    // backfill without a data migration step.
+    color: varchar('color', { length: 32 }).notNull().default('amber'),
     createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
     updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
   },

--- a/apps/backend/src/middleware/library.ts
+++ b/apps/backend/src/middleware/library.ts
@@ -8,6 +8,18 @@ declare module 'fastify' {
   }
 }
 
+/** Header the frontend mirrors its `/lib/:id` route segment into. */
+const LIBRARY_HEADER = 'x-library-id';
+
+/**
+ * Resolve the active library scope onto request.libraryId.
+ *
+ * The library is taken from the `X-Library-Id` header (the frontend sets it from
+ * the `/lib/:id` route). When present it MUST belong to the authenticated user —
+ * an unknown or un-owned id resolves to NOT_FOUND, never another user's data.
+ * When the header is absent we fall back to the user's default library, which
+ * preserves the single-library behavior every existing route relied on before P5.
+ */
 export async function requireLibrary(
   request: FastifyRequest,
   _reply: FastifyReply,
@@ -16,5 +28,8 @@ export async function requireLibrary(
     throw unauthorized('Authentication required');
   }
 
-  request.libraryId = await libraryService.resolveDefaultLibraryId(request.user.id);
+  const header = request.headers?.[LIBRARY_HEADER];
+  const requestedId = Array.isArray(header) ? header[0] : header;
+
+  request.libraryId = await libraryService.resolveLibraryId(request.user.id, requestedId ?? null);
 }

--- a/apps/backend/src/routes/collections.ts
+++ b/apps/backend/src/routes/collections.ts
@@ -67,12 +67,13 @@ export async function collectionRoutes(app: FastifyInstance): Promise<void> {
     },
   );
 
-  // GET /:id — single collection detail
+  // GET /:id — single collection detail (scoped to the active library)
   app.get(
     '/:id',
-    { preHandler: [requireAuth] },
+    { preHandler: [requireAuth, requireLibrary] },
     async (request, reply) => {
       const { id } = request.params as { id: string };
+      await collectionService.requireCollectionInLibrary(id, request.libraryId!);
       const detail = await presenterService.buildCollectionDetail(id);
 
       return reply.status(200).send({ data: detail, meta: null, errors: null });
@@ -113,8 +114,8 @@ export async function collectionRoutes(app: FastifyInstance): Promise<void> {
       const { id } = request.params as { id: string };
       const rawQuery = request.query as Record<string, unknown>;
 
-      // Verify collection exists
-      await collectionService.getCollectionById(id);
+      // Verify collection exists in the active library
+      await collectionService.requireCollectionInLibrary(id, request.libraryId!);
 
       // Extract metadata.* keys into a metadataFilters record
       const metadataFilters: Record<string, string> = {};

--- a/apps/backend/src/routes/libraries.test.ts
+++ b/apps/backend/src/routes/libraries.test.ts
@@ -1,0 +1,306 @@
+/**
+ * Integration tests for /libraries (P5 multi-library).
+ *
+ * Hit the real Fastify app against the real test database. Auth via the login
+ * cookie pattern from smart-collections.test.ts.
+ *
+ * Coverage:
+ * - CRUD happy paths + { data, meta, errors } envelope; color defaulting.
+ * - listLibraries derived model/collection counts, default-first ordering.
+ * - set-default flips exactly one default.
+ * - delete guards: 409 when default / non-empty / only-library; 200 when empty
+ *   non-default; list reflects the removal.
+ * - Cross-tenant guard: another user's library → 404 on every :id route.
+ * - Active-library scoping via X-Library-Id: content is scoped to the header
+ *   library; absent header falls back to default; un-owned id → 404.
+ * - Auth guard: no cookie → 401.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import { eq, inArray } from 'drizzle-orm';
+import { buildApp } from '../app.js';
+import { db } from '../db/index.js';
+import { users, libraries, models, collections } from '../db/schema/index.js';
+
+let app: FastifyInstance;
+let sessionCookie: string;
+
+let userId: string;
+let defaultLibraryId: string;
+let secondLibraryId: string;
+let otherUserId: string;
+let otherLibraryId: string;
+
+const EMAIL = 'lib-route-test@example.com';
+const OTHER_EMAIL = 'lib-route-other@example.com';
+const SINGLE_EMAIL = 'lib-route-single@example.com';
+
+async function login(email: string, password: string): Promise<string> {
+  const res = await app.inject({ method: 'POST', url: '/auth/login', payload: { email, password } });
+  const setCookie = res.headers['set-cookie'];
+  const cookieStr = Array.isArray(setCookie) ? setCookie[0] : String(setCookie);
+  return cookieStr.split(';')[0];
+}
+
+function authedGet(url: string, cookie = sessionCookie, libraryId?: string) {
+  const headers: Record<string, string> = { cookie };
+  if (libraryId) headers['x-library-id'] = libraryId;
+  return app.inject({ method: 'GET', url, headers });
+}
+function authedPost(url: string, body: object, cookie = sessionCookie, libraryId?: string) {
+  const headers: Record<string, string> = { cookie };
+  if (libraryId) headers['x-library-id'] = libraryId;
+  return app.inject({ method: 'POST', url, headers, payload: body });
+}
+function authedPatch(url: string, body: object, cookie = sessionCookie) {
+  return app.inject({ method: 'PATCH', url, headers: { cookie }, payload: body });
+}
+function authedDelete(url: string, cookie = sessionCookie) {
+  return app.inject({ method: 'DELETE', url, headers: { cookie } });
+}
+
+beforeAll(async () => {
+  app = await buildApp();
+  await app.ready();
+  const ts = Date.now();
+
+  const emails = [EMAIL, OTHER_EMAIL, SINGLE_EMAIL];
+  const leftover = await db.select({ id: users.id }).from(users).where(inArray(users.email, emails));
+  if (leftover.length > 0) {
+    const ids = leftover.map((u) => u.id);
+    await db.delete(collections).where(inArray(collections.userId, ids));
+    await db.delete(models).where(inArray(models.userId, ids));
+    await db.delete(libraries).where(inArray(libraries.userId, ids));
+    await db.delete(users).where(inArray(users.id, ids));
+  }
+
+  const authService = (
+    app as FastifyInstance & { authService: import('../services/auth.service.js').AuthService }
+  ).authService;
+  await authService.createUser(EMAIL, 'password123', 'Lib Test User');
+  await authService.createUser(OTHER_EMAIL, 'password123', 'Lib Other User');
+  await authService.createUser(SINGLE_EMAIL, 'password123', 'Lib Single User');
+
+  const [u] = await db.select().from(users).where(eq(users.email, EMAIL)).limit(1);
+  const [other] = await db.select().from(users).where(eq(users.email, OTHER_EMAIL)).limit(1);
+  userId = u.id;
+  otherUserId = other.id;
+
+  // User A: a default library ("Main") with one model + one collection, and an
+  // empty second library.
+  const [mainLib] = await db
+    .insert(libraries)
+    .values({ name: 'Main', slug: `main-${ts}`, userId, isDefault: true })
+    .returning();
+  defaultLibraryId = mainLib.id;
+  const [secondLib] = await db
+    .insert(libraries)
+    .values({ name: 'Minis', slug: `minis-${ts}`, userId, isDefault: false, color: 'teal' })
+    .returning();
+  secondLibraryId = secondLib.id;
+
+  await db.insert(models).values({
+    name: 'Main Model',
+    slug: `main-model-${ts}`,
+    userId,
+    libraryId: defaultLibraryId,
+    status: 'ready',
+    sourceType: 'upload',
+  });
+  await db.insert(collections).values({
+    name: 'Main Collection',
+    slug: `main-collection-${ts}`,
+    userId,
+    libraryId: defaultLibraryId,
+  });
+
+  // Other user: their own default library (cross-tenant target).
+  const [otherLib] = await db
+    .insert(libraries)
+    .values({ name: 'Other', slug: `other-${ts}`, userId: otherUserId, isDefault: true })
+    .returning();
+  otherLibraryId = otherLib.id;
+
+  sessionCookie = await login(EMAIL, 'password123');
+});
+
+afterAll(async () => {
+  const emails = [EMAIL, OTHER_EMAIL, SINGLE_EMAIL];
+  const rows = await db.select({ id: users.id }).from(users).where(inArray(users.email, emails));
+  const ids = rows.map((u) => u.id);
+  if (ids.length > 0) {
+    await db.delete(collections).where(inArray(collections.userId, ids));
+    await db.delete(models).where(inArray(models.userId, ids));
+    await db.delete(libraries).where(inArray(libraries.userId, ids));
+    await db.delete(users).where(inArray(users.id, ids));
+  }
+  await app.close();
+});
+
+describe('GET /libraries', () => {
+  it('lists the user libraries default-first with derived counts', async () => {
+    const res = await authedGet('/libraries');
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.errors).toBeNull();
+    expect(body.meta.total).toBeGreaterThanOrEqual(2);
+
+    const main = body.data.find((l: { id: string }) => l.id === defaultLibraryId);
+    const minis = body.data.find((l: { id: string }) => l.id === secondLibraryId);
+    expect(main).toMatchObject({ name: 'Main', isDefault: true, color: 'amber', modelCount: 1, collectionCount: 1 });
+    expect(minis).toMatchObject({ name: 'Minis', isDefault: false, color: 'teal', modelCount: 0, collectionCount: 0 });
+
+    // Default sorts first.
+    expect(body.data[0].isDefault).toBe(true);
+  });
+
+  it('rejects unauthenticated requests', async () => {
+    const res = await app.inject({ method: 'GET', url: '/libraries' });
+    expect(res.statusCode).toBe(401);
+  });
+});
+
+describe('POST /libraries', () => {
+  it('creates a non-default library with default color', async () => {
+    const res = await authedPost('/libraries', { name: 'Reference Kit' });
+    expect(res.statusCode).toBe(201);
+    const lib = res.json().data;
+    expect(lib).toMatchObject({ name: 'Reference Kit', isDefault: false, color: 'amber', modelCount: 0, collectionCount: 0 });
+    expect(lib.slug).toMatch(/^reference-kit/);
+
+    // Clean up so later count assertions stay stable.
+    await authedDelete(`/libraries/${lib.id}`);
+  });
+
+  it('accepts an explicit color and rejects an invalid one', async () => {
+    const ok = await authedPost('/libraries', { name: 'Plum Lib', color: 'plum' });
+    expect(ok.statusCode).toBe(201);
+    expect(ok.json().data.color).toBe('plum');
+    await authedDelete(`/libraries/${ok.json().data.id}`);
+
+    const bad = await authedPost('/libraries', { name: 'Bad', color: 'rainbow' });
+    expect(bad.statusCode).toBe(400);
+  });
+
+  it('rejects a blank name', async () => {
+    const res = await authedPost('/libraries', { name: '   ' });
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+describe('PATCH /libraries/:id', () => {
+  it('renames and recolors, regenerating the slug', async () => {
+    const created = (await authedPost('/libraries', { name: 'Temp Name' })).json().data;
+    const res = await authedPatch(`/libraries/${created.id}`, { name: 'Painted Minis', color: 'sage' });
+    expect(res.statusCode).toBe(200);
+    const lib = res.json().data;
+    expect(lib).toMatchObject({ name: 'Painted Minis', color: 'sage' });
+    expect(lib.slug).toMatch(/^painted-minis/);
+    await authedDelete(`/libraries/${created.id}`);
+  });
+
+  it('404s on another user library', async () => {
+    const res = await authedPatch(`/libraries/${otherLibraryId}`, { name: 'Hijack' });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('400s when no fields are provided', async () => {
+    const res = await authedPatch(`/libraries/${secondLibraryId}`, {});
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+describe('POST /libraries/:id/set-default', () => {
+  it('flips the default to exactly one library', async () => {
+    const res = await authedPost(`/libraries/${secondLibraryId}/set-default`, {});
+    expect(res.statusCode).toBe(200);
+
+    const rows = await db.select().from(libraries).where(eq(libraries.userId, userId));
+    const defaults = rows.filter((r) => r.isDefault);
+    expect(defaults).toHaveLength(1);
+    expect(defaults[0].id).toBe(secondLibraryId);
+
+    // Restore Main as default for the remaining tests.
+    await authedPost(`/libraries/${defaultLibraryId}/set-default`, {});
+    const restored = (await db.select().from(libraries).where(eq(libraries.id, defaultLibraryId)))[0];
+    expect(restored.isDefault).toBe(true);
+  });
+
+  it('404s on another user library', async () => {
+    const res = await authedPost(`/libraries/${otherLibraryId}/set-default`, {});
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+describe('DELETE /libraries/:id', () => {
+  it('409s when the library is the default', async () => {
+    const res = await authedDelete(`/libraries/${defaultLibraryId}`);
+    expect(res.statusCode).toBe(409);
+  });
+
+  it('409s when the library still contains models or collections', async () => {
+    // Give the (non-default) second library a collection, then try to delete it.
+    const lib = (await authedPost('/libraries', { name: 'Has Content' })).json().data;
+    await authedPost('/collections', { name: 'Inside' }, sessionCookie, lib.id);
+    const res = await authedDelete(`/libraries/${lib.id}`);
+    expect(res.statusCode).toBe(409);
+
+    // Remove the collection, then deletion succeeds.
+    await db.delete(collections).where(eq(collections.libraryId, lib.id));
+    const ok = await authedDelete(`/libraries/${lib.id}`);
+    expect(ok.statusCode).toBe(200);
+  });
+
+  it('409s when it is the user only library', async () => {
+    const [single] = await db
+      .select({ id: users.id })
+      .from(users)
+      .where(eq(users.email, SINGLE_EMAIL));
+    const [onlyLib] = await db
+      .insert(libraries)
+      .values({ name: 'Solo', slug: `solo-${Date.now()}`, userId: single.id, isDefault: false })
+      .returning();
+    const singleCookie = await login(SINGLE_EMAIL, 'password123');
+    const res = await authedDelete(`/libraries/${onlyLib.id}`, singleCookie);
+    expect(res.statusCode).toBe(409);
+  });
+
+  it('deletes an empty, non-default library and removes it from the list', async () => {
+    const lib = (await authedPost('/libraries', { name: 'Disposable' })).json().data;
+    const res = await authedDelete(`/libraries/${lib.id}`);
+    expect(res.statusCode).toBe(200);
+
+    const list = (await authedGet('/libraries')).json().data;
+    expect(list.find((l: { id: string }) => l.id === lib.id)).toBeUndefined();
+  });
+
+  it('404s on another user library', async () => {
+    const res = await authedDelete(`/libraries/${otherLibraryId}`);
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+describe('active-library scoping via X-Library-Id', () => {
+  it('scopes content to the header library and falls back to default when absent', async () => {
+    // Create a collection in the second (empty) library via the header.
+    const created = await authedPost('/collections', { name: 'Scoped Coll' }, sessionCookie, secondLibraryId);
+    expect(created.statusCode).toBe(201);
+
+    // With the header, the second library shows the new collection.
+    const scoped = (await authedGet('/collections', sessionCookie, secondLibraryId)).json().data;
+    expect(scoped.some((c: { name: string }) => c.name === 'Scoped Coll')).toBe(true);
+
+    // Without the header (→ default library), it does not.
+    const def = (await authedGet('/collections')).json().data;
+    expect(def.some((c: { name: string }) => c.name === 'Scoped Coll')).toBe(false);
+    expect(def.some((c: { name: string }) => c.name === 'Main Collection')).toBe(true);
+
+    await db.delete(collections).where(eq(collections.libraryId, secondLibraryId));
+  });
+
+  it('404s when the header references an un-owned library', async () => {
+    const res = await authedGet('/collections', sessionCookie, otherLibraryId);
+    expect(res.statusCode).toBe(404);
+  });
+});

--- a/apps/backend/src/routes/libraries.ts
+++ b/apps/backend/src/routes/libraries.ts
@@ -1,0 +1,60 @@
+import type { FastifyInstance } from 'fastify';
+import type { CreateLibraryRequest, UpdateLibraryRequest } from '@alexandria/shared';
+import { createLibrarySchema, updateLibrarySchema } from '@alexandria/shared';
+import { requireAuth } from '../middleware/auth.js';
+import { validate } from '../middleware/validate.js';
+import { libraryService } from '../services/library.service.js';
+
+/**
+ * Library management routes. These manage the library scope itself, so they use
+ * only requireAuth (NOT requireLibrary) and resolve ownership inside the service
+ * via the userId. libraryId is taken from the URL :id and always ownership-checked.
+ */
+export async function libraryRoutes(app: FastifyInstance): Promise<void> {
+  // GET / — list the user's libraries with model/collection counts (home cards)
+  app.get('/', { preHandler: [requireAuth] }, async (request, reply) => {
+    const items = await libraryService.listLibraries(request.user!.id);
+    return reply.status(200).send({
+      data: items,
+      meta: { total: items.length, cursor: null, pageSize: items.length },
+      errors: null,
+    });
+  });
+
+  // POST / — create a new library
+  app.post(
+    '/',
+    { preHandler: [requireAuth, validate(createLibrarySchema)] },
+    async (request, reply) => {
+      const body = request.body as CreateLibraryRequest;
+      const library = await libraryService.createLibrary(request.user!.id, body);
+      return reply.status(201).send({ data: library, meta: null, errors: null });
+    },
+  );
+
+  // PATCH /:id — rename / recolor a library
+  app.patch(
+    '/:id',
+    { preHandler: [requireAuth, validate(updateLibrarySchema)] },
+    async (request, reply) => {
+      const { id } = request.params as { id: string };
+      const body = request.body as UpdateLibraryRequest;
+      const library = await libraryService.updateLibrary(request.user!.id, id, body);
+      return reply.status(200).send({ data: library, meta: null, errors: null });
+    },
+  );
+
+  // POST /:id/set-default — mark this library as the user's default
+  app.post('/:id/set-default', { preHandler: [requireAuth] }, async (request, reply) => {
+    const { id } = request.params as { id: string };
+    await libraryService.setDefaultLibrary(request.user!.id, id);
+    return reply.status(200).send({ data: null, meta: null, errors: null });
+  });
+
+  // DELETE /:id — delete an empty, non-default library
+  app.delete('/:id', { preHandler: [requireAuth] }, async (request, reply) => {
+    const { id } = request.params as { id: string };
+    await libraryService.deleteLibrary(request.user!.id, id);
+    return reply.status(200).send({ data: null, meta: null, errors: null });
+  });
+}

--- a/apps/backend/src/routes/models.ts
+++ b/apps/backend/src/routes/models.ts
@@ -290,10 +290,10 @@ export async function modelRoutes(app: FastifyInstance): Promise<void> {
   // GET /:id/status — poll processing status
   app.get(
     '/:id/status',
-    { preHandler: [requireAuth] },
+    { preHandler: [requireAuth, requireLibrary] },
     async (request, reply) => {
       const { id } = request.params as { id: string };
-      const model = await modelService.getModelById(id);
+      const model = await modelService.requireModelInLibrary(id, request.libraryId!);
 
       // If the model is still processing, also check the job queue for progress
       let progress: number | null = null;
@@ -320,12 +320,13 @@ export async function modelRoutes(app: FastifyInstance): Promise<void> {
     },
   );
 
-  // GET /:id — model detail
+  // GET /:id — model detail (scoped to the active library)
   app.get(
     '/:id',
-    { preHandler: [requireAuth] },
+    { preHandler: [requireAuth, requireLibrary] },
     async (request, reply) => {
       const { id } = request.params as { id: string };
+      await modelService.requireModelInLibrary(id, request.libraryId!);
       const detail = await presenterService.buildModelDetail(id);
 
       return reply.status(200).send({ data: detail, meta: null, errors: null });
@@ -335,10 +336,10 @@ export async function modelRoutes(app: FastifyInstance): Promise<void> {
   // GET /:id/files — file tree for a model
   app.get(
     '/:id/files',
-    { preHandler: [requireAuth] },
+    { preHandler: [requireAuth, requireLibrary] },
     async (request, reply) => {
       const { id } = request.params as { id: string };
-      await modelService.getModelById(id); // verify exists
+      await modelService.requireModelInLibrary(id, request.libraryId!); // verify exists + scope
       const files = await modelService.getModelFiles(id);
       const tree = presenterService.buildFileTree(files);
 

--- a/apps/backend/src/services/collection.service.ts
+++ b/apps/backend/src/services/collection.service.ts
@@ -116,6 +116,18 @@ export class CollectionService {
   }
 
   /**
+   * Verify a collection exists AND belongs to the active library. Throws
+   * NOT_FOUND otherwise, so a stale deep link to a collection in another library
+   * 404s after the user switches libraries instead of rendering its content.
+   */
+  async requireCollectionInLibrary(id: string, libraryId: string): Promise<void> {
+    const row = await this._requireCollection(id);
+    if (row.libraryId !== libraryId) {
+      throw notFound(`Collection not found: ${id}`);
+    }
+  }
+
+  /**
    * Add a single model to a collection. Idempotent.
    * Preserved for folder import backward compatibility.
    */

--- a/apps/backend/src/services/library.service.ts
+++ b/apps/backend/src/services/library.service.ts
@@ -1,22 +1,32 @@
-import { and, eq } from 'drizzle-orm';
+import { and, eq, asc, desc, count, inArray } from 'drizzle-orm';
+import type {
+  LibrarySummary,
+  CreateLibraryRequest,
+  UpdateLibraryRequest,
+} from '@alexandria/shared';
 import { db } from '../db/index.js';
-import { libraries } from '../db/schema/index.js';
+import { libraries, models, collections } from '../db/schema/index.js';
+import type { Library as LibraryRow } from '../db/schema/library.js';
 import { generateSlug } from '../utils/slug.js';
 import { createLogger } from '../utils/logger.js';
+import { notFound, conflict } from '../utils/errors.js';
 
 const logger = createLogger('LibraryService');
 
 /**
- * LibraryService — resolves the library scope that models and collections
- * belong to. Every model/collection requires a libraryId (NOT NULL since
- * migration 0007); the invariant established by the migration backfill is that
- * every user has exactly one default library.
+ * LibraryService — owns the library scope that models and collections belong to.
+ * Every model/collection requires a libraryId (NOT NULL since migration 0007);
+ * the invariant established by the 0006 backfill is that every user has exactly
+ * one default library.
  *
- * This service is intentionally minimal: it resolves (and lazily creates, for
- * users that post-date the backfill) a user's default library. Full library
- * management (multiple libraries, switching, renaming) is a later workspace task.
+ * P5 surfaces multiple libraries to the user: this service resolves the active
+ * scope (validated against ownership) and provides the management CRUD that the
+ * All-Libraries home and rail switcher drive. libraryId is never accepted from
+ * untrusted input without an ownership check.
  */
 export class LibraryService {
+  // ---- Scope resolution (used by the requireLibrary middleware) ----
+
   /**
    * Return the id of the user's default library, creating one if none exists.
    * Mirrors the 0006 backfill invariant: one default library per user.
@@ -51,6 +61,226 @@ export class LibraryService {
 
     return created.id;
   }
+
+  /**
+   * Resolve the active library for a request. If `requestedId` is provided it
+   * MUST belong to the user — otherwise NOT_FOUND (same error whether it does
+   * not exist or belongs to someone else, so ids cannot be enumerated). When no
+   * id is requested, fall back to the user's default library.
+   */
+  async resolveLibraryId(userId: string, requestedId?: string | null): Promise<string> {
+    if (requestedId) {
+      await this.requireOwnedLibrary(userId, requestedId);
+      return requestedId;
+    }
+    return this.resolveDefaultLibraryId(userId);
+  }
+
+  /**
+   * Verify a library exists and belongs to the user. Throws NOT_FOUND otherwise.
+   */
+  async requireOwnedLibrary(userId: string, libraryId: string): Promise<LibraryRow> {
+    const [row] = await db
+      .select()
+      .from(libraries)
+      .where(and(eq(libraries.id, libraryId), eq(libraries.userId, userId)))
+      .limit(1);
+
+    if (!row) {
+      throw notFound('Library not found');
+    }
+    return row;
+  }
+
+  // ---- Management CRUD (drives the All-Libraries home + switcher) ----
+
+  /**
+   * List a user's libraries with derived model/collection counts, default first
+   * then oldest first. Counts come from two grouped queries rather than N+1.
+   */
+  async listLibraries(userId: string): Promise<LibrarySummary[]> {
+    const rows = await db
+      .select()
+      .from(libraries)
+      .where(eq(libraries.userId, userId))
+      .orderBy(desc(libraries.isDefault), asc(libraries.createdAt));
+
+    if (rows.length === 0) {
+      return [];
+    }
+
+    const ids = rows.map((r) => r.id);
+    const [modelCounts, collectionCounts] = await Promise.all([
+      this._countModelsByLibrary(ids),
+      this._countCollectionsByLibrary(ids),
+    ]);
+
+    return rows.map((row) => ({
+      ...toLibrary(row),
+      modelCount: modelCounts.get(row.id) ?? 0,
+      collectionCount: collectionCounts.get(row.id) ?? 0,
+    }));
+  }
+
+  /**
+   * Create a new (non-default) library for the user.
+   */
+  async createLibrary(userId: string, data: CreateLibraryRequest): Promise<LibrarySummary> {
+    const [row] = await db
+      .insert(libraries)
+      .values({
+        name: data.name,
+        slug: generateSlug(data.name),
+        userId,
+        isDefault: false,
+        ...(data.color ? { color: data.color } : {}),
+      })
+      .returning();
+
+    logger.info(
+      { service: 'LibraryService', userId, libraryId: row.id, name: row.name },
+      'Library created',
+    );
+
+    return { ...toLibrary(row), modelCount: 0, collectionCount: 0 };
+  }
+
+  /**
+   * Rename / recolor a library. Renaming regenerates the slug.
+   */
+  async updateLibrary(
+    userId: string,
+    libraryId: string,
+    data: UpdateLibraryRequest,
+  ): Promise<LibrarySummary> {
+    await this.requireOwnedLibrary(userId, libraryId);
+
+    const updateValues: Partial<{ name: string; slug: string; color: string; updatedAt: Date }> = {
+      updatedAt: new Date(),
+    };
+    if (data.name !== undefined) {
+      updateValues.name = data.name;
+      updateValues.slug = generateSlug(data.name);
+    }
+    if (data.color !== undefined) {
+      updateValues.color = data.color;
+    }
+
+    const [updated] = await db
+      .update(libraries)
+      .set(updateValues)
+      .where(eq(libraries.id, libraryId))
+      .returning();
+
+    logger.info({ service: 'LibraryService', userId, libraryId }, 'Library updated');
+
+    const [modelCount, collectionCount] = await this._countContents(libraryId);
+    return { ...toLibrary(updated), modelCount, collectionCount };
+  }
+
+  /**
+   * Mark a library as the user's default. Clears the prior default and sets the
+   * new one in a single transaction so the partial unique index never sees two
+   * defaults mid-flip.
+   */
+  async setDefaultLibrary(userId: string, libraryId: string): Promise<void> {
+    await this.requireOwnedLibrary(userId, libraryId);
+
+    await db.transaction(async (tx) => {
+      await tx
+        .update(libraries)
+        .set({ isDefault: false, updatedAt: new Date() })
+        .where(and(eq(libraries.userId, userId), eq(libraries.isDefault, true)));
+      await tx
+        .update(libraries)
+        .set({ isDefault: true, updatedAt: new Date() })
+        .where(eq(libraries.id, libraryId));
+    });
+
+    logger.info({ service: 'LibraryService', userId, libraryId }, 'Default library changed');
+  }
+
+  /**
+   * Delete a library. Refuses when it is the default, the user's only library,
+   * or still owns models or collections (the FK is ON DELETE no action; we
+   * surface a clear 409 rather than a raw constraint error).
+   */
+  async deleteLibrary(userId: string, libraryId: string): Promise<void> {
+    const row = await this.requireOwnedLibrary(userId, libraryId);
+
+    if (row.isDefault) {
+      throw conflict('Cannot delete the default library. Set another library as default first.');
+    }
+
+    const [{ value: total }] = await db
+      .select({ value: count() })
+      .from(libraries)
+      .where(eq(libraries.userId, userId));
+    if (Number(total) <= 1) {
+      throw conflict('Cannot delete your only library.');
+    }
+
+    const [modelCount, collectionCount] = await this._countContents(libraryId);
+    if (modelCount > 0 || collectionCount > 0) {
+      throw conflict(
+        'Cannot delete a library that still contains models or collections. Move or delete its contents first.',
+      );
+    }
+
+    await db.delete(libraries).where(eq(libraries.id, libraryId));
+
+    logger.info({ service: 'LibraryService', userId, libraryId }, 'Library deleted');
+  }
+
+  // ---- Private helpers ----
+
+  private async _countModelsByLibrary(libraryIds: string[]): Promise<Map<string, number>> {
+    const rows = await db
+      .select({ libraryId: models.libraryId, value: count() })
+      .from(models)
+      .where(inArray(models.libraryId, libraryIds))
+      .groupBy(models.libraryId);
+    return toCountMap(rows);
+  }
+
+  private async _countCollectionsByLibrary(libraryIds: string[]): Promise<Map<string, number>> {
+    const rows = await db
+      .select({ libraryId: collections.libraryId, value: count() })
+      .from(collections)
+      .where(inArray(collections.libraryId, libraryIds))
+      .groupBy(collections.libraryId);
+    return toCountMap(rows);
+  }
+
+  /** Returns [modelCount, collectionCount] for a single library. */
+  private async _countContents(libraryId: string): Promise<[number, number]> {
+    const [[m], [c]] = await Promise.all([
+      db.select({ value: count() }).from(models).where(eq(models.libraryId, libraryId)),
+      db.select({ value: count() }).from(collections).where(eq(collections.libraryId, libraryId)),
+    ]);
+    return [Number(m.value), Number(c.value)];
+  }
+}
+
+function toCountMap(rows: { libraryId: string; value: number }[]): Map<string, number> {
+  const map = new Map<string, number>();
+  for (const row of rows) {
+    map.set(row.libraryId, Number(row.value));
+  }
+  return map;
+}
+
+function toLibrary(row: LibraryRow) {
+  return {
+    id: row.id,
+    name: row.name,
+    slug: row.slug,
+    userId: row.userId,
+    isDefault: row.isDefault,
+    color: row.color,
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+  };
 }
 
 export const libraryService = new LibraryService();

--- a/apps/backend/src/services/model.service.ts
+++ b/apps/backend/src/services/model.service.ts
@@ -129,6 +129,19 @@ export class ModelService {
     return row;
   }
 
+  /**
+   * Verify a model exists AND belongs to the active library. Throws NOT_FOUND
+   * otherwise, so a stale deep link to a model in another library 404s after the
+   * user switches libraries instead of rendering cross-library content.
+   */
+  async requireModelInLibrary(id: string, libraryId: string): Promise<Model> {
+    const model = await this.getModelById(id);
+    if (model.libraryId !== libraryId) {
+      throw notFound(`Model not found: ${id}`);
+    }
+    return model;
+  }
+
   async updateModel(id: string, data: UpdateModelRequest): Promise<Model> {
     await this.getModelById(id);
 

--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -1,8 +1,10 @@
-import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
+import { Navigate, Outlet, Route, Routes, useLocation } from 'react-router-dom';
 import { Loader2 } from 'lucide-react';
 import { useAuth } from './hooks/use-auth';
+import { LibraryProvider } from './hooks/use-libraries';
 import { AppShell } from './components/layout/AppShell';
 import { LoginPage } from './pages/LoginPage';
+import { AllLibrariesPage } from './pages/AllLibrariesPage';
 import { PivotPage } from './pages/PivotPage';
 import { ModelDetailPage } from './pages/ModelDetailPage';
 import { CollectionsPage } from './pages/CollectionsPage';
@@ -32,31 +34,45 @@ function ProtectedRoute({ children }: { children: React.ReactNode }) {
   return <>{children}</>;
 }
 
+/**
+ * Authenticated shell: gates on auth then mounts LibraryProvider so every nested
+ * route (the All-Libraries home and each `/lib/:id` workspace route) shares one
+ * libraries query and keeps the API client's active-library header in sync.
+ */
+function AuthedLayout() {
+  return (
+    <ProtectedRoute>
+      <LibraryProvider>
+        <Outlet />
+      </LibraryProvider>
+    </ProtectedRoute>
+  );
+}
+
 export default function App() {
   return (
     <Routes>
       <Route path="/login" element={<LoginPage />} />
-      <Route
-        element={
-          <ProtectedRoute>
-            <AppShell />
-          </ProtectedRoute>
-        }
-      >
-        <Route index element={<PivotPage />} />
-        <Route path="models/:id" element={<ModelDetailPage />} />
-        <Route path="collections" element={<CollectionsPage />} />
-        <Route path="collections/:id" element={<CollectionDetailPage />} />
-        <Route path="upload" element={<UploadPage />} />
-        <Route path="smart-collections/new" element={<SmartCollectionComposerPage />} />
-        <Route path="smart-collections/:id/edit" element={<SmartCollectionComposerPage />} />
-        <Route path="settings" element={<SettingsPage />} />
-        <Route path="search" element={<SearchPage />} />
+      <Route element={<AuthedLayout />}>
+        {/* All-Libraries home — pick or manage a library */}
+        <Route index element={<AllLibrariesPage />} />
+        {/* Per-library workspace */}
+        <Route path="lib/:libraryId" element={<AppShell />}>
+          <Route index element={<PivotPage />} />
+          <Route path="models/:id" element={<ModelDetailPage />} />
+          <Route path="collections" element={<CollectionsPage />} />
+          <Route path="collections/:id" element={<CollectionDetailPage />} />
+          <Route path="upload" element={<UploadPage />} />
+          <Route path="smart-collections/new" element={<SmartCollectionComposerPage />} />
+          <Route path="smart-collections/:id/edit" element={<SmartCollectionComposerPage />} />
+          <Route path="settings" element={<SettingsPage />} />
+          <Route path="search" element={<SearchPage />} />
+        </Route>
       </Route>
       {import.meta.env.DEV && (
         <Route path="/design-system" element={<DesignSystemPage />} />
       )}
-      {/* Catch-all */}
+      {/* Catch-all → home */}
       <Route path="*" element={<Navigate to="/" replace />} />
     </Routes>
   );

--- a/apps/frontend/src/api/client.ts
+++ b/apps/frontend/src/api/client.ts
@@ -2,6 +2,21 @@ import type { ApiResponse } from '@alexandria/shared';
 
 const BASE_URL = '/api';
 
+/**
+ * The active library id, mirrored from the `/lib/:id` route by LibraryProvider.
+ * Sent as the `X-Library-Id` header on every request so all resource endpoints
+ * scope to the selected library without each api module threading it through.
+ * Null on the All-Libraries home / login, where the backend falls back to the
+ * user's default library.
+ */
+let activeLibraryId: string | null = null;
+
+export function setActiveLibraryId(id: string | null): void {
+  activeLibraryId = id;
+}
+
+const LIBRARY_HEADER = 'X-Library-Id';
+
 export class ApiRequestError extends Error {
   constructor(
     public statusCode: number,
@@ -25,6 +40,9 @@ async function request<T>(
   // Content-Type: application/json on requests with no body.
   if (init.body !== undefined) {
     headers['Content-Type'] ??= 'application/json';
+  }
+  if (activeLibraryId) {
+    headers[LIBRARY_HEADER] ??= activeLibraryId;
   }
 
   const response = await fetch(url, {
@@ -79,6 +97,7 @@ export async function postForm<T>(
     const xhr = new XMLHttpRequest();
     xhr.open('POST', `${BASE_URL}${path}`);
     xhr.withCredentials = true;
+    if (activeLibraryId) xhr.setRequestHeader(LIBRARY_HEADER, activeLibraryId);
 
     if (onProgress) {
       xhr.upload.addEventListener('progress', (e) => {
@@ -127,6 +146,7 @@ export async function putRaw<T>(
     xhr.open('PUT', `${BASE_URL}${path}`);
     xhr.withCredentials = true;
     xhr.setRequestHeader('Content-Type', 'application/octet-stream');
+    if (activeLibraryId) xhr.setRequestHeader(LIBRARY_HEADER, activeLibraryId);
 
     if (onProgress) {
       xhr.upload.addEventListener('progress', (e) => {

--- a/apps/frontend/src/api/libraries.ts
+++ b/apps/frontend/src/api/libraries.ts
@@ -1,0 +1,32 @@
+import type {
+  ApiResponse,
+  LibrarySummary,
+  CreateLibraryRequest,
+  UpdateLibraryRequest,
+} from '@alexandria/shared';
+import { get, post, patch, del } from './client';
+
+export async function listLibraries(): Promise<ApiResponse<LibrarySummary[]>> {
+  return get<LibrarySummary[]>('/libraries');
+}
+
+export async function createLibrary(data: CreateLibraryRequest): Promise<LibrarySummary> {
+  const response = await post<LibrarySummary>('/libraries', data);
+  return response.data;
+}
+
+export async function updateLibrary(
+  id: string,
+  data: UpdateLibraryRequest
+): Promise<LibrarySummary> {
+  const response = await patch<LibrarySummary>(`/libraries/${id}`, data);
+  return response.data;
+}
+
+export async function setDefaultLibrary(id: string): Promise<void> {
+  await post(`/libraries/${id}/set-default`);
+}
+
+export async function deleteLibrary(id: string): Promise<void> {
+  await del(`/libraries/${id}`);
+}

--- a/apps/frontend/src/components/command/CommandPalette.tsx
+++ b/apps/frontend/src/components/command/CommandPalette.tsx
@@ -4,6 +4,7 @@ import { Search, Package, Folder, ArrowRight } from 'lucide-react';
 import { Dialog, DialogContent } from '../ui/dialog';
 import { useCommandPalette } from '../../hooks/use-command-palette';
 import { useGlobalSearch } from '../../hooks/use-global-search';
+import { useLibraryPath } from '../../hooks/use-libraries';
 
 function useDebounce<T>(value: T, delay: number): T {
   const [debounced, setDebounced] = useState(value);
@@ -17,6 +18,7 @@ function useDebounce<T>(value: T, delay: number): T {
 export function CommandPalette() {
   const { isOpen, close } = useCommandPalette();
   const navigate = useNavigate();
+  const libPath = useLibraryPath();
   const inputRef = useRef<HTMLInputElement>(null);
 
   const [inputValue, setInputValue] = useState('');
@@ -32,7 +34,7 @@ export function CommandPalette() {
       type: 'search',
       label: `Search everything for "${debouncedQ}"`,
       action: () => {
-        navigate(`/search?q=${encodeURIComponent(debouncedQ)}`);
+        navigate(libPath(`/search?q=${encodeURIComponent(debouncedQ)}`));
         close();
       },
     });
@@ -45,7 +47,7 @@ export function CommandPalette() {
         label: model.name,
         sub: `${model.fileCount} ${model.fileCount === 1 ? 'file' : 'files'}`,
         action: () => {
-          navigate(`/models/${model.id}`);
+          navigate(libPath(`/models/${model.id}`));
           close();
         },
       });
@@ -56,7 +58,7 @@ export function CommandPalette() {
         label: col.name,
         sub: `${col.modelCount} ${col.modelCount === 1 ? 'model' : 'models'}`,
         action: () => {
-          navigate(`/collections/${col.id}`);
+          navigate(libPath(`/collections/${col.id}`));
           close();
         },
       });

--- a/apps/frontend/src/components/libraries/LibraryDialog.tsx
+++ b/apps/frontend/src/components/libraries/LibraryDialog.tsx
@@ -1,0 +1,128 @@
+import { useEffect, useState } from 'react';
+import type { LibrarySummary, LibraryColor } from '@alexandria/shared';
+import { useToast } from '../../hooks/use-toast';
+import { useLibraries } from '../../hooks/use-libraries';
+import { LIBRARY_COLORS, libraryGradient } from '../../lib/library-color';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '../ui/dialog';
+import { Button } from '../ui/button';
+import { Input } from '../ui/input';
+import { Label } from '../ui/label';
+import { cn } from '../../lib/utils';
+
+interface LibraryDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** If provided, the dialog edits the given library. Otherwise it creates one. */
+  library?: LibrarySummary;
+  /** Called with the created/updated library on success. */
+  onSuccess?: (result: LibrarySummary) => void;
+}
+
+export function LibraryDialog({ open, onOpenChange, library, onSuccess }: LibraryDialogProps) {
+  const isEdit = !!library;
+  const { toast } = useToast();
+  const { createLibrary, updateLibrary } = useLibraries();
+
+  const [name, setName] = useState('');
+  const [color, setColor] = useState<LibraryColor>('amber');
+  const [isSaving, setIsSaving] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      setName(library?.name ?? '');
+      setColor((library?.color as LibraryColor) ?? 'amber');
+    }
+  }, [open, library]);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const trimmed = name.trim();
+    if (!trimmed) return;
+
+    setIsSaving(true);
+    try {
+      const result = isEdit
+        ? await updateLibrary(library!.id, { name: trimmed, color })
+        : await createLibrary({ name: trimmed, color });
+      toast({ title: isEdit ? 'Library updated' : 'Library created' });
+      onOpenChange(false);
+      onSuccess?.(result);
+    } catch {
+      toast({
+        title: isEdit ? 'Failed to update library' : 'Failed to create library',
+        variant: 'destructive',
+      });
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>{isEdit ? 'Edit library' : 'New library'}</DialogTitle>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="library-name">Name</Label>
+            <Input
+              id="library-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Library name"
+              required
+              autoFocus
+              maxLength={255}
+            />
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label>Color</Label>
+            <div className="flex gap-2">
+              {LIBRARY_COLORS.map((c) => {
+                const grad = libraryGradient(c);
+                const selected = color === c;
+                return (
+                  <button
+                    key={c}
+                    type="button"
+                    onClick={() => setColor(c)}
+                    aria-label={c}
+                    aria-pressed={selected}
+                    className={cn(
+                      'h-8 w-8 rounded-lg ring-offset-2 ring-offset-background transition',
+                      selected ? 'ring-2 ring-ring' : 'hover:scale-105',
+                    )}
+                    style={{ background: grad.background }}
+                  />
+                );
+              })}
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={isSaving}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isSaving || !name.trim()}>
+              {isSaving ? 'Saving...' : isEdit ? 'Save changes' : 'Create library'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/frontend/src/components/models/CollectionsList.tsx
+++ b/apps/frontend/src/components/models/CollectionsList.tsx
@@ -1,12 +1,14 @@
 import { Link } from 'react-router-dom';
 import { FolderOpen } from 'lucide-react';
 import type { CollectionSummary } from '@alexandria/shared';
+import { useLibraryPath } from '../../hooks/use-libraries';
 
 interface CollectionsListProps {
   collections: CollectionSummary[];
 }
 
 export function CollectionsList({ collections }: CollectionsListProps) {
+  const libPath = useLibraryPath();
   return (
     <div className="rounded-xl border border-border bg-card overflow-hidden">
       <div className="flex items-center justify-between px-4 py-3 border-b border-border bg-muted/30">
@@ -22,7 +24,7 @@ export function CollectionsList({ collections }: CollectionsListProps) {
             {collections.map((col) => (
               <li key={col.id}>
                 <Link
-                  to={`/collections/${col.id}`}
+                  to={libPath(`/collections/${col.id}`)}
                   className="flex items-center gap-2 text-sm text-foreground hover:text-primary transition-colors py-0.5 group"
                 >
                   <FolderOpen className="h-4 w-4 text-muted-foreground flex-shrink-0 group-hover:text-primary transition-colors" />

--- a/apps/frontend/src/components/models/ModelBreadcrumb.tsx
+++ b/apps/frontend/src/components/models/ModelBreadcrumb.tsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom';
 import type { CollectionSummary } from '@alexandria/shared';
 import { LibraryIcon, CollectionsIcon, ChevronRightIcon } from '../icons';
+import { useLibraryPath } from '../../hooks/use-libraries';
 
 interface ModelBreadcrumbProps {
   /** The model's primary collection (collections[0]), or null if it has none. */
@@ -18,17 +19,18 @@ interface ModelBreadcrumbProps {
  * intermediate crumbs are real navigation links.
  */
 export function ModelBreadcrumb({ collection, modelName }: ModelBreadcrumbProps) {
+  const libPath = useLibraryPath();
   const crumbs: Array<{
     label: string;
     to?: string;
     icon?: React.ReactNode;
   }> = [
-    { label: 'Library', to: '/', icon: <LibraryIcon className="h-3.5 w-3.5" /> },
+    { label: 'Library', to: libPath('/'), icon: <LibraryIcon className="h-3.5 w-3.5" /> },
     ...(collection
       ? [
           {
             label: collection.name,
-            to: `/collections/${collection.id}`,
+            to: libPath(`/collections/${collection.id}`),
             icon: <CollectionsIcon className="h-3.5 w-3.5" />,
           },
         ]

--- a/apps/frontend/src/components/models/ModelCard.tsx
+++ b/apps/frontend/src/components/models/ModelCard.tsx
@@ -5,6 +5,7 @@ import { Badge } from '../ui/badge';
 import { formatFileSize } from '../../lib/format';
 import { cn } from '../../lib/utils';
 import { useDisplayPreferences } from '../../hooks/use-display-preferences';
+import { useLibraryPath } from '../../hooks/use-libraries';
 
 interface ModelCardProps {
   model: ModelCardType;
@@ -40,6 +41,7 @@ function StatusIndicator({ status }: { status: ModelCardType['status'] }) {
 
 export function ModelCard({ model, selectable, selected, onToggleSelect }: ModelCardProps) {
   const navigate = useNavigate();
+  const libPath = useLibraryPath();
   const { cardAspectRatio } = useDisplayPreferences();
 
   const tags = model.metadata
@@ -55,7 +57,7 @@ export function ModelCard({ model, selectable, selected, onToggleSelect }: Model
       onToggleSelect?.(model.id);
       return;
     }
-    navigate(`/models/${model.id}`);
+    navigate(libPath(`/models/${model.id}`));
   }
 
   return (

--- a/apps/frontend/src/components/models/ModelList.tsx
+++ b/apps/frontend/src/components/models/ModelList.tsx
@@ -3,6 +3,7 @@ import { Package, CheckCircle2, AlertCircle, Loader2 } from 'lucide-react';
 import type { ModelCard } from '@alexandria/shared';
 import { formatFileSize } from '../../lib/format';
 import { cn } from '../../lib/utils';
+import { useLibraryPath } from '../../hooks/use-libraries';
 
 interface ModelRowProps {
   model: ModelCard;
@@ -14,6 +15,7 @@ interface ModelRowProps {
 
 function ModelRow({ model, selectable, selected, onToggleSelect, showThumbnails = true }: ModelRowProps) {
   const navigate = useNavigate();
+  const libPath = useLibraryPath();
 
   const artist = model.metadata.find((m) => m.fieldSlug === 'artist');
   const artistName = artist
@@ -36,7 +38,7 @@ function ModelRow({ model, selectable, selected, onToggleSelect, showThumbnails 
       onToggleSelect?.(model.id);
       return;
     }
-    navigate(`/models/${model.id}`);
+    navigate(libPath(`/models/${model.id}`));
   }
 
   return (

--- a/apps/frontend/src/components/pivot/AxisFacetBody.tsx
+++ b/apps/frontend/src/components/pivot/AxisFacetBody.tsx
@@ -5,6 +5,7 @@ import { getCollections } from '../../api/collections';
 import { getFieldValues } from '../../api/metadata';
 import { getSmartCollections } from '../../api/smart-collections';
 import { useModelFilters } from '../../hooks/use-model-filters';
+import { useLibraryPath } from '../../hooks/use-libraries';
 import type { PivotAxis } from '../../hooks/use-model-filters';
 import { CollectionTree } from '../collections/CollectionTree';
 import { ArtistIcon, TagIcon, SmartIcon } from '../icons';
@@ -126,6 +127,7 @@ function TagsAxis() {
 
 function SmartAxis() {
   const { smartCollectionId, setSmartCollectionId } = useModelFilters();
+  const libPath = useLibraryPath();
 
   const { data, isLoading } = useQuery({
     queryKey: ['smart-collections'],
@@ -135,7 +137,7 @@ function SmartAxis() {
   return (
     <div className="flex flex-col gap-px px-1">
       <Link
-        to="/smart-collections/new"
+        to={libPath('/smart-collections/new')}
         className="flex items-center gap-1.5 mx-1 my-1 rounded-md px-2 py-1.5 text-xs font-medium transition-colors hover:bg-[var(--ax-rail-hover)]"
         style={{ color: 'var(--ax-rail-fg)' }}
       >

--- a/apps/frontend/src/components/pivot/PivotMain.tsx
+++ b/apps/frontend/src/components/pivot/PivotMain.tsx
@@ -3,6 +3,7 @@ import { Link, useNavigate } from 'react-router-dom';
 import { Loader2, Pencil } from 'lucide-react';
 import { useQuery } from '@tanstack/react-query';
 import { useModelFilters } from '../../hooks/use-model-filters';
+import { useLibraryPath } from '../../hooks/use-libraries';
 import { useModelResults } from '../../hooks/use-model-results';
 import { getSmartCollections, getSmartCollectionModels } from '../../api/smart-collections';
 import { useDisplayPreferences } from '../../hooks/use-display-preferences';
@@ -70,6 +71,7 @@ function deriveContextTitle(
  */
 export function PivotMain() {
   const navigate = useNavigate();
+  const libPath = useLibraryPath();
   const { filters, toApiParams, setQ, axis, activeAxisValue, hasActiveFilters, smartCollectionId } =
     useModelFilters();
   const { view, showThumbnails } = useDisplayPreferences();
@@ -147,7 +149,7 @@ export function PivotMain() {
             onSubmit={(e) => {
               e.preventDefault();
               const val = filters.q.trim();
-              if (val) navigate(`/search?q=${encodeURIComponent(val)}`);
+              if (val) navigate(libPath(`/search?q=${encodeURIComponent(val)}`));
             }}
           >
             <label className="relative flex items-center">
@@ -176,7 +178,7 @@ export function PivotMain() {
 
           {/* Upload action */}
           <Link
-            to="/upload"
+            to={libPath('/upload')}
             className="flex items-center gap-1.5 rounded-lg px-3 h-8 text-sm font-medium transition-colors"
             style={{
               background: 'var(--ax-amber)',
@@ -234,7 +236,7 @@ export function PivotMain() {
         <div className="flex items-center gap-2 flex-shrink-0">
           {smartActive && (
             <Link
-              to={`/smart-collections/${smartCollectionId}/edit`}
+              to={libPath(`/smart-collections/${smartCollectionId}/edit`)}
               className="flex items-center gap-1.5 h-8 rounded-lg px-3 text-sm font-medium transition-colors"
               style={{ background: 'var(--ax-bg-elev)', border: '1px solid var(--ax-border)', color: 'var(--ax-fg)', textDecoration: 'none' }}
             >
@@ -373,7 +375,7 @@ export function PivotMain() {
               Select a smart collection from the rail, or
             </p>
             <Link
-              to="/smart-collections/new"
+              to={libPath('/smart-collections/new')}
               className="rounded-lg px-3 h-8 flex items-center text-sm font-medium"
               style={{ background: 'var(--ax-amber)', color: 'var(--ax-amber-fg, white)', textDecoration: 'none' }}
             >

--- a/apps/frontend/src/components/pivot/PivotRail.test.tsx
+++ b/apps/frontend/src/components/pivot/PivotRail.test.tsx
@@ -35,6 +35,23 @@ vi.mock('../../hooks/use-auth', () => ({
   useAuth: vi.fn(),
 }));
 
+// Mock the libraries hook so the switcher renders without a LibraryProvider
+vi.mock('../../hooks/use-libraries', () => ({
+  useLibraries: () => ({
+    libraries: [
+      { id: 'lib-1', name: 'Main', slug: 'main', color: 'amber', isDefault: true, modelCount: 3, collectionCount: 1, userId: 'user-1', createdAt: '', updatedAt: '' },
+    ],
+    isLoading: false,
+    currentLibraryId: 'lib-1',
+    currentLibrary: { id: 'lib-1', name: 'Main', slug: 'main', color: 'amber', isDefault: true, modelCount: 3, collectionCount: 1, userId: 'user-1', createdAt: '', updatedAt: '' },
+    createLibrary: vi.fn(),
+    updateLibrary: vi.fn(),
+    setDefaultLibrary: vi.fn(),
+    deleteLibrary: vi.fn(),
+  }),
+  useLibraryPath: () => (path: string) => path,
+}));
+
 // Mock useNavigate (used by UserMenu)
 const mockNavigate = vi.fn();
 vi.mock('react-router-dom', async (importOriginal) => {
@@ -136,13 +153,13 @@ describe('PivotRail', () => {
     expect(screen.getByText('JR')).toBeTruthy();
   });
 
-  it('the library-switcher stub is disabled (aria-disabled + tabIndex=-1)', async () => {
+  it('renders the interactive library switcher with the current library name', async () => {
     render(<PivotRail />, { wrapper: makeWrapper() });
 
-    // The stub button has aria-disabled="true" and tabIndex -1
-    const stubBtn = screen.getByTitle(/library switching coming soon/i);
-    expect(stubBtn.getAttribute('aria-disabled')).toBe('true');
-    expect(stubBtn.getAttribute('tabindex')).toBe('-1');
+    // The switcher is now an enabled control showing the active library name.
+    const switcherBtn = screen.getByTitle(/switch library/i);
+    expect(switcherBtn.getAttribute('aria-disabled')).toBeNull();
+    expect(screen.getByText('Main')).toBeTruthy();
   });
 
   it('reflects axis=tags from the URL in the axis picker', async () => {

--- a/apps/frontend/src/components/pivot/PivotRail.tsx
+++ b/apps/frontend/src/components/pivot/PivotRail.tsx
@@ -1,5 +1,17 @@
-import { BookOpen, ChevronDown } from 'lucide-react';
+import { useState } from 'react';
+import { BookOpen, ChevronDown, Check, Plus, LayoutGrid } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
 import { useModelFilters } from '../../hooks/use-model-filters';
+import { useLibraries } from '../../hooks/use-libraries';
+import { libraryGradient, libraryInitials } from '../../lib/library-color';
+import { LibraryDialog } from '../libraries/LibraryDialog';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '../ui/dropdown-menu';
 import { AxisPicker } from './AxisPicker';
 import { AxisFacetBody } from './AxisFacetBody';
 import { UserMenu } from './UserMenu';
@@ -8,13 +20,18 @@ import { UserMenu } from './UserMenu';
  * Full dark pivot rail. Replaces Sidebar in the pivot workspace (wired in F19).
  *
  * Structure (top → bottom):
- *   1. Library header — static name + DISABLED library-switcher stub (multi-library is P5)
+ *   1. Library header — brand + interactive library switcher (P5 multi-library)
  *   2. AxisPicker — 2-col grid letting the user pick Collections / Artists / Tags
  *   3. AxisFacetBody — scrollable list for the active axis (flex-1)
  *   4. UserMenu — pinned footer with avatar, identity, theme toggle, Settings, Log out
  */
 export function PivotRail() {
   const { axis } = useModelFilters();
+  const navigate = useNavigate();
+  const { libraries, currentLibrary } = useLibraries();
+  const [createOpen, setCreateOpen] = useState(false);
+
+  const grad = libraryGradient(currentLibrary?.color ?? 'amber');
 
   return (
     <aside
@@ -43,56 +60,83 @@ export function PivotRail() {
           </span>
         </div>
 
-        {/*
-         * Library switcher — DISABLED stub for P5 multi-library support.
-         * The button is intentionally non-interactive; aria-disabled communicates
-         * this to assistive technology.
-         */}
-        <button
-          type="button"
-          aria-disabled="true"
-          title="Library switching coming soon"
-          className="flex items-center gap-2.5 w-full rounded-lg px-2.5 py-2 text-left cursor-not-allowed opacity-80"
-          style={{
-            background: 'var(--ax-rail-elev)',
-            border: '1px solid var(--ax-rail-border)',
-            color: 'inherit',
-            fontFamily: 'inherit',
-          }}
-          tabIndex={-1}
-        >
-          {/* Library color badge */}
-          <div
-            className="flex-shrink-0 flex items-center justify-center rounded-lg font-bold"
-            style={{
-              width: 28,
-              height: 28,
-              background: 'linear-gradient(135deg, var(--ax-amber) 0%, var(--ax-amber-deep) 100%)',
-              color: 'var(--ax-amber-fg)',
-              fontSize: '11px',
-            }}
-          >
-            L
-          </div>
-          <div className="flex-1 min-w-0">
-            <div
-              className="font-semibold truncate"
-              style={{ fontSize: '13px', color: 'var(--ax-rail-fg)' }}
+        {/* Library switcher */}
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button
+              type="button"
+              title="Switch library"
+              className="flex items-center gap-2.5 w-full rounded-lg px-2.5 py-2 text-left transition hover:brightness-110"
+              style={{
+                background: 'var(--ax-rail-elev)',
+                border: '1px solid var(--ax-rail-border)',
+                color: 'inherit',
+                fontFamily: 'inherit',
+              }}
             >
-              Library
-            </div>
-            <div
-              className="ax-mono truncate"
-              style={{ fontSize: '11.5px', color: 'var(--ax-rail-fg-muted)' }}
-            >
-              active
-            </div>
-          </div>
-          <ChevronDown
-            className="flex-shrink-0 h-3 w-3"
-            style={{ color: 'var(--ax-rail-fg-muted)' }}
-          />
-        </button>
+              {/* Library color badge */}
+              <div
+                className="flex-shrink-0 flex items-center justify-center rounded-lg font-bold"
+                style={{
+                  width: 28,
+                  height: 28,
+                  background: grad.background,
+                  color: grad.color,
+                  fontSize: '11px',
+                }}
+              >
+                {currentLibrary ? libraryInitials(currentLibrary.name) : 'L'}
+              </div>
+              <div className="flex-1 min-w-0">
+                <div
+                  className="font-semibold truncate"
+                  style={{ fontSize: '13px', color: 'var(--ax-rail-fg)' }}
+                >
+                  {currentLibrary?.name ?? 'Library'}
+                </div>
+                <div
+                  className="ax-mono truncate"
+                  style={{ fontSize: '11.5px', color: 'var(--ax-rail-fg-muted)' }}
+                >
+                  {currentLibrary
+                    ? `${currentLibrary.modelCount} ${currentLibrary.modelCount === 1 ? 'model' : 'models'}`
+                    : 'active'}
+                </div>
+              </div>
+              <ChevronDown
+                className="flex-shrink-0 h-3 w-3"
+                style={{ color: 'var(--ax-rail-fg-muted)' }}
+              />
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="start" className="w-60">
+            {libraries.map((lib) => {
+              const g = libraryGradient(lib.color);
+              const active = lib.id === currentLibrary?.id;
+              return (
+                <DropdownMenuItem key={lib.id} onClick={() => navigate(`/lib/${lib.id}`)}>
+                  <div
+                    className="mr-2 flex-shrink-0 flex items-center justify-center rounded font-bold"
+                    style={{ width: 20, height: 20, background: g.background, color: g.color, fontSize: '9px' }}
+                  >
+                    {libraryInitials(lib.name)}
+                  </div>
+                  <span className="flex-1 truncate">{lib.name}</span>
+                  {active && <Check className="ml-2 h-4 w-4 flex-shrink-0" />}
+                </DropdownMenuItem>
+              );
+            })}
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onClick={() => navigate('/')}>
+              <LayoutGrid className="mr-2 h-4 w-4" />
+              All libraries
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={() => setCreateOpen(true)}>
+              <Plus className="mr-2 h-4 w-4" />
+              New library…
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
       </div>
 
       {/* ── Axis picker ─────────────────────────────────────── */}
@@ -105,6 +149,12 @@ export function PivotRail() {
 
       {/* ── User menu (pinned footer) ────────────────────────── */}
       <UserMenu />
+
+      <LibraryDialog
+        open={createOpen}
+        onOpenChange={setCreateOpen}
+        onSuccess={(lib) => navigate(`/lib/${lib.id}`)}
+      />
     </aside>
   );
 }

--- a/apps/frontend/src/components/pivot/UserMenu.tsx
+++ b/apps/frontend/src/components/pivot/UserMenu.tsx
@@ -1,6 +1,7 @@
 import { LogOut, MoreHorizontal, User } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../../hooks/use-auth';
+import { useLibraryPath } from '../../hooks/use-libraries';
 import { Avatar, AvatarFallback } from '../ui/avatar';
 import {
   DropdownMenu,
@@ -29,6 +30,7 @@ function getInitials(displayName: string): string {
 export function UserMenu() {
   const { user, logout } = useAuth();
   const navigate = useNavigate();
+  const libPath = useLibraryPath();
 
   return (
     <div
@@ -92,7 +94,7 @@ export function UserMenu() {
                 </div>
               </DropdownMenuLabel>
               <DropdownMenuSeparator />
-              <DropdownMenuItem onClick={() => navigate('/settings')}>
+              <DropdownMenuItem onClick={() => navigate(libPath('/settings'))}>
                 <User className="mr-2 h-4 w-4" />
                 Settings
               </DropdownMenuItem>

--- a/apps/frontend/src/components/search/ArtistResultCard.tsx
+++ b/apps/frontend/src/components/search/ArtistResultCard.tsx
@@ -1,5 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 import type { SearchArtistHit } from '@alexandria/shared';
+import { useLibraryPath } from '../../hooks/use-libraries';
 
 // A deterministic palette per artist name for the gradient avatar
 const GRADIENTS: [string, string][] = [
@@ -35,10 +36,11 @@ interface ArtistResultCardProps {
 
 export function ArtistResultCard({ artist }: ArtistResultCardProps) {
   const navigate = useNavigate();
+  const libPath = useLibraryPath();
   const [from, to] = getGradient(artist.name);
 
   function handleClick() {
-    navigate(`/?meta_artist=${encodeURIComponent(artist.name)}`);
+    navigate(`${libPath('/')}?meta_artist=${encodeURIComponent(artist.name)}`);
   }
 
   return (

--- a/apps/frontend/src/components/search/CollectionResultRow.tsx
+++ b/apps/frontend/src/components/search/CollectionResultRow.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from 'react-router-dom';
 import { Folder, ArrowRight } from 'lucide-react';
 import type { SearchCollectionHit } from '@alexandria/shared';
+import { useLibraryPath } from '../../hooks/use-libraries';
 
 interface CollectionResultRowProps {
   collection: SearchCollectionHit;
@@ -8,16 +9,17 @@ interface CollectionResultRowProps {
 
 export function CollectionResultRow({ collection }: CollectionResultRowProps) {
   const navigate = useNavigate();
+  const libPath = useLibraryPath();
 
   return (
     <div
       role="button"
       tabIndex={0}
-      onClick={() => navigate(`/collections/${collection.id}`)}
+      onClick={() => navigate(libPath(`/collections/${collection.id}`))}
       onKeyDown={(e) => {
         if (e.key === 'Enter' || e.key === ' ') {
           e.preventDefault();
-          navigate(`/collections/${collection.id}`);
+          navigate(libPath(`/collections/${collection.id}`));
         }
       }}
       style={{

--- a/apps/frontend/src/components/search/TagResultPill.tsx
+++ b/apps/frontend/src/components/search/TagResultPill.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from 'react-router-dom';
 import { Hash } from 'lucide-react';
 import type { SearchTagHit } from '@alexandria/shared';
+import { useLibraryPath } from '../../hooks/use-libraries';
 
 interface TagResultPillProps {
   tag: SearchTagHit;
@@ -8,9 +9,10 @@ interface TagResultPillProps {
 
 export function TagResultPill({ tag }: TagResultPillProps) {
   const navigate = useNavigate();
+  const libPath = useLibraryPath();
 
   function handleClick() {
-    navigate(`/?tags=${encodeURIComponent(tag.name)}`);
+    navigate(`${libPath('/')}?tags=${encodeURIComponent(tag.name)}`);
   }
 
   return (

--- a/apps/frontend/src/components/upload/FolderImport.tsx
+++ b/apps/frontend/src/components/upload/FolderImport.tsx
@@ -5,6 +5,7 @@ import { FolderOpen, ArrowRight, AlertCircle, Loader2 } from 'lucide-react';
 import { getFields } from '../../api/metadata';
 import { importFolder } from '../../api/models';
 import type { ImportStrategy } from '@alexandria/shared';
+import { useLibraryPath } from '../../hooks/use-libraries';
 import { Button } from '../ui/button';
 import { Input } from '../ui/input';
 import { Label } from '../ui/label';
@@ -45,6 +46,7 @@ type ImportState =
   | { phase: 'error'; message: string };
 
 export function FolderImport() {
+  const libPath = useLibraryPath();
   const [sourcePath, setSourcePath] = useState('');
   const [segments, setSegments] = useState<Segment[]>(createDefaultSegments);
   const [strategy, setStrategy] = useState<ImportStrategy>('hardlink');
@@ -180,7 +182,7 @@ export function FolderImport() {
           </p>
           <div className="flex gap-3">
             <Link
-              to={`/models/${importState.modelId}`}
+              to={libPath(`/models/${importState.modelId}`)}
               className="inline-flex items-center gap-1 text-sm text-primary hover:underline"
             >
               Track progress <ArrowRight className="h-3.5 w-3.5" />

--- a/apps/frontend/src/components/upload/RecentUploads.tsx
+++ b/apps/frontend/src/components/upload/RecentUploads.tsx
@@ -4,6 +4,7 @@ import { Loader2, AlertCircle, Package, CheckCircle2, ArrowRight } from 'lucide-
 import { getModels } from '../../api/models';
 import { formatDate, formatFileSize } from '../../lib/format';
 import type { ModelCard } from '@alexandria/shared';
+import { useLibraryPath } from '../../hooks/use-libraries';
 
 function StatusBadge({ status }: { status: ModelCard['status'] }) {
   if (status === 'processing') {
@@ -31,6 +32,7 @@ function StatusBadge({ status }: { status: ModelCard['status'] }) {
 }
 
 export function RecentUploads() {
+  const libPath = useLibraryPath();
   const { data, isLoading } = useQuery({
     queryKey: ['recent-uploads'],
     queryFn: () =>
@@ -67,7 +69,7 @@ export function RecentUploads() {
         return (
           <li key={model.id}>
             <Link
-              to={`/models/${model.id}`}
+              to={libPath(`/models/${model.id}`)}
               className="flex items-center gap-3 px-4 py-3 hover:bg-muted/40 transition-colors"
             >
               {/* Thumbnail or placeholder */}

--- a/apps/frontend/src/components/upload/UploadProgress.tsx
+++ b/apps/frontend/src/components/upload/UploadProgress.tsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom';
 import { Loader2, CheckCircle2, AlertCircle, ArrowRight } from 'lucide-react';
 import { getModelStatus } from '../../api/models';
 import type { JobStatus } from '@alexandria/shared';
+import { useLibraryPath } from '../../hooks/use-libraries';
 
 interface UploadProgressProps {
   modelId: string;
@@ -20,6 +21,7 @@ function statusLabel(status: JobStatus['status'], progress: number | null): stri
 }
 
 export function UploadProgress({ modelId }: UploadProgressProps) {
+  const libPath = useLibraryPath();
   const { data: status, error } = useQuery({
     queryKey: ['model-status', modelId],
     queryFn: () => getModelStatus(modelId),
@@ -63,7 +65,7 @@ export function UploadProgress({ modelId }: UploadProgressProps) {
           <span>{status.error ?? 'Processing failed with an unknown error.'}</span>
         </div>
         <Link
-          to={`/models/${modelId}`}
+          to={libPath(`/models/${modelId}`)}
           className="text-sm text-primary hover:underline inline-flex items-center gap-1"
         >
           View model anyway <ArrowRight className="h-3 w-3" />
@@ -80,7 +82,7 @@ export function UploadProgress({ modelId }: UploadProgressProps) {
           <span>Model is ready.</span>
         </div>
         <Link
-          to={`/models/${modelId}`}
+          to={libPath(`/models/${modelId}`)}
           className="inline-flex items-center gap-1 rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
         >
           View model <ArrowRight className="h-3.5 w-3.5" />

--- a/apps/frontend/src/hooks/use-libraries.tsx
+++ b/apps/frontend/src/hooks/use-libraries.tsx
@@ -1,0 +1,134 @@
+import React, { createContext, useContext, useEffect, useRef } from 'react';
+import { useMatch, useNavigate } from 'react-router-dom';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import type {
+  LibrarySummary,
+  CreateLibraryRequest,
+  UpdateLibraryRequest,
+} from '@alexandria/shared';
+import * as librariesApi from '../api/libraries';
+import { setActiveLibraryId } from '../api/client';
+import { useAuth } from './use-auth';
+
+interface LibrariesContextValue {
+  libraries: LibrarySummary[];
+  isLoading: boolean;
+  /** The library id from the `/lib/:id` route (null on the home/login routes). */
+  currentLibraryId: string | null;
+  /** The resolved library object, once the list has loaded. */
+  currentLibrary: LibrarySummary | null;
+  createLibrary: (data: CreateLibraryRequest) => Promise<LibrarySummary>;
+  updateLibrary: (id: string, data: UpdateLibraryRequest) => Promise<LibrarySummary>;
+  setDefaultLibrary: (id: string) => Promise<void>;
+  deleteLibrary: (id: string) => Promise<void>;
+}
+
+const LibrariesContext = createContext<LibrariesContextValue | null>(null);
+
+export function LibraryProvider({ children }: { children: React.ReactNode }) {
+  const { isAuthenticated } = useAuth();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  // The `/lib/:libraryId` segment is the single source of truth for the active
+  // library, at any depth (`/lib/:id`, `/lib/:id/models/:mid`, …).
+  const match = useMatch('/lib/:libraryId/*');
+  const currentLibraryId = match?.params.libraryId ?? null;
+
+  // Mirror the route into the API client BEFORE children render so their data
+  // fetches carry the X-Library-Id header on the very first request. Children's
+  // effects run before a parent effect, so this must happen during render — not
+  // in a useEffect — to avoid the first query racing ahead without the header.
+  setActiveLibraryId(currentLibraryId);
+
+  const { data: libraries = [], isLoading } = useQuery({
+    queryKey: ['libraries'],
+    queryFn: () => librariesApi.listLibraries().then((r) => r.data),
+    enabled: isAuthenticated,
+  });
+
+  const currentLibrary = libraries.find((l) => l.id === currentLibraryId) ?? null;
+
+  // Library-scoped query keys (models, collections, search, …) do NOT include the
+  // library id — scoping rides on the X-Library-Id header instead. So when the
+  // active library changes we must drop their cached entries, otherwise the
+  // still-mounted workspace would show the previous library's data until refetch.
+  // The 'libraries' query itself is preserved (it's user-scoped, not per-library).
+  const prevLibraryId = useRef(currentLibraryId);
+  useEffect(() => {
+    if (prevLibraryId.current !== currentLibraryId) {
+      prevLibraryId.current = currentLibraryId;
+      queryClient.removeQueries({ predicate: (q) => q.queryKey[0] !== 'libraries' });
+    }
+  }, [currentLibraryId, queryClient]);
+
+  // A `/lib/:id` deep link to an unknown or un-owned library bounces home once
+  // the list has loaded (the backend would 404 every scoped request anyway).
+  useEffect(() => {
+    if (!isLoading && currentLibraryId && !currentLibrary) {
+      navigate('/', { replace: true });
+    }
+  }, [isLoading, currentLibraryId, currentLibrary, navigate]);
+
+  const invalidate = () => queryClient.invalidateQueries({ queryKey: ['libraries'] });
+
+  const createMutation = useMutation({
+    mutationFn: (data: CreateLibraryRequest) => librariesApi.createLibrary(data),
+    onSuccess: invalidate,
+  });
+  const updateMutation = useMutation({
+    mutationFn: ({ id, data }: { id: string; data: UpdateLibraryRequest }) =>
+      librariesApi.updateLibrary(id, data),
+    onSuccess: invalidate,
+  });
+  const setDefaultMutation = useMutation({
+    mutationFn: (id: string) => librariesApi.setDefaultLibrary(id),
+    onSuccess: invalidate,
+  });
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => librariesApi.deleteLibrary(id),
+    onSuccess: invalidate,
+  });
+
+  return (
+    <LibrariesContext.Provider
+      value={{
+        libraries,
+        isLoading,
+        currentLibraryId,
+        currentLibrary,
+        createLibrary: (data) => createMutation.mutateAsync(data),
+        updateLibrary: (id, data) => updateMutation.mutateAsync({ id, data }),
+        setDefaultLibrary: (id) => setDefaultMutation.mutateAsync(id),
+        deleteLibrary: (id) => deleteMutation.mutateAsync(id),
+      }}
+    >
+      {children}
+    </LibrariesContext.Provider>
+  );
+}
+
+export function useLibraries(): LibrariesContextValue {
+  const context = useContext(LibrariesContext);
+  if (!context) {
+    throw new Error('useLibraries must be used within a LibraryProvider');
+  }
+  return context;
+}
+
+/**
+ * Returns a `libPath` function that prefixes an app path with the active
+ * `/lib/:id` segment, so internal links stay scoped to the current library.
+ * Falls back to the bare path when no library is active (the home page) or when
+ * used outside a LibraryProvider (e.g. isolated component tests) — it reads the
+ * context directly rather than through useLibraries so it never throws.
+ */
+export function useLibraryPath(): (path: string) => string {
+  const ctx = useContext(LibrariesContext);
+  const currentLibraryId = ctx?.currentLibraryId ?? null;
+  return (path: string) => {
+    if (!currentLibraryId) return path;
+    const suffix = path === '/' ? '' : path;
+    return `/lib/${currentLibraryId}${suffix}`;
+  };
+}

--- a/apps/frontend/src/lib/library-color.ts
+++ b/apps/frontend/src/lib/library-color.ts
@@ -1,0 +1,35 @@
+import { LIBRARY_COLORS, type LibraryColor } from '@alexandria/shared';
+
+export { LIBRARY_COLORS };
+export type { LibraryColor };
+
+/**
+ * CSS gradient + on-color text for each library accent. amber/teal reuse the ax
+ * design tokens; sage/plum/slate are given explicit stops (no ax accent vars
+ * exist for them). Rendered as the square badge on the cards and rail switcher.
+ */
+const GRADIENTS: Record<string, { background: string; color: string }> = {
+  amber: {
+    background: 'linear-gradient(135deg, var(--ax-amber) 0%, var(--ax-amber-deep) 100%)',
+    color: 'var(--ax-amber-fg)',
+  },
+  teal: {
+    background: 'linear-gradient(135deg, var(--ax-teal) 0%, var(--ax-teal-deep) 100%)',
+    color: 'var(--ax-teal-fg)',
+  },
+  sage: { background: 'linear-gradient(135deg, #6f9e7b 0%, #4a7d57 100%)', color: '#fff' },
+  plum: { background: 'linear-gradient(135deg, #9d6ba0 0%, #6f4a7d 100%)', color: '#fff' },
+  slate: { background: 'linear-gradient(135deg, #6b7a9e 0%, #45527a 100%)', color: '#fff' },
+};
+
+export function libraryGradient(color: string): { background: string; color: string } {
+  return GRADIENTS[color] ?? GRADIENTS.amber;
+}
+
+/** Two-letter monogram from a library name for the badge. */
+export function libraryInitials(name: string): string {
+  const words = name.trim().split(/\s+/).filter(Boolean);
+  if (words.length === 0) return 'L';
+  if (words.length === 1) return words[0].slice(0, 2).toUpperCase();
+  return (words[0][0] + words[1][0]).toUpperCase();
+}

--- a/apps/frontend/src/pages/AllLibrariesPage.tsx
+++ b/apps/frontend/src/pages/AllLibrariesPage.tsx
@@ -1,0 +1,204 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { BookOpen, Plus, MoreVertical, Pencil, Star, Trash2 } from 'lucide-react';
+import type { LibrarySummary } from '@alexandria/shared';
+import { useLibraries } from '../hooks/use-libraries';
+import { useToast } from '../hooks/use-toast';
+import { libraryGradient, libraryInitials } from '../lib/library-color';
+import { LibraryDialog } from '../components/libraries/LibraryDialog';
+import { AlertDialog } from '../components/ui/alert-dialog';
+import { Button } from '../components/ui/button';
+import { Skeleton } from '../components/ui/skeleton';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '../components/ui/dropdown-menu';
+
+export function AllLibrariesPage() {
+  const navigate = useNavigate();
+  const { toast } = useToast();
+  const { libraries, isLoading, setDefaultLibrary, deleteLibrary } = useLibraries();
+
+  const [createOpen, setCreateOpen] = useState(false);
+  const [editTarget, setEditTarget] = useState<LibrarySummary | undefined>(undefined);
+  const [deleteTarget, setDeleteTarget] = useState<LibrarySummary | undefined>(undefined);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  async function handleSetDefault(lib: LibrarySummary) {
+    try {
+      await setDefaultLibrary(lib.id);
+      toast({ title: `"${lib.name}" is now your default library` });
+    } catch {
+      toast({ title: 'Failed to set default library', variant: 'destructive' });
+    }
+  }
+
+  async function handleDelete() {
+    if (!deleteTarget) return;
+    setIsDeleting(true);
+    try {
+      await deleteLibrary(deleteTarget.id);
+      toast({ title: 'Library deleted' });
+      setDeleteTarget(undefined);
+    } catch {
+      toast({ title: 'Failed to delete library', variant: 'destructive' });
+    } finally {
+      setIsDeleting(false);
+    }
+  }
+
+  /** Why a library cannot be deleted, or null if it can. */
+  function deleteBlockedReason(lib: LibrarySummary): string | null {
+    if (lib.isDefault) return 'Default library — set another as default first';
+    if (libraries.length <= 1) return 'You must keep at least one library';
+    if (lib.modelCount > 0 || lib.collectionCount > 0)
+      return 'Library still contains models or collections';
+    return null;
+  }
+
+  return (
+    <div className="ax-app min-h-screen" style={{ background: 'var(--ax-bg)', color: 'var(--ax-fg)' }}>
+      <div className="mx-auto max-w-5xl px-6 py-10">
+        <header className="flex items-center gap-2.5 mb-8">
+          <BookOpen className="h-6 w-6" style={{ color: 'var(--ax-amber)' }} />
+          <h1 className="text-2xl font-semibold tracking-tight">Libraries</h1>
+        </header>
+
+        {isLoading ? (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {[0, 1, 2].map((i) => (
+              <Skeleton key={i} className="h-40 rounded-xl" />
+            ))}
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {libraries.map((lib) => {
+              const grad = libraryGradient(lib.color);
+              const blocked = deleteBlockedReason(lib);
+              return (
+                <div
+                  key={lib.id}
+                  role="button"
+                  tabIndex={0}
+                  onClick={() => navigate(`/lib/${lib.id}`)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault();
+                      navigate(`/lib/${lib.id}`);
+                    }
+                  }}
+                  className="group relative flex flex-col rounded-xl border p-4 text-left transition hover:shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-ring cursor-pointer"
+                  style={{ background: 'var(--ax-bg-elev)', borderColor: 'var(--ax-border)' }}
+                >
+                  <div className="flex items-start justify-between">
+                    <div
+                      className="flex items-center justify-center rounded-lg font-bold"
+                      style={{
+                        width: 44,
+                        height: 44,
+                        background: grad.background,
+                        color: grad.color,
+                        fontSize: '15px',
+                      }}
+                    >
+                      {libraryInitials(lib.name)}
+                    </div>
+
+                    {/* Stop menu clicks from bubbling to the card's navigate handler */}
+                    <div onClick={(e) => e.stopPropagation()}>
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-8 w-8 opacity-0 group-hover:opacity-100"
+                            aria-label={`Actions for ${lib.name}`}
+                          >
+                            <MoreVertical className="h-4 w-4" />
+                          </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end">
+                          <DropdownMenuItem onClick={() => setEditTarget(lib)}>
+                            <Pencil className="mr-2 h-4 w-4" />
+                            Rename
+                          </DropdownMenuItem>
+                          {!lib.isDefault && (
+                            <DropdownMenuItem onClick={() => handleSetDefault(lib)}>
+                              <Star className="mr-2 h-4 w-4" />
+                              Set as default
+                            </DropdownMenuItem>
+                          )}
+                          <DropdownMenuSeparator />
+                          <DropdownMenuItem
+                            disabled={!!blocked}
+                            className="text-destructive focus:text-destructive"
+                            onClick={() => {
+                              if (!blocked) setDeleteTarget(lib);
+                            }}
+                          >
+                            <Trash2 className="mr-2 h-4 w-4" />
+                            Delete
+                          </DropdownMenuItem>
+                          {blocked && (
+                            <p className="px-2 pb-1 pt-0.5 text-[11px] leading-tight text-muted-foreground">
+                              {blocked}
+                            </p>
+                          )}
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    </div>
+                  </div>
+
+                  <div className="mt-3 flex items-center gap-2">
+                    <h2 className="font-semibold truncate" style={{ fontSize: '15px' }}>
+                      {lib.name}
+                    </h2>
+                    {lib.isDefault && (
+                      <span className="ax-chip ax-chip-amber text-[10px]">Default</span>
+                    )}
+                  </div>
+                  <p className="ax-mono mt-1" style={{ fontSize: '12px', color: 'var(--ax-fg-muted)' }}>
+                    {lib.modelCount} {lib.modelCount === 1 ? 'model' : 'models'} ·{' '}
+                    {lib.collectionCount}{' '}
+                    {lib.collectionCount === 1 ? 'collection' : 'collections'}
+                  </p>
+                </div>
+              );
+            })}
+
+            {/* New library card */}
+            <button
+              type="button"
+              onClick={() => setCreateOpen(true)}
+              className="flex flex-col items-center justify-center gap-2 rounded-xl border border-dashed p-4 transition hover:bg-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-ring min-h-[136px]"
+              style={{ borderColor: 'var(--ax-border)', color: 'var(--ax-fg-muted)' }}
+            >
+              <Plus className="h-6 w-6" />
+              <span className="text-sm font-medium">New library</span>
+            </button>
+          </div>
+        )}
+      </div>
+
+      <LibraryDialog open={createOpen} onOpenChange={setCreateOpen} />
+      <LibraryDialog
+        open={!!editTarget}
+        onOpenChange={(o) => !o && setEditTarget(undefined)}
+        library={editTarget}
+      />
+      <AlertDialog
+        open={!!deleteTarget}
+        onOpenChange={(o) => !o && setDeleteTarget(undefined)}
+        title={`Delete "${deleteTarget?.name}"?`}
+        description="This permanently deletes the library. Its models and collections must be moved or removed first."
+        confirmLabel="Delete"
+        destructive
+        isLoading={isDeleting}
+        onConfirm={handleDelete}
+      />
+    </div>
+  );
+}

--- a/apps/frontend/src/pages/CollectionDetailPage.tsx
+++ b/apps/frontend/src/pages/CollectionDetailPage.tsx
@@ -5,6 +5,7 @@ import { ArrowLeft, Pencil, Trash2, FolderOpen, Loader2 } from 'lucide-react';
 import type { ModelCard } from '@alexandria/shared';
 import { getCollection, getCollectionModels, deleteCollection } from '../api/collections';
 import { useToast } from '../hooks/use-toast';
+import { useLibraryPath } from '../hooks/use-libraries';
 import { CollectionDialog } from '../components/collections/CollectionDialog';
 import { AlertDialog } from '../components/ui/alert-dialog';
 import { ModelCard as ModelCardComponent } from '../components/models/ModelCard';
@@ -15,6 +16,7 @@ import { Skeleton } from '../components/ui/skeleton';
 export function CollectionDetailPage() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
+  const libPath = useLibraryPath();
   const queryClient = useQueryClient();
   const { toast } = useToast();
 
@@ -47,7 +49,7 @@ export function CollectionDetailPage() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['collections'] });
       toast({ title: 'Collection deleted' });
-      navigate('/collections');
+      navigate(libPath('/collections'));
     },
     onError: () => {
       toast({ title: 'Failed to delete collection', variant: 'destructive' });
@@ -58,7 +60,7 @@ export function CollectionDetailPage() {
     return (
       <div className="flex flex-col items-center justify-center min-h-[300px] gap-4">
         <p className="text-destructive">Collection not found or failed to load.</p>
-        <Link to="/collections" className="text-sm text-primary hover:underline">
+        <Link to={libPath('/collections')} className="text-sm text-primary hover:underline">
           Back to Collections
         </Link>
       </div>
@@ -70,7 +72,7 @@ export function CollectionDetailPage() {
       {/* Back nav */}
       <div>
         <Link
-          to="/collections"
+          to={libPath('/collections')}
           className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
         >
           <ArrowLeft className="h-3.5 w-3.5" />
@@ -125,7 +127,7 @@ export function CollectionDetailPage() {
             {collection.children.map((child) => (
               <Link
                 key={child.id}
-                to={`/collections/${child.id}`}
+                to={libPath(`/collections/${child.id}`)}
                 className="inline-flex items-center gap-1.5 rounded-lg border bg-card px-3 py-1.5 text-sm hover:bg-accent transition-colors"
               >
                 <FolderOpen className="h-3.5 w-3.5 text-muted-foreground" />

--- a/apps/frontend/src/pages/CollectionsPage.tsx
+++ b/apps/frontend/src/pages/CollectionsPage.tsx
@@ -5,6 +5,7 @@ import { Plus, FolderOpen, Pencil, Trash2, ExternalLink } from 'lucide-react';
 import type { CollectionDetail } from '@alexandria/shared';
 import { getCollections, deleteCollection } from '../api/collections';
 import { useToast } from '../hooks/use-toast';
+import { useLibraryPath } from '../hooks/use-libraries';
 import { CollectionTree } from '../components/collections/CollectionTree';
 import { CollectionDialog } from '../components/collections/CollectionDialog';
 import { AlertDialog } from '../components/ui/alert-dialog';
@@ -13,6 +14,7 @@ import { Skeleton } from '../components/ui/skeleton';
 
 export function CollectionsPage() {
   const navigate = useNavigate();
+  const libPath = useLibraryPath();
   const queryClient = useQueryClient();
   const { toast } = useToast();
 
@@ -125,7 +127,7 @@ export function CollectionsPage() {
                 <Button
                   variant="outline"
                   size="sm"
-                  onClick={() => navigate(`/collections/${selectedCollection.id}`)}
+                  onClick={() => navigate(libPath(`/collections/${selectedCollection.id}`))}
                 >
                   <ExternalLink className="h-3.5 w-3.5 mr-1.5" />
                   Open
@@ -176,7 +178,7 @@ export function CollectionsPage() {
                 View all models in this collection on the collection detail page.
               </p>
               <Button
-                onClick={() => navigate(`/collections/${selectedCollection.id}`)}
+                onClick={() => navigate(libPath(`/collections/${selectedCollection.id}`))}
               >
                 <ExternalLink className="h-4 w-4 mr-1.5" />
                 Open Collection Detail

--- a/apps/frontend/src/pages/ModelDetailPage.tsx
+++ b/apps/frontend/src/pages/ModelDetailPage.tsx
@@ -9,9 +9,11 @@ import { ModelBreadcrumb } from '../components/models/ModelBreadcrumb';
 import { ModelViewer3DModal } from '../components/models/ModelViewer3DModal';
 import { ModelDetailSkeleton } from '../components/models/ModelDetailSkeleton';
 import { collectStlFiles, type StlFileRef } from '../lib/model-files';
+import { useLibraryPath } from '../hooks/use-libraries';
 
 export function ModelDetailPage() {
   const { id } = useParams<{ id: string }>();
+  const libPath = useLibraryPath();
 
   const {
     data: model,
@@ -51,7 +53,7 @@ export function ModelDetailPage() {
       {/* Header: back link + breadcrumb */}
       <div className="flex flex-col gap-2">
         <Link
-          to="/"
+          to={libPath('/')}
           className="inline-flex items-center gap-0.5 h-8 px-2 -ml-2 rounded-md text-sm text-muted-foreground hover:text-foreground hover:bg-accent transition-colors self-start"
         >
           <ChevronLeft className="h-4 w-4" />
@@ -77,7 +79,7 @@ export function ModelDetailPage() {
             </p>
           </div>
           <Link
-            to="/"
+            to={libPath('/')}
             className="inline-flex items-center justify-center h-9 px-4 rounded-md border border-input bg-background text-sm font-medium shadow-sm hover:bg-accent hover:text-accent-foreground transition-colors"
           >
             Go to Library

--- a/apps/frontend/src/pages/SearchPage.tsx
+++ b/apps/frontend/src/pages/SearchPage.tsx
@@ -3,6 +3,7 @@ import { useSearchParams, useNavigate } from 'react-router-dom';
 import { Search, Zap, Box, Folder, User, Hash, SortAsc } from 'lucide-react';
 import { Loader2 } from 'lucide-react';
 import { useGlobalSearch } from '../hooks/use-global-search';
+import { useLibraryPath } from '../hooks/use-libraries';
 import { ModelCard } from '../components/models/ModelCard';
 import { SearchSection } from '../components/search/SearchSection';
 import { CollectionResultRow } from '../components/search/CollectionResultRow';
@@ -100,6 +101,7 @@ function ResultPill({ count, label, icon }: { count: number; label: string; icon
 export function SearchPage() {
   const [searchParams, setSearchParams] = useSearchParams();
   const navigate = useNavigate();
+  const libPath = useLibraryPath();
   const q = searchParams.get('q') ?? '';
   const refineRef = useRef<HTMLInputElement>(null);
   const [refineValue, setRefineValue] = useState('');
@@ -200,7 +202,7 @@ export function SearchPage() {
               <button
                 type="button"
                 onClick={() =>
-                  navigate('/smart-collections/new', {
+                  navigate(libPath('/smart-collections/new'), {
                     state: {
                       name: q,
                       definition: {
@@ -393,7 +395,7 @@ export function SearchPage() {
                   {data.models.total > data.models.items.length && (
                     <button
                       type="button"
-                      onClick={() => navigate(`/?q=${encodeURIComponent(q)}`)}
+                      onClick={() => navigate(`${libPath('/')}?q=${encodeURIComponent(q)}`)}
                       style={{
                         marginTop: 12,
                         padding: '8px 12px',

--- a/apps/frontend/src/pages/SmartCollectionComposerPage.tsx
+++ b/apps/frontend/src/pages/SmartCollectionComposerPage.tsx
@@ -10,6 +10,7 @@ import { Textarea } from '../components/ui/textarea';
 import { RuleGroupEditor } from '../components/smart/RuleGroupEditor';
 import { PreviewPane } from '../components/smart/PreviewPane';
 import { useSmartCollectionDraft } from '../hooks/use-smart-collection-draft';
+import { useLibraryPath } from '../hooks/use-libraries';
 import {
   getSmartCollection,
   createSmartCollection,
@@ -30,6 +31,7 @@ export function SmartCollectionComposerPage() {
   const isEdit = Boolean(id);
   const navigate = useNavigate();
   const location = useLocation();
+  const libPath = useLibraryPath();
   const queryClient = useQueryClient();
   const { toast } = useToast();
 
@@ -68,7 +70,7 @@ export function SmartCollectionComposerPage() {
       queryClient.invalidateQueries({ queryKey: ['smart-collections'] });
       queryClient.invalidateQueries({ queryKey: ['smart-collection', data.id] });
       toast({ title: isEdit ? 'Smart collection updated' : 'Smart collection created' });
-      navigate(`/?axis=smart&smartCollectionId=${data.id}`);
+      navigate(`${libPath('/')}?axis=smart&smartCollectionId=${data.id}`);
     },
     onError: (err) => {
       toast({

--- a/docs/API.md
+++ b/docs/API.md
@@ -38,6 +38,17 @@ Requests without a valid session cookie receive a `401 Unauthorized` response.
 
 The session mechanism uses `@fastify/cookie` with signed cookies. The cookie value is the authenticated user's ID, signed with the configured session secret. Cookie attributes: `HttpOnly`, `SameSite=Lax`, `Path=/`.
 
+### Library scoping (multi-library)
+
+Every model, collection, smart collection, and import session belongs to exactly one **library**. A user owns one or more libraries (one marked default). All list/search/detail endpoints are scoped to a single **active library**, resolved server-side as follows:
+
+- If the request carries an **`X-Library-Id`** header, that library is used — but only after an ownership check. An unknown or un-owned id returns `404 NOT_FOUND` (same response whether it does not exist or belongs to another user, so ids cannot be enumerated).
+- If the header is absent, the request falls back to the user's **default library**.
+
+Clients never pass `libraryId` in a query string or body; scoping rides on the header only. The frontend mirrors its `/lib/:id` route segment into this header. Library membership itself is managed through the `Libraries` endpoints below.
+
+> Note: the per-endpoint "Library scope" notes throughout this document predate P5 and say "default library". They now mean **the active library** (the `X-Library-Id` header when present, otherwise the default).
+
 ### Upload Limits
 
 For single-request uploads (`POST /models/upload`), archive files are capped at 100 MB. For larger files, use the chunked upload protocol (`POST /models/upload/init` + chunk PUTs + `POST /models/upload/:uploadId/complete`), which supports files up to 5 GB with 10 MB chunks and per-chunk retry.
@@ -810,11 +821,103 @@ Keys are field slugs. Values may be `string`, `number`, `boolean`, `string[]` (f
 
 ---
 
+## Libraries
+
+Manage the libraries a user owns. These endpoints manage the library scope itself, so they are **not** scoped by the `X-Library-Id` header — they operate on the authenticated user's full set of libraries, identified by the URL `:id`. See [Library scoping](#library-scoping-multi-library).
+
+### GET /libraries
+
+List the authenticated user's libraries with derived model and collection counts. Ordered default-first, then oldest-first. Drives the All-Libraries home and the rail switcher.
+
+**Auth required:** Yes
+
+**Response (200):**
+
+```json
+{
+  "data": [
+    {
+      "id": "uuid",
+      "name": "Main",
+      "slug": "main-a1b2",
+      "userId": "uuid",
+      "isDefault": true,
+      "color": "amber",
+      "modelCount": 142,
+      "collectionCount": 7,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    }
+  ],
+  "meta": { "total": 1, "cursor": null, "pageSize": 1 },
+  "errors": null
+}
+```
+
+`data` is an array of `LibrarySummary` (a `Library` plus `modelCount` / `collectionCount`).
+
+---
+
+### POST /libraries
+
+Create a new (non-default) library.
+
+**Auth required:** Yes
+
+**Request body:**
+
+| Field | Type | Constraints |
+|-------|------|-------------|
+| `name` | string | Required; 1–255 characters |
+| `color` | string (optional) | One of `amber`, `teal`, `sage`, `plum`, `slate` (default `amber`) |
+
+**Response (201):** the created `LibrarySummary` (`modelCount` / `collectionCount` are `0`).
+
+---
+
+### PATCH /libraries/:id
+
+Rename and/or recolor a library. Renaming regenerates the slug. At least one of `name` / `color` must be provided. A library not owned by the user returns `404 NOT_FOUND`.
+
+**Auth required:** Yes
+
+**Path parameter:** `id` — library UUID
+
+**Request body:** `name` (optional, 1–255), `color` (optional enum, as above).
+
+**Response (200):** the updated `LibrarySummary`.
+
+---
+
+### POST /libraries/:id/set-default
+
+Mark a library as the user's default. The prior default is cleared in the same transaction, so exactly one library is default at all times. A library not owned by the user returns `404 NOT_FOUND`.
+
+**Auth required:** Yes
+
+**Path parameter:** `id` — library UUID
+
+**Response (200):** `{ "data": null, "meta": null, "errors": null }`
+
+---
+
+### DELETE /libraries/:id
+
+Delete a library. Refused (`409 CONFLICT`) when the library is the default, is the user's only library, or still contains any models or collections (move or remove its contents first). A library not owned by the user returns `404 NOT_FOUND`.
+
+**Auth required:** Yes
+
+**Path parameter:** `id` — library UUID
+
+**Response (200):** `{ "data": null, "meta": null, "errors": null }`
+
+---
+
 ## Collections
 
 ### GET /collections
 
-List collections belonging to the authenticated user's default library.
+List collections belonging to the active library.
 
 **Auth required:** Yes
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -97,11 +97,11 @@ The `runSeed` function is also exported for use as a standalone CLI script (`npm
 
 ## Data Model: Library Scope
 
-Every model and collection belongs to a library. Libraries are the top-level organizational scope introduced in P1 as a foundation for future multi-library support.
+Every model and collection belongs to a library. Libraries are the top-level organizational scope introduced in P1 as a foundation for multi-library support, surfaced to users in **P5** (All-Libraries home, `/lib/:id` routing, switcher, per-library scoping).
 
 ### Schema
 
-The `libraries` table (`apps/backend/src/db/schema/library.ts`) has these columns: `id` (UUID PK), `name`, `slug` (globally unique), `user_id` (FK → users), `is_default` (boolean), `created_at`, `updated_at`.
+The `libraries` table (`apps/backend/src/db/schema/library.ts`) has these columns: `id` (UUID PK), `name`, `slug` (globally unique), `user_id` (FK → users), `is_default` (boolean), `color` (palette-accent name; added by `0010_add_library_color`, defaulted to `amber`), `created_at`, `updated_at`.
 
 Both `models` and `collections` carry a `library_id` column (NOT NULL FK → libraries). This was added by migration `0007_add_library_id` after `0005_add_libraries` created the table and `0006_backfill_default_libraries` ensured every existing user had exactly one default library to backfill into.
 
@@ -115,28 +115,31 @@ This index makes the enforcement race-safe: the database rejects a second `is_de
 
 ### LibraryService
 
-`LibraryService.resolveDefaultLibraryId(userId)` is the single entry point for resolving a user's active library. It finds the user's `is_default = true` library and returns its id. If none exists (users created after the migration backfill), it creates one with name `"Library"`. This lazy creation mirrors what the migration backfill did for pre-existing users.
+`LibraryService` owns library resolution **and** management CRUD (expanded in P5). Methods all take `userId` explicitly and never trust a `libraryId` without an ownership check:
 
-The seed (`runSeed`) calls this method for the admin user on startup, so the admin always has a default library even on a fresh database.
+- `resolveDefaultLibraryId(userId)` — finds the user's `is_default = true` library, lazily creating one (name `"Library"`) if none exists. The seed (`runSeed`) calls this for the admin on startup so a default always exists.
+- `resolveLibraryId(userId, requestedId?)` — the scope resolver used by `requireLibrary`: returns `requestedId` if owned (else `NOT_FOUND`), otherwise the default.
+- `requireOwnedLibrary(userId, libraryId)` — ownership guard returning `NOT_FOUND` (no enumeration), reused by the management routes.
+- `listLibraries(userId)` — libraries with derived model/collection counts (two grouped queries, default-first ordering).
+- `createLibrary` / `updateLibrary` / `setDefaultLibrary` / `deleteLibrary` — management CRUD. `setDefaultLibrary` clears the prior default and sets the new one in one transaction (the partial unique index never sees two defaults). `deleteLibrary` refuses (`CONFLICT`) the default, the user's last library, or a non-empty library.
 
 ### The `requireLibrary` Prehandler
 
-`requireLibrary` (`apps/backend/src/middleware/library.ts`) is a Fastify preHandler that runs after `requireAuth` on every route that reads or writes library-scoped data. It calls `LibraryService.resolveDefaultLibraryId` and stores the result on `request.libraryId`.
+`requireLibrary` (`apps/backend/src/middleware/library.ts`) is a Fastify preHandler that runs after `requireAuth` on every route that reads or writes library-scoped data. It reads an optional **`X-Library-Id`** header and calls `LibraryService.resolveLibraryId(userId, header)`, storing the result on `request.libraryId`. Absent header → the user's default library (preserving pre-P5 single-library behavior).
 
-**Security invariant:** `libraryId` is server-injected only. No route accepts a `libraryId` from the client in the query string, path, or request body. The value is always derived from the authenticated session. This prevents one user from accessing another user's library by supplying a different `libraryId`.
+**Security invariant:** `libraryId` is never trusted from untrusted input. The header is accepted only after `resolveLibraryId` confirms the user owns that library; an unknown or un-owned id returns `NOT_FOUND` (same error either way, so ids cannot be enumerated). No route accepts a `libraryId` in the query string, path, or body. The frontend mirrors its `/lib/:id` route segment into the header; the `/libraries` management routes do **not** use `requireLibrary` (they manage the scope itself, keyed by URL `:id` + `userId`).
 
-Routes that apply `requireLibrary` (as of P4):
+Routes that apply `requireLibrary` (as of P5):
 
-- `GET /models`
-- `GET /collections`, `POST /collections`
-- `GET /collections/:id/models`
+- `GET /models`, `GET /models/:id`, `GET /models/:id/files`, `GET /models/:id/status`
+- `GET /collections`, `POST /collections`, `GET /collections/:id`, `GET /collections/:id/models`
 - `GET /metadata/fields/:slug/values`
 - `POST /models/upload`, `POST /models/upload/:uploadId/complete`, `POST /models/import`
 - `GET /models/import-sessions`, `POST /models/import-sessions/:id/commit`
 - `GET /search`
 - All `/smart-collections` routes
 
-By-id detail routes (`GET /models/:id`, `GET /collections/:id`, `PATCH /models/:id`, etc.) remain owned by `userId` and are not yet library-scoped. Library scoping for detail routes is deferred to P5 multi-library.
+P5 added library-scope guards to the read/detail routes above via `ModelService.requireModelInLibrary` / `CollectionService.requireCollectionInLibrary` (the entity must belong to `request.libraryId`, else `NOT_FOUND`), so a stale deep link to another library's item 404s after switching. By-id **mutation** routes (`PATCH`/`DELETE /models/:id`, `PATCH`/`DELETE /collections/:id`) remain `userId`-owned only — they are same-user operations and were intentionally left out of the minimal P5 sweep.
 
 ### P4: Smart Collections (shipped)
 
@@ -152,13 +155,18 @@ Smart collections were implemented in P4. Key architectural facts:
 
 - **`searchAll` global-search union still deferred**: `SearchService.searchAll` returns only manual collections. Unioning smart collections into global search results is a fast-follow that was explicitly deferred from this phase.
 
-### P5 Deferrals
+### P5: Multi-library (shipped)
 
-The following are explicitly deferred to the multi-library phase:
+P5 surfaced the library layer to users:
 
-- Multi-library UI and routing (the library-switcher button in PivotRail is a non-interactive stub).
-- Library scoping for by-id detail routes (`GET /models/:id`, `GET /collections/:id`, etc.).
+- **Backend**: `color` column (migration `0010`), expanded `LibraryService` CRUD, `requireLibrary` resolving the `X-Library-Id` header, a `/libraries` route module, and library-scope guards on read/detail routes (see above).
+- **Frontend**: an `X-Library-Id` header seam in `api/client.ts` (module-level `activeLibraryId` set by `LibraryProvider` from the `/lib/:id` route), the All-Libraries home, `/lib/:id` routing, the rail switcher, and library-relative navigation via `useLibraryPath`. Because library-scoped React Query keys do not include the library id (scoping rides on the header), `LibraryProvider` clears non-`libraries` queries when the active library changes so the workspace never shows the previous library's cached data.
+
+Still deferred:
+
+- By-id **mutation** routes are not library-scoped (same-user operations; see above).
 - Per-collection group counts in group view (requires server support to return paginated per-group totals).
+- Multi-user / invites / roles (P6).
 
 ---
 
@@ -166,11 +174,11 @@ The following are explicitly deferred to the multi-library phase:
 
 ### LibraryService
 
-**Owns:** Resolving and lazily creating a user's default library.
+**Owns:** Resolving a user's active library (default or `X-Library-Id`-requested, ownership-checked) and full library management CRUD (list-with-counts, create, rename/recolor, set-default, delete).
 
-**Does not own:** Library CRUD, multi-library switching (deferred to P5), or any data scoped within a library.
+**Does not own:** Any data scoped *within* a library (models, collections, etc.), or multi-user sharing (P6).
 
-**Behavior:** `resolveDefaultLibraryId(userId)` finds the user's default library in the `libraries` table. If none exists, it inserts one (name: `"Library"`, `is_default: true`) and returns its id. The partial unique index on the table makes this safe under concurrent calls.
+**Behavior:** `resolveDefaultLibraryId(userId)` finds (or lazily creates) the user's default library; `resolveLibraryId(userId, requestedId?)` validates a requested library against ownership before use. Management methods are detailed under *Data Model: Library Scope → LibraryService*. The partial unique index on `(user_id) WHERE is_default` keeps default resolution and `setDefaultLibrary` race-safe.
 
 ### IngestionService
 

--- a/docs/TYPES.md
+++ b/docs/TYPES.md
@@ -28,12 +28,23 @@ interface Library {
   slug: string;       // globally unique; URL-safe
   userId: string;
   isDefault: boolean; // exactly one default per user; enforced by DB partial unique index
+  color: string;      // palette-accent badge: amber | teal | sage | plum | slate (P5)
   createdAt: string;
   updatedAt: string;
 }
+
+// P5 — returned by GET /libraries; powers the All-Libraries cards and switcher
+interface LibrarySummary extends Library {
+  modelCount: number;
+  collectionCount: number;
+}
+
+interface CreateLibraryRequest { name: string; color?: LibraryColor }
+interface UpdateLibraryRequest { name?: string; color?: LibraryColor }
+// LibraryColor = 'amber' | 'teal' | 'sage' | 'plum' | 'slate' (LIBRARY_COLORS)
 ```
 
-The shared type is defined in `packages/shared/src/types/library.ts`. The database schema is in `apps/backend/src/db/schema/library.ts`. See the Architecture Reference for the `requireLibrary` preHandler and library-scoping rules.
+The shared types are defined in `packages/shared/src/types/library.ts` (validation in `packages/shared/src/validation/library.ts`). The database schema is in `apps/backend/src/db/schema/library.ts`. See the Architecture Reference for the `requireLibrary` preHandler, the `X-Library-Id` header, and library-scoping rules.
 
 ### User
 

--- a/packages/shared/src/types/library.ts
+++ b/packages/shared/src/types/library.ts
@@ -1,9 +1,30 @@
+/** Palette-accent names a library badge can use. */
+export const LIBRARY_COLORS = ['amber', 'teal', 'sage', 'plum', 'slate'] as const;
+export type LibraryColor = (typeof LIBRARY_COLORS)[number];
+
 export interface Library {
   id: string;
   name: string;
   slug: string;
   userId: string;
   isDefault: boolean;
+  color: string;
   createdAt: string; // ISO string
   updatedAt: string; // ISO string
+}
+
+/** A library plus the derived counts shown on the All-Libraries cards. */
+export interface LibrarySummary extends Library {
+  modelCount: number;
+  collectionCount: number;
+}
+
+export interface CreateLibraryRequest {
+  name: string;
+  color?: LibraryColor;
+}
+
+export interface UpdateLibraryRequest {
+  name?: string;
+  color?: LibraryColor;
 }

--- a/packages/shared/src/validation/index.ts
+++ b/packages/shared/src/validation/index.ts
@@ -4,5 +4,6 @@ export * from './model.js';
 export * from './import.js';
 export * from './search.js';
 export * from './collection.js';
+export * from './library.js';
 export * from './upload.js';
 export * from './smart-collection.js';

--- a/packages/shared/src/validation/library.ts
+++ b/packages/shared/src/validation/library.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod';
+import { LIBRARY_COLORS, type LibraryColor } from '../types/library.js';
+
+const colorEnum = z.enum(LIBRARY_COLORS as unknown as [LibraryColor, ...LibraryColor[]]);
+
+export const createLibrarySchema = z.object({
+  name: z.string().trim().min(1).max(255),
+  color: colorEnum.optional(),
+});
+
+export const updateLibrarySchema = z
+  .object({
+    name: z.string().trim().min(1).max(255).optional(),
+    color: colorEnum.optional(),
+  })
+  .refine((d) => d.name !== undefined || d.color !== undefined, {
+    message: 'At least one field must be provided',
+  });


### PR DESCRIPTION
## P5 — Multi-library

Surfaces the library layer that's been in the data model since P1. The backend was already fully library-scoped (every model/collection/smart-collection/import-session carries a NOT NULL `library_id`, all list/search queries filter on it); the single chokepoint — `requireLibrary` — previously always resolved the user's *default* library. P5 makes the active library selectable and adds management. **No query migration** — only one additive column.

### Backend
- **Schema:** `color` column on `libraries` (migration `0010`, defaulted to `amber`; existing rows backfill automatically).
- **LibraryService:** `listLibraries` (with model/collection counts), `resolveLibraryId`, `requireOwnedLibrary`, and CRUD — `create` / `updateLibrary` (rename + recolor) / `setDefaultLibrary` (clears prior default in one txn) / `deleteLibrary` (refuses the default, the last library, or a non-empty one).
- **`requireLibrary` middleware:** reads an optional **`X-Library-Id`** header, validated against ownership (un-owned → `NOT_FOUND`, no enumeration); absent → default library. No existing route signature changed — they still read `request.libraryId`.
- **`/libraries` route module:** list / create / patch / set-default / delete.
- **Detail-scope sweep (B5):** `GET /models/:id`(+`/files`,`/status`) and `GET /collections/:id`(+`/models`) now assert the entity belongs to the active library, so a stale cross-library deep link 404s after switching.

### Frontend
- **Header seam** in `api/client.ts` (module-level `activeLibraryId` → `X-Library-Id` on every request incl. XHR uploads) — scopes all existing API calls without touching each module.
- **`LibraryProvider` / `useLibraries` / `useLibraryPath`:** mirrors the `/lib/:id` route into the header (synchronously, so first fetch carries it), redirects un-owned ids home, and **clears non-`libraries` query cache on switch** (library-scoped query keys don't include the id — scoping rides on the header — so cached data from the previous library would otherwise show).
- **`/lib/:id` routing** restructure, **All-Libraries home** with rich cards (name, color badge, counts, per-card rename/set-default/delete), **rail switcher**, `LibraryDialog`, and **library-relative navigation** across every internal link.

### Out of scope (later)
Multi-user / invites / roles (P6); by-id *mutation* routes stay `userId`-owned (same-user ops).

### Verification
- Migration applied to `alexandria` + `alexandria_test`; `color` present, existing rows backfilled.
- **Backend:** 454 tests pass (17 new `/libraries` integration tests: CRUD, counts, set-default flip, delete guards, cross-tenant 404, header scoping isolation).
- **Frontend:** 159 tests pass; `tsc` clean; production build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)