### PR TITLE
feat: autocomplete existing tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A self-hosted personal library for managing 3D printing model collections. Think
 **Organization**
 - Flexible metadata system with default fields (Artist, Year, Tags, NSFW, Pre-supported, URL) and user-defined custom fields
 - Nestable collections — models can belong to multiple collections simultaneously
+- Existing tag values are suggested during model editing, upload review, and bulk tagging; free-form tags remain supported
 - Tag normalization prevents case-variant duplicates
 
 **Search and browse**

--- a/apps/frontend/src/components/metadata/tag-autocomplete.test.tsx
+++ b/apps/frontend/src/components/metadata/tag-autocomplete.test.tsx
@@ -1,0 +1,117 @@
+import { useState } from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+import type { MetadataFieldValue } from '@alexandria/shared';
+import { TagAutocomplete } from './tag-autocomplete';
+
+const suggestions: MetadataFieldValue[] = [
+  { value: 'Dragon', modelCount: 8 },
+  { value: 'Forest', modelCount: 5 },
+  { value: 'Terrain', modelCount: 3 },
+];
+
+function Harness({ initialValue = [] }: { initialValue?: string[] }) {
+  const [value, setValue] = useState(initialValue);
+  const [inputValue, setInputValue] = useState('');
+
+  return (
+    <>
+      <TagAutocomplete
+        value={value}
+        onChange={setValue}
+        inputValue={inputValue}
+        onInputChange={setInputValue}
+        suggestions={suggestions}
+        inputAriaLabel="Tag name"
+      />
+      <button type="button">After tags</button>
+    </>
+  );
+}
+
+describe('TagAutocomplete', () => {
+  it('should filter suggestions case-insensitively and exclude selected tags', async () => {
+    const user = userEvent.setup();
+    render(<Harness initialValue={['dragon']} />);
+
+    await user.type(screen.getByRole('combobox', { name: 'Tag name' }), 'ORE');
+
+    expect(screen.getByRole('option', { name: /Forest/ })).toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: /Dragon/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: /Terrain/ })).not.toBeInTheDocument();
+  });
+
+  it('should add a suggestion when it is clicked', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+
+    const input = screen.getByRole('combobox', { name: 'Tag name' });
+    await user.click(input);
+    await user.click(screen.getByRole('option', { name: /Dragon/ }));
+
+    expect(screen.getByRole('button', { name: 'Remove tag Dragon' })).toBeInTheDocument();
+    expect(input).toHaveValue('');
+  });
+
+  it('should add a highlighted suggestion with the keyboard', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+
+    const input = screen.getByRole('combobox', { name: 'Tag name' });
+    await user.click(input);
+    await user.keyboard('{ArrowDown}{ArrowDown}');
+
+    expect(screen.getByRole('option', { name: /Forest/ })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+
+    await user.keyboard('{Enter}');
+
+    expect(screen.getByRole('button', { name: 'Remove tag Forest' })).toBeInTheDocument();
+    expect(input).toHaveValue('');
+  });
+
+  it('should navigate suggestions upward from the first option', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+
+    const input = screen.getByRole('combobox', { name: 'Tag name' });
+    await user.click(input);
+    await user.keyboard('{ArrowUp}{Enter}');
+
+    expect(screen.getByRole('button', { name: 'Remove tag Terrain' })).toBeInTheDocument();
+  });
+
+  it('should create free-form tags with Enter or comma and reject case-insensitive duplicates', async () => {
+    const user = userEvent.setup();
+    render(<Harness initialValue={['Forest']} />);
+
+    const input = screen.getByRole('combobox', { name: 'Tag name' });
+    await user.type(input, 'New tag{Enter}');
+    expect(screen.getByRole('button', { name: 'Remove tag New tag' })).toBeInTheDocument();
+
+    await user.type(input, 'Another tag,');
+    expect(screen.getByRole('button', { name: 'Remove tag Another tag' })).toBeInTheDocument();
+
+    await user.type(input, 'forest{Enter}');
+    expect(screen.getAllByRole('button', { name: /Remove tag Forest/i })).toHaveLength(1);
+    expect(input).toHaveValue('');
+  });
+
+  it('should skip listbox options when tabbing away from the combobox', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+
+    const input = screen.getByRole('combobox', { name: 'Tag name' });
+    await user.click(input);
+
+    for (const option of screen.getAllByRole('option')) {
+      expect(option).toHaveAttribute('tabindex', '-1');
+    }
+
+    await user.tab();
+    expect(screen.getByRole('button', { name: 'After tags' })).toHaveFocus();
+  });
+});

--- a/apps/frontend/src/components/metadata/tag-autocomplete.tsx
+++ b/apps/frontend/src/components/metadata/tag-autocomplete.tsx
@@ -1,0 +1,216 @@
+import * as React from 'react';
+import { Plus, Tag, X } from 'lucide-react';
+import type { MetadataFieldValue } from '@alexandria/shared';
+import { cn } from '../../lib/utils';
+import { Button } from '../ui/button';
+import { Input } from '../ui/input';
+
+interface TagAutocompleteProps {
+  value: string[];
+  onChange: (value: string[]) => void;
+  inputValue: string;
+  onInputChange: (value: string) => void;
+  suggestions: MetadataFieldValue[];
+  placeholder?: string;
+  inputAriaLabel?: string;
+  autoFocus?: boolean;
+  showAddButton?: boolean;
+  className?: string;
+  inputClassName?: string;
+  chipClassName?: string;
+}
+
+const MAX_SUGGESTIONS = 6;
+
+function normalizeTag(tag: string) {
+  return tag.trim().toLowerCase();
+}
+
+export function TagAutocomplete({
+  value,
+  onChange,
+  inputValue,
+  onInputChange,
+  suggestions,
+  placeholder = 'Add or create tags',
+  inputAriaLabel = 'Tag name',
+  autoFocus,
+  showAddButton = false,
+  className,
+  inputClassName,
+  chipClassName,
+}: TagAutocompleteProps) {
+  const listboxId = React.useId();
+  const [focused, setFocused] = React.useState(false);
+  const [activeIndex, setActiveIndex] = React.useState(-1);
+  const selectedKeys = React.useMemo(
+    () => new Set(value.map(normalizeTag)),
+    [value],
+  );
+  const query = normalizeTag(inputValue);
+  const filteredSuggestions = suggestions
+    .filter((suggestion) => !selectedKeys.has(normalizeTag(suggestion.value)))
+    .filter((suggestion) => !query || normalizeTag(suggestion.value).includes(query))
+    .slice(0, MAX_SUGGESTIONS);
+  const isOpen = focused && filteredSuggestions.length > 0;
+
+  React.useEffect(() => {
+    setActiveIndex((current) =>
+      current >= filteredSuggestions.length ? filteredSuggestions.length - 1 : current,
+    );
+  }, [filteredSuggestions.length]);
+
+  function addTag(rawTag: string) {
+    const tag = rawTag.trim();
+    if (!tag || selectedKeys.has(normalizeTag(tag))) {
+      onInputChange('');
+      setActiveIndex(-1);
+      return;
+    }
+
+    onChange([...value, tag]);
+    onInputChange('');
+    setActiveIndex(-1);
+  }
+
+  function removeTag(tag: string) {
+    onChange(value.filter((item) => item !== tag));
+  }
+
+  function handleKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
+    if (event.key === 'ArrowDown' && filteredSuggestions.length > 0) {
+      event.preventDefault();
+      setFocused(true);
+      setActiveIndex((current) => (current + 1) % filteredSuggestions.length);
+      return;
+    }
+
+    if (event.key === 'ArrowUp' && filteredSuggestions.length > 0) {
+      event.preventDefault();
+      setFocused(true);
+      setActiveIndex((current) =>
+        current <= 0 ? filteredSuggestions.length - 1 : current - 1,
+      );
+      return;
+    }
+
+    if (event.key === 'Escape') {
+      setFocused(false);
+      setActiveIndex(-1);
+      return;
+    }
+
+    if (event.key === 'Enter' || event.key === ',') {
+      event.preventDefault();
+      if (event.key === 'Enter' && activeIndex >= 0) {
+        addTag(filteredSuggestions[activeIndex].value);
+      } else {
+        addTag(inputValue);
+      }
+    }
+  }
+
+  return (
+    <div
+      className={cn('flex min-w-0 flex-col gap-1.5', className)}
+      onBlur={(event) => {
+        if (!event.currentTarget.contains(event.relatedTarget)) {
+          setFocused(false);
+          setActiveIndex(-1);
+        }
+      }}
+    >
+      {value.length > 0 && (
+        <div className="flex flex-wrap gap-1.5">
+          {value.map((tag) => (
+            <span
+              key={tag}
+              className={cn(
+                'inline-flex h-6 items-center gap-1 rounded-full bg-secondary px-2 text-xs font-medium text-secondary-foreground',
+                chipClassName,
+              )}
+            >
+              <Tag className="h-3 w-3" aria-hidden="true" />
+              {tag}
+              <button
+                type="button"
+                onClick={() => removeTag(tag)}
+                aria-label={`Remove tag ${tag}`}
+                className="text-muted-foreground transition-colors hover:text-foreground"
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </span>
+          ))}
+        </div>
+      )}
+
+      <div className="flex gap-1">
+        <Input
+          value={inputValue}
+          onChange={(event) => {
+            onInputChange(event.target.value);
+            setFocused(true);
+            setActiveIndex(-1);
+          }}
+          onFocus={() => setFocused(true)}
+          onKeyDown={handleKeyDown}
+          placeholder={placeholder}
+          aria-label={inputAriaLabel}
+          role="combobox"
+          aria-autocomplete="list"
+          aria-expanded={isOpen}
+          aria-controls={listboxId}
+          aria-activedescendant={
+            isOpen && activeIndex >= 0 ? `${listboxId}-option-${activeIndex}` : undefined
+          }
+          autoFocus={autoFocus}
+          className={inputClassName}
+        />
+        {showAddButton && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => addTag(inputValue)}
+            aria-label="Add tag"
+            className="h-7 px-2"
+          >
+            <Plus className="h-3 w-3" />
+          </Button>
+        )}
+      </div>
+
+      {isOpen && (
+        <div
+          id={listboxId}
+          role="listbox"
+          aria-label="Tag suggestions"
+          className="flex max-h-40 flex-col gap-0.5 overflow-y-auto rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-md"
+        >
+          {filteredSuggestions.map((suggestion, index) => (
+            <button
+              key={suggestion.value}
+              id={`${listboxId}-option-${index}`}
+              type="button"
+              role="option"
+              tabIndex={-1}
+              aria-selected={activeIndex === index}
+              onMouseDown={(event) => event.preventDefault()}
+              onClick={() => addTag(suggestion.value)}
+              className={cn(
+                'flex w-full items-center justify-between rounded-sm px-2.5 py-1.5 text-left text-sm transition-colors hover:bg-accent',
+                activeIndex === index && 'bg-accent',
+              )}
+            >
+              <span className="truncate">{suggestion.value}</span>
+              <span className="ml-3 text-xs tabular-nums text-muted-foreground">
+                {suggestion.modelCount}
+              </span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/src/components/models/BulkActions.test.tsx
+++ b/apps/frontend/src/components/models/BulkActions.test.tsx
@@ -60,8 +60,8 @@ describe('BulkActions', () => {
     );
 
     fireEvent.click(screen.getByRole('button', { name: 'Tag' }));
-    await waitFor(() => expect(screen.getByRole('button', { name: /Fantasy/ })).toBeTruthy());
-    fireEvent.click(screen.getByRole('button', { name: /Fantasy/ }));
+    await waitFor(() => expect(screen.getByRole('option', { name: /Fantasy/ })).toBeTruthy());
+    fireEvent.click(screen.getByRole('option', { name: /Fantasy/ }));
     fireEvent.click(screen.getByRole('button', { name: 'Add 1 tag' }));
 
     await waitFor(() => {
@@ -86,7 +86,7 @@ describe('BulkActions', () => {
     );
 
     fireEvent.click(screen.getByRole('button', { name: 'Tag' }));
-    fireEvent.change(screen.getByRole('textbox', { name: 'Tag name' }), {
+    fireEvent.change(screen.getByRole('combobox', { name: 'Tag name' }), {
       target: { value: 'New Tag' },
     });
     fireEvent.click(screen.getByRole('button', { name: 'Add 1 tag' }));

--- a/apps/frontend/src/components/models/BulkActions.tsx
+++ b/apps/frontend/src/components/models/BulkActions.tsx
@@ -1,14 +1,14 @@
 import { useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Trash2, FolderInput, Tag, X } from 'lucide-react';
-import type { CollectionDetail, MetadataFieldValue } from '@alexandria/shared';
+import type { CollectionDetail } from '@alexandria/shared';
 import { bulkDelete, bulkCollection, bulkMetadata } from '../../api/bulk';
 import { getCollections } from '../../api/collections';
 import { getFieldValues } from '../../api/metadata';
 import { useToast } from '../../hooks/use-toast';
 import { Button } from '../ui/button';
-import { Input } from '../ui/input';
 import { AlertDialog } from '../ui/alert-dialog';
+import { TagAutocomplete } from '../metadata/tag-autocomplete';
 
 interface BulkActionsProps {
   selectedIds: Set<string>;
@@ -98,7 +98,7 @@ function TagPicker({ selectedIds, onClose, onDone }: TagPickerProps) {
     queryFn: () => getFieldValues('tags'),
   });
 
-  const existingTags: MetadataFieldValue[] = data ?? [];
+  const existingTags = data ?? [];
   const selectedKeys = new Set(selectedTags.map((tag) => tag.toLowerCase()));
   const trimmedInput = input.trim();
   const normalizedInput = trimmedInput.toLowerCase();
@@ -106,18 +106,6 @@ function TagPicker({ selectedIds, onClose, onDone }: TagPickerProps) {
     trimmedInput && !selectedKeys.has(normalizedInput)
       ? [...selectedTags, trimmedInput]
       : selectedTags;
-  const suggestions = existingTags
-    .filter((tag) => !selectedKeys.has(tag.value.toLowerCase()))
-    .filter((tag) => !normalizedInput || tag.value.toLowerCase().includes(normalizedInput))
-    .slice(0, 6);
-
-  const addTag = (rawTag: string) => {
-    const tag = rawTag.trim();
-    if (!tag || selectedKeys.has(tag.toLowerCase())) return;
-    setSelectedTags((current) => [...current, tag]);
-    setInput('');
-  };
-
   const tagMutation = useMutation({
     mutationFn: (tags: string[]) =>
       bulkMetadata({
@@ -152,59 +140,16 @@ function TagPicker({ selectedIds, onClose, onDone }: TagPickerProps) {
       </div>
       <p className="text-xs text-muted-foreground">Existing tags will be kept.</p>
 
-      {selectedTags.length > 0 && (
-        <div className="flex flex-wrap gap-1.5">
-          {selectedTags.map((tag) => (
-            <span
-              key={tag}
-              className="inline-flex h-6 items-center gap-1 rounded-md bg-accent px-2 text-xs"
-            >
-              {tag}
-              <button
-                type="button"
-                onClick={() =>
-                  setSelectedTags((current) => current.filter((item) => item !== tag))
-                }
-                aria-label={`Remove tag ${tag}`}
-                className="text-muted-foreground hover:text-foreground"
-              >
-                <X className="h-3 w-3" />
-              </button>
-            </span>
-          ))}
-        </div>
-      )}
-
-      <Input
-        value={input}
-        onChange={(event) => setInput(event.target.value)}
-        onKeyDown={(event) => {
-          if (event.key === 'Enter' || event.key === ',') {
-            event.preventDefault();
-            addTag(input);
-          }
-        }}
+      <TagAutocomplete
+        value={selectedTags}
+        onChange={setSelectedTags}
+        inputValue={input}
+        onInputChange={setInput}
+        suggestions={existingTags}
         placeholder="Add or create tags"
-        aria-label="Tag name"
+        inputAriaLabel="Tag name"
         autoFocus
       />
-
-      {suggestions.length > 0 && (
-        <ul className="flex max-h-40 flex-col gap-1 overflow-y-auto">
-          {suggestions.map((tag) => (
-            <li key={tag.value}>
-              <button
-                type="button"
-                onClick={() => addTag(tag.value)}
-                className="flex w-full items-center justify-between rounded-md px-2.5 py-1.5 text-left text-sm transition-colors hover:bg-accent"
-              >
-                <span className="truncate">{tag.value}</span>
-                <span className="text-xs text-muted-foreground tabular-nums">{tag.modelCount}</span>
-              </button>
-            </li>
-          ))}
-        </ul>
-      )}
 
       <Button
         size="sm"

--- a/apps/frontend/src/components/models/MetadataPanel.tsx
+++ b/apps/frontend/src/components/models/MetadataPanel.tsx
@@ -8,6 +8,7 @@ import { Button } from '../ui/button';
 import { Input } from '../ui/input';
 import { Select } from '../ui/select';
 import { toast } from '../../hooks/use-toast';
+import { TagAutocomplete } from '../metadata/tag-autocomplete';
 
 interface MetadataPanelProps {
   metadata: MetadataValue[];
@@ -124,6 +125,29 @@ function TagInput({ value, onChange }: TagInputProps) {
         </Button>
       </div>
     </div>
+  );
+}
+
+function TagsFieldEditor({ value, onChange }: TagInputProps) {
+  const [inputValue, setInputValue] = React.useState('');
+  const { data: suggestions = [] } = useQuery<MetadataFieldValue[]>({
+    queryKey: ['field-values', 'tags'],
+    queryFn: () => getFieldValues('tags'),
+    staleTime: 60_000,
+  });
+
+  return (
+    <TagAutocomplete
+      value={value}
+      onChange={onChange}
+      inputValue={inputValue}
+      onInputChange={setInputValue}
+      suggestions={suggestions}
+      placeholder="Add tag..."
+      inputAriaLabel="Tag name"
+      showAddButton
+      inputClassName="h-7 text-xs"
+    />
   );
 }
 
@@ -252,6 +276,14 @@ function EditFieldValue({
         <EnumMultiSelect
           value={Array.isArray(value) ? value : [value as string].filter(Boolean)}
           options={enumOptions}
+          onChange={onChange}
+        />
+      );
+    }
+    if (field.fieldSlug === 'tags') {
+      return (
+        <TagsFieldEditor
+          value={Array.isArray(value) ? value : [value as string].filter(Boolean)}
           onChange={onChange}
         />
       );
@@ -418,8 +450,11 @@ export function MetadataPanel({ metadata, modelId }: MetadataPanelProps) {
 
   const mutation = useMutation({
     mutationFn: (req: SetModelMetadataRequest) => setModelMetadata(modelId, req),
-    onSuccess: () => {
+    onSuccess: (_data, request) => {
       queryClient.invalidateQueries({ queryKey: ['model', modelId] });
+      if ('tags' in request) {
+        queryClient.invalidateQueries({ queryKey: ['field-values', 'tags'] });
+      }
       setEditing(false);
       setEditState({});
       toast({ title: 'Metadata saved' });

--- a/apps/frontend/src/components/models/metadata-panel.component.test.tsx
+++ b/apps/frontend/src/components/models/metadata-panel.component.test.tsx
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { MetadataFieldDetail, MetadataValue } from '@alexandria/shared';
+import { MetadataPanel } from './MetadataPanel';
+
+vi.mock('../../api/metadata', () => ({
+  getFields: vi.fn(),
+  getFieldValues: vi.fn(),
+  setModelMetadata: vi.fn(),
+}));
+
+import { getFields, getFieldValues, setModelMetadata } from '../../api/metadata';
+
+const tagsField: MetadataFieldDetail = {
+  id: '11111111-1111-4111-8111-111111111111',
+  name: 'Tags',
+  slug: 'tags',
+  type: 'multi_enum',
+  isDefault: true,
+  isFilterable: true,
+  isBrowsable: true,
+  config: null,
+  sortOrder: 1,
+};
+
+const metadata: MetadataValue[] = [
+  {
+    fieldSlug: 'tags',
+    fieldName: 'Tags',
+    type: 'multi_enum',
+    value: ['Fantasy'],
+    displayValue: 'Fantasy',
+  },
+];
+
+describe('MetadataPanel tag editing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getFields).mockResolvedValue([tagsField]);
+    vi.mocked(getFieldValues).mockResolvedValue([{ value: 'Terrain', modelCount: 4 }]);
+    vi.mocked(setModelMetadata).mockResolvedValue(undefined);
+  });
+
+  it('should save a selected library tag when editing the tags field', async () => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const invalidateQueries = vi.spyOn(client, 'invalidateQueries');
+    render(
+      <QueryClientProvider client={client}>
+        <MetadataPanel metadata={metadata} modelId="model-1" />
+      </QueryClientProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Edit/ }));
+    const input = await screen.findByRole('combobox', { name: 'Tag name' });
+    fireEvent.change(input, { target: { value: 'terr' } });
+    fireEvent.focus(input);
+    fireEvent.click(await screen.findByRole('option', { name: /Terrain/ }));
+
+    expect(screen.getByRole('button', { name: 'Remove tag Terrain' })).toBeInTheDocument();
+    expect(getFieldValues).toHaveBeenCalledWith('tags');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() => {
+      expect(setModelMetadata).toHaveBeenCalledWith('model-1', {
+        tags: ['Fantasy', 'Terrain'],
+      });
+      expect(invalidateQueries).toHaveBeenCalledWith({
+        queryKey: ['field-values', 'tags'],
+      });
+    });
+  });
+});

--- a/apps/frontend/src/components/upload/BatchMetadataForm.test.tsx
+++ b/apps/frontend/src/components/upload/BatchMetadataForm.test.tsx
@@ -1,5 +1,5 @@
-import { describe, expect, it, vi } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { CollectionDetail, DetectedImportMetadata } from '@alexandria/shared';
 import { BatchMetadataForm } from './BatchMetadataForm';
@@ -8,7 +8,12 @@ vi.mock('../../api/collections', () => ({
   getCollections: vi.fn(),
 }));
 
+vi.mock('../../api/metadata', () => ({
+  getFieldValues: vi.fn(),
+}));
+
 import { getCollections } from '../../api/collections';
+import { getFieldValues } from '../../api/metadata';
 
 const collection: CollectionDetail = {
   id: '22222222-2222-4222-8222-222222222222',
@@ -23,6 +28,11 @@ const collection: CollectionDetail = {
 };
 
 describe('BatchMetadataForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getFieldValues).mockResolvedValue([]);
+  });
+
   it('lists collections when the browse rail has already populated its cache', async () => {
     const client = new QueryClient({
       defaultOptions: { queries: { retry: false } },
@@ -114,5 +124,67 @@ describe('BatchMetadataForm', () => {
 
     expect(screen.getByPlaceholderText('Artist name (optional)')).toHaveValue('Second Artist');
     expect(screen.getByPlaceholderText('Model name')).toHaveValue('second-model');
+  });
+
+  it('should add an existing tag suggestion when it is selected', async () => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    vi.mocked(getCollections).mockResolvedValue({ data: [], meta: null, errors: null });
+    vi.mocked(getFieldValues).mockResolvedValue([
+      { value: 'Terrain', modelCount: 12 },
+      { value: 'Fantasy', modelCount: 7 },
+    ]);
+
+    render(
+      <QueryClientProvider client={client}>
+        <BatchMetadataForm
+          sessionId="session-1"
+          originalFilename="starter.zip"
+          detected={{
+            modelCount: 1,
+            fileCount: 1,
+            totalSizeBytes: 100,
+            artist: null,
+            tagsGuessed: ['fantasy'],
+            folderStructure: [],
+          }}
+          onCommitted={vi.fn()}
+        />
+      </QueryClientProvider>,
+    );
+
+    const input = screen.getByRole('combobox', { name: 'Tag name' });
+    fireEvent.change(input, { target: { value: 'TERR' } });
+    fireEvent.focus(input);
+    fireEvent.click(await screen.findByRole('option', { name: /Terrain/ }));
+
+    expect(screen.getByRole('button', { name: 'Remove tag Terrain' })).toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: /Fantasy/ })).not.toBeInTheDocument();
+    expect(getFieldValues).toHaveBeenCalledWith('tags');
+  });
+
+  it('should de-duplicate detected tags case-insensitively', () => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    vi.mocked(getCollections).mockResolvedValue({ data: [], meta: null, errors: null });
+
+    render(
+      <QueryClientProvider client={client}>
+        <BatchMetadataForm
+          sessionId="session-1"
+          originalFilename="starter.zip"
+          detected={{
+            modelCount: 1,
+            fileCount: 1,
+            totalSizeBytes: 100,
+            artist: null,
+            tagsGuessed: ['Fantasy', ' fantasy ', 'Terrain', '  '],
+            folderStructure: [],
+          }}
+          onCommitted={vi.fn()}
+        />
+      </QueryClientProvider>,
+    );
+
+    expect(screen.getAllByRole('button', { name: /Remove tag Fantasy/i })).toHaveLength(1);
+    expect(screen.getByRole('button', { name: 'Remove tag Terrain' })).toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/components/upload/BatchMetadataForm.tsx
+++ b/apps/frontend/src/components/upload/BatchMetadataForm.tsx
@@ -1,14 +1,16 @@
 import { useEffect, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { Loader2, X, FolderOpen, User, Tag } from 'lucide-react';
+import { Loader2, FolderOpen, User } from 'lucide-react';
 import type { DetectedImportMetadata, BatchUploadMetadata } from '@alexandria/shared';
 import { getCollections } from '../../api/collections';
+import { getFieldValues } from '../../api/metadata';
 import { useCommitSession } from '../../hooks/use-import-sessions';
 import { Button } from '../ui/button';
 import { Input } from '../ui/input';
 import { Label } from '../ui/label';
 import { Checkbox } from '../ui/checkbox';
 import { Textarea } from '../ui/textarea';
+import { TagAutocomplete } from '../metadata/tag-autocomplete';
 
 interface BatchMetadataFormProps {
   sessionId: string;
@@ -36,13 +38,23 @@ function archiveName(filename: string): string {
 }
 
 function createInitialForm(detected: DetectedImportMetadata, originalFilename: string): FormState {
+  const seenTags = new Set<string>();
+  const tags = detected.tagsGuessed.reduce<string[]>((result, rawTag) => {
+    const tag = rawTag.trim();
+    const key = tag.toLowerCase();
+    if (!key || seenTags.has(key)) return result;
+    seenTags.add(key);
+    result.push(tag);
+    return result;
+  }, []);
+
   return {
     modelName: archiveName(originalFilename),
     description: '',
     collectionId: '',
     newCollectionName: '',
     artist: detected.artist ?? '',
-    tags: [...detected.tagsGuessed],
+    tags,
     tagInput: '',
     markPreSupported: false,
     autoThumbnails: true,
@@ -70,20 +82,13 @@ export function BatchMetadataForm({
   });
   const availableCollections = collections ?? [];
 
+  const { data: tagSuggestions = [] } = useQuery({
+    queryKey: ['field-values', 'tags'],
+    queryFn: () => getFieldValues('tags'),
+    staleTime: 60_000,
+  });
+
   const commitMutation = useCommitSession();
-
-  function addTag(tag: string) {
-    const t = tag.trim();
-    if (t && !form.tags.includes(t)) {
-      setForm((f) => ({ ...f, tags: [...f.tags, t], tagInput: '' }));
-    } else {
-      setForm((f) => ({ ...f, tagInput: '' }));
-    }
-  }
-
-  function removeTag(tag: string) {
-    setForm((f) => ({ ...f, tags: f.tags.filter((t) => t !== tag) }));
-  }
 
   async function handleSubmit() {
     // collectionId and newCollectionName are mutually exclusive: if an existing
@@ -210,42 +215,22 @@ export function BatchMetadataForm({
       {/* Tags */}
       <FormSection label="Tags to apply to all">
         <div
-          className="flex flex-wrap gap-1.5 p-2.5 rounded-lg min-h-[40px]"
+          className="rounded-lg p-2.5 min-h-[40px]"
           style={{
             background: 'var(--ax-bg-elev)',
             border: '1px solid var(--ax-border)',
           }}
         >
-          {form.tags.map((tag) => (
-            <span
-              key={tag}
-              className="ax-chip ax-chip-amber flex items-center gap-1"
-              style={{ height: 22 }}
-            >
-              <Tag className="w-2.5 h-2.5" />
-              {tag}
-              <button
-                type="button"
-                onClick={() => removeTag(tag)}
-                className="ml-0.5 hover:opacity-70"
-                aria-label={`Remove tag ${tag}`}
-              >
-                <X className="w-2.5 h-2.5" />
-              </button>
-            </span>
-          ))}
-          <input
-            value={form.tagInput}
-            onChange={(e) => setForm((f) => ({ ...f, tagInput: e.target.value }))}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter' || e.key === ',') {
-                e.preventDefault();
-                addTag(form.tagInput);
-              }
-            }}
+          <TagAutocomplete
+            value={form.tags}
+            onChange={(tags) => setForm((f) => ({ ...f, tags }))}
+            inputValue={form.tagInput}
+            onInputChange={(tagInput) => setForm((f) => ({ ...f, tagInput }))}
+            suggestions={tagSuggestions}
             placeholder={form.tags.length === 0 ? 'Type a tag and press Enter…' : '+ tag'}
-            className="bg-transparent text-[12px] outline-none flex-1 min-w-[80px] placeholder:text-[var(--ax-fg-muted)]"
-            style={{ color: 'var(--ax-fg)', fontFamily: 'inherit' }}
+            inputAriaLabel="Tag name"
+            chipClassName="ax-chip ax-chip-amber h-[22px] rounded-md"
+            inputClassName="h-7 min-w-[80px] border-0 bg-transparent px-1 text-[12px] shadow-none focus-visible:ring-0"
           />
         </div>
         <p className="text-[11.5px] mt-1.5" style={{ color: 'var(--ax-fg-muted)' }}>


### PR DESCRIPTION
## What changed

- Added a reusable tag autocomplete with case-insensitive filtering, model-count hints, click selection, and keyboard navigation.
- Integrated existing-tag suggestions into model metadata editing, staged upload review, and bulk tagging.
- Preserved free-form tag creation with Enter or comma and prevented case-variant duplicates.
- Refreshes shared tag values after single-model tag edits so autocomplete and tag facets stay current.
- Added focused accessibility and integration coverage, plus a concise README note.

## Why

Tag entry previously required users to remember and retype existing values in some workflows, which made duplicate or inconsistent tags easier to create. The shared control makes existing library tags discoverable while retaining the flexibility to create new tags.

## Validation

- `npm test -w @alexandria/frontend` — 192 tests passed
- `npm run build -w @alexandria/frontend` — passed
- `git diff --check` — passed
- Independent reviewer pass — no remaining actionable findings
