### PR TITLE
fix: show progress for model file operations

### DIFF
--- a/apps/frontend/src/components/models/FileTree.test.tsx
+++ b/apps/frontend/src/components/models/FileTree.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import type { FileTreeNode } from '@alexandria/shared';
 import { FileTree } from './FileTree';
 
@@ -13,6 +13,16 @@ const TREE: FileTreeNode[] = [
   },
   { name: 'readme.txt', type: 'file', fileType: 'document', sizeBytes: 10, id: 'd1' },
 ];
+
+function deferredPromise() {
+  let resolve!: () => void;
+  let reject!: (error: Error) => void;
+  const promise = new Promise<void>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
 
 describe('FileTree', () => {
   it('fires onOpenStl with the reconstructed relative path for a nested STL', () => {
@@ -137,5 +147,59 @@ describe('FileTree', () => {
 
     fireEvent.click(imageRow);
     expect(onSelectImageFile).toHaveBeenCalledWith('img-1');
+  });
+
+  it('shows an accessible operation status while file actions are pending', () => {
+    const { container } = render(
+      <FileTree
+        tree={TREE}
+        modelId="m1"
+        disabled
+        operationStatus="Renaming folder…"
+      />,
+    );
+
+    expect(screen.getByRole('status')).toHaveTextContent('Renaming folder…');
+    expect(container.firstElementChild).toHaveAttribute('aria-busy', 'true');
+    expect(screen.getByRole('button', { name: 'Create folder' })).toBeDisabled();
+  });
+
+  it('keeps the move dialog open with a busy indicator until the move completes', async () => {
+    const move = deferredPromise();
+    const onMoveFolder = vi.fn(() => move.promise);
+    render(<FileTree tree={TREE} modelId="m1" onMoveFolder={onMoveFolder} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Actions for folder parts' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Move' }));
+
+    const dialog = screen.getByRole('dialog');
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Move' }));
+
+    expect(onMoveFolder).toHaveBeenCalledWith('parts', '');
+    expect(within(dialog).getByRole('button', { name: 'Moving…' })).toBeDisabled();
+    expect(within(dialog).getByRole('button', { name: 'Cancel' })).toBeDisabled();
+    expect(dialog).toHaveAttribute('aria-busy', 'true');
+
+    expect(within(dialog).queryByRole('button', { name: 'Close dialog' })).not.toBeInTheDocument();
+
+    move.resolve();
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+  });
+
+  it('keeps the move dialog open for retry when the move fails', async () => {
+    const move = deferredPromise();
+    const onMoveFolder = vi.fn(() => move.promise);
+    render(<FileTree tree={TREE} modelId="m1" onMoveFolder={onMoveFolder} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Actions for folder parts' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Move' }));
+    fireEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: 'Move' }));
+
+    move.reject(new Error('Move failed'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+      expect(within(screen.getByRole('dialog')).getByRole('button', { name: 'Move' })).toBeEnabled();
+    });
   });
 });

--- a/apps/frontend/src/components/models/FileTree.tsx
+++ b/apps/frontend/src/components/models/FileTree.tsx
@@ -15,6 +15,7 @@ import {
   SquareCheck,
   Trash2,
   PackageOpen,
+  Loader2,
 } from 'lucide-react';
 import type { FileTreeNode, FileType } from '@alexandria/shared';
 import { formatFileSize } from '../../lib/format';
@@ -59,11 +60,11 @@ interface FileNodeProps {
   onToggleFileSelection: (fileId: string) => void;
   onCreateFolder?: (parentPath: string) => void;
   onRenameFile?: (fileId: string, filename: string) => void;
-  onMoveFile?: (fileId: string, parentPath: string) => void;
+  onMoveFile?: (fileId: string, parentPath: string) => Promise<void>;
   onDeleteFile?: (fileId: string, name: string) => void;
   onExtractArchive?: (fileId: string, name: string) => void;
   onRenameFolder?: (path: string, name: string) => void;
-  onMoveFolder?: (path: string, parentPath: string) => void;
+  onMoveFolder?: (path: string, parentPath: string) => Promise<void>;
   onDeleteFolder?: (path: string, name: string) => void;
   selectionMode: boolean;
   onRequestMove: (request: MoveRequest) => void;
@@ -181,11 +182,12 @@ function MoveDestinationDialog({
   request: MoveRequest | null;
   destinations: FolderDestination[];
   onCreateDestination: (parentPath: string, name: string) => FolderDestination | null;
-  onConfirm: (destinationPath: string) => void;
+  onConfirm: (destinationPath: string) => Promise<void>;
 }) {
   const [selectedPath, setSelectedPath] = React.useState('');
   const [newFolderParentPath, setNewFolderParentPath] = React.useState('');
   const [newFolderName, setNewFolderName] = React.useState('');
+  const [isSubmitting, setIsSubmitting] = React.useState(false);
   const title = request?.type === 'folder' ? `Move ${request.folderName}` : 'Move Files';
 
   React.useEffect(() => {
@@ -193,6 +195,7 @@ function MoveDestinationDialog({
       setSelectedPath('');
       setNewFolderParentPath('');
       setNewFolderName('');
+      setIsSubmitting(false);
       return;
     }
     setSelectedPath(destinations[0]?.path ?? '');
@@ -207,9 +210,29 @@ function MoveDestinationDialog({
     setNewFolderName('');
   }
 
+  async function confirmMove(): Promise<void> {
+    setIsSubmitting(true);
+    try {
+      await onConfirm(selectedPath);
+    } catch {
+      // The mutation owner reports the error. Keep this dialog open for retry.
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-md">
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!isSubmitting) onOpenChange(nextOpen);
+      }}
+    >
+      <DialogContent
+        className="max-w-md"
+        aria-busy={isSubmitting}
+        showCloseButton={!isSubmitting}
+      >
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
         </DialogHeader>
@@ -220,6 +243,7 @@ function MoveDestinationDialog({
               key={destination.path || 'root'}
               type="button"
               onClick={() => setSelectedPath(destination.path)}
+              disabled={isSubmitting}
               className={cn(
                 'flex w-full items-center gap-2 border-b border-border px-3 py-2 text-left text-sm last:border-b-0 hover:bg-accent',
                 selectedPath === destination.path && 'bg-primary/10 text-primary hover:bg-primary/15',
@@ -238,6 +262,7 @@ function MoveDestinationDialog({
             <select
               value={newFolderParentPath}
               onChange={(event) => setNewFolderParentPath(event.currentTarget.value)}
+              disabled={isSubmitting}
               className="h-8 max-w-[180px] rounded-md border border-input bg-background px-2 text-xs text-foreground"
             >
               {destinations.map((destination) => (
@@ -251,13 +276,14 @@ function MoveDestinationDialog({
             <input
               value={newFolderName}
               onChange={(event) => setNewFolderName(event.currentTarget.value)}
+              disabled={isSubmitting}
               className="h-8 min-w-0 flex-1 rounded-md border border-input bg-background px-2 text-sm"
               aria-label="New folder name"
             />
             <button
               type="button"
               onClick={createDestination}
-              disabled={newFolderName.trim().length === 0}
+              disabled={isSubmitting || newFolderName.trim().length === 0}
               className="inline-flex h-8 items-center gap-1 rounded-md border border-input px-2 text-xs font-medium hover:bg-accent disabled:opacity-50"
             >
               <FolderPlus className="h-3.5 w-3.5" />
@@ -270,17 +296,21 @@ function MoveDestinationDialog({
           <button
             type="button"
             onClick={() => onOpenChange(false)}
+            disabled={isSubmitting}
             className="inline-flex h-8 items-center rounded-md border border-input px-3 text-sm hover:bg-accent"
           >
             Cancel
           </button>
           <button
             type="button"
-            onClick={() => onConfirm(selectedPath)}
-            disabled={destinations.length === 0}
-            className="inline-flex h-8 items-center rounded-md bg-primary px-3 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+            onClick={() => void confirmMove()}
+            disabled={isSubmitting || destinations.length === 0}
+            className="inline-flex h-8 items-center gap-1.5 rounded-md bg-primary px-3 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
           >
-            Move
+            {isSubmitting && (
+              <Loader2 className="h-3.5 w-3.5 animate-spin motion-reduce:animate-none" aria-hidden="true" />
+            )}
+            {isSubmitting ? 'Moving…' : 'Move'}
           </button>
         </DialogFooter>
       </DialogContent>
@@ -658,15 +688,16 @@ interface FileTreeProps {
   selectedImageFileId?: string | null;
   onSelectImageFile?: (fileId: string) => void;
   disabled?: boolean;
+  operationStatus?: string;
   onCreateFolder?: (path: string) => void;
   onRenameFile?: (fileId: string, filename: string) => void;
-  onMoveFile?: (fileId: string, parentPath: string) => void;
+  onMoveFile?: (fileId: string, parentPath: string) => Promise<void>;
   onDeleteFile?: (fileId: string, name: string) => void;
   onExtractArchive?: (fileId: string, name: string) => void;
-  onMoveFiles?: (fileIds: string[], parentPath: string) => void;
+  onMoveFiles?: (fileIds: string[], parentPath: string) => Promise<void>;
   onDeleteFiles?: (fileIds: string[]) => void;
   onRenameFolder?: (path: string, name: string) => void;
-  onMoveFolder?: (path: string, parentPath: string) => void;
+  onMoveFolder?: (path: string, parentPath: string) => Promise<void>;
   onDeleteFolder?: (path: string, name: string) => void;
 }
 
@@ -678,6 +709,7 @@ export function FileTree({
   selectedImageFileId,
   onSelectImageFile,
   disabled = false,
+  operationStatus,
   onCreateFolder,
   onRenameFile,
   onMoveFile,
@@ -819,21 +851,24 @@ export function FileTree({
     return created;
   }
 
-  function confirmMove(destinationPath: string): void {
+  async function confirmMove(destinationPath: string): Promise<void> {
     if (!moveRequest) return;
     if (moveRequest.type === 'folder') {
-      onMoveFolder?.(moveRequest.folderPath, destinationPath);
+      await onMoveFolder?.(moveRequest.folderPath, destinationPath);
     } else if (moveRequest.fileIds.length === 1) {
-      onMoveFile?.(moveRequest.fileIds[0], destinationPath);
+      await onMoveFile?.(moveRequest.fileIds[0], destinationPath);
     } else {
-      onMoveFiles?.(moveRequest.fileIds, destinationPath);
+      await onMoveFiles?.(moveRequest.fileIds, destinationPath);
       setSelectedFileIds(new Set());
     }
     setMoveRequest(null);
   }
 
   return (
-    <div className="rounded-xl border border-border bg-card overflow-visible">
+    <div
+      className="rounded-xl border border-border bg-card overflow-visible"
+      aria-busy={Boolean(operationStatus)}
+    >
       <div className="flex items-center justify-between gap-2 px-4 py-3 border-b border-border bg-muted/30">
         <span className="text-sm font-semibold text-foreground">Files</span>
         <div className="flex items-center gap-2">
@@ -864,7 +899,21 @@ export function FileTree({
           >
             <FolderPlus className="h-4 w-4" />
           </button>
-          <span className="text-xs text-muted-foreground">{totalFiles} files</span>
+          {operationStatus ? (
+            <span
+              role="status"
+              aria-live="polite"
+              className="inline-flex items-center gap-1.5 text-xs font-medium text-primary"
+            >
+              <Loader2
+                className="h-3.5 w-3.5 animate-spin motion-reduce:animate-none"
+                aria-hidden="true"
+              />
+              {operationStatus}
+            </span>
+          ) : (
+            <span className="text-xs text-muted-foreground">{totalFiles} files</span>
+          )}
         </div>
       </div>
       {selectionMode && (

--- a/apps/frontend/src/components/models/ModelDetailPanel.tsx
+++ b/apps/frontend/src/components/models/ModelDetailPanel.tsx
@@ -22,15 +22,16 @@ interface ModelDetailPanelProps {
   selectedImageFileId: string | null;
   onSelectImageFile: (fileId: string) => void;
   fileActionsDisabled?: boolean;
+  fileActionStatus?: string;
   onCreateFolder?: (path: string) => void;
   onRenameFile?: (fileId: string, filename: string) => void;
-  onMoveFile?: (fileId: string, parentPath: string) => void;
+  onMoveFile?: (fileId: string, parentPath: string) => Promise<void>;
   onDeleteFile?: (fileId: string, name: string) => void;
   onExtractArchive?: (fileId: string, name: string) => void;
-  onMoveFiles?: (fileIds: string[], parentPath: string) => void;
+  onMoveFiles?: (fileIds: string[], parentPath: string) => Promise<void>;
   onDeleteFiles?: (fileIds: string[]) => void;
   onRenameFolder?: (path: string, name: string) => void;
-  onMoveFolder?: (path: string, parentPath: string) => void;
+  onMoveFolder?: (path: string, parentPath: string) => Promise<void>;
   onDeleteFolder?: (path: string, name: string) => void;
 }
 
@@ -46,6 +47,7 @@ export function ModelDetailPanel({
   selectedImageFileId,
   onSelectImageFile,
   fileActionsDisabled,
+  fileActionStatus,
   onCreateFolder,
   onRenameFile,
   onMoveFile,
@@ -92,6 +94,7 @@ export function ModelDetailPanel({
           selectedImageFileId={selectedImageFileId}
           onSelectImageFile={onSelectImageFile}
           disabled={fileActionsDisabled}
+          operationStatus={fileActionStatus}
           onCreateFolder={onCreateFolder}
           onRenameFile={onRenameFile}
           onMoveFile={onMoveFile}

--- a/apps/frontend/src/components/ui/dialog.tsx
+++ b/apps/frontend/src/components/ui/dialog.tsx
@@ -79,41 +79,46 @@ function DialogOverlay({ className, ...props }: React.HTMLAttributes<HTMLDivElem
   );
 }
 
-const DialogContent = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, children, ...props }, ref) => {
-  const { onOpenChange } = useDialog();
-  return (
-    <DialogPortal>
-      <DialogOverlay />
-      <div
-        ref={ref}
-        role="dialog"
-        aria-modal="true"
-        className={cn(
-          'fixed left-1/2 top-1/2 z-50 w-full max-w-lg -translate-x-1/2 -translate-y-1/2',
-          'bg-background rounded-xl border shadow-xl',
-          'p-6 flex flex-col gap-4',
-          'max-h-[90vh] overflow-y-auto',
-          className
-        )}
-        onClick={(e) => e.stopPropagation()}
-        {...props}
-      >
-        {children}
-        <button
-          type="button"
-          onClick={() => onOpenChange(false)}
-          className="absolute right-4 top-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-1 focus:ring-ring"
-          aria-label="Close dialog"
+interface DialogContentProps extends React.HTMLAttributes<HTMLDivElement> {
+  showCloseButton?: boolean;
+}
+
+const DialogContent = React.forwardRef<HTMLDivElement, DialogContentProps>(
+  ({ className, children, showCloseButton = true, ...props }, ref) => {
+    const { onOpenChange } = useDialog();
+    return (
+      <DialogPortal>
+        <DialogOverlay />
+        <div
+          ref={ref}
+          role="dialog"
+          aria-modal="true"
+          className={cn(
+            'fixed left-1/2 top-1/2 z-50 w-full max-w-lg -translate-x-1/2 -translate-y-1/2',
+            'bg-background rounded-xl border shadow-xl',
+            'p-6 flex flex-col gap-4',
+            'max-h-[90vh] overflow-y-auto',
+            className
+          )}
+          onClick={(e) => e.stopPropagation()}
+          {...props}
         >
-          <X className="h-4 w-4" />
-        </button>
-      </div>
-    </DialogPortal>
-  );
-});
+          {children}
+          {showCloseButton && (
+            <button
+              type="button"
+              onClick={() => onOpenChange(false)}
+              className="absolute right-4 top-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-1 focus:ring-ring"
+              aria-label="Close dialog"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          )}
+        </div>
+      </DialogPortal>
+    );
+  },
+);
 DialogContent.displayName = 'DialogContent';
 
 function DialogHeader({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {

--- a/apps/frontend/src/pages/ModelDetailPage.tsx
+++ b/apps/frontend/src/pages/ModelDetailPage.tsx
@@ -39,6 +39,34 @@ import { useToast } from '../hooks/use-toast';
 import { formatFileSize } from '../lib/format';
 import { cn } from '../lib/utils';
 
+type FileAction =
+  | { type: 'create-folder'; path: string }
+  | { type: 'rename-file'; fileId: string; filename: string }
+  | { type: 'move-file'; fileId: string; parentPath: string }
+  | { type: 'delete-file'; fileId: string; name: string }
+  | { type: 'extract-archive'; fileId: string; name: string }
+  | { type: 'move-files'; fileIds: string[]; parentPath: string }
+  | { type: 'delete-files'; fileIds: string[] }
+  | { type: 'rename-folder'; path: string; name: string }
+  | { type: 'move-folder'; path: string; parentPath: string }
+  | { type: 'delete-folder'; path: string; name: string };
+
+function fileActionStatus(action: FileAction | undefined): string | undefined {
+  if (!action) return undefined;
+  switch (action.type) {
+    case 'create-folder': return 'Creating folder…';
+    case 'rename-file': return 'Renaming file…';
+    case 'move-file': return 'Moving file…';
+    case 'delete-file': return 'Deleting file…';
+    case 'extract-archive': return 'Extracting archive…';
+    case 'move-files': return `Moving ${action.fileIds.length} files…`;
+    case 'delete-files': return `Deleting ${action.fileIds.length} files…`;
+    case 'rename-folder': return 'Renaming folder…';
+    case 'move-folder': return 'Moving folder…';
+    case 'delete-folder': return 'Deleting folder…';
+  }
+}
+
 export function ModelDetailPage() {
   const { id } = useParams<{ id: string }>();
   const libPath = useLibraryPath();
@@ -79,19 +107,7 @@ export function ModelDetailPage() {
   const [selectedImageFileId, setSelectedImageFileId] = React.useState<string | null>(null);
 
   const fileMutation = useMutation({
-    mutationFn: async (
-      action:
-        | { type: 'create-folder'; path: string }
-        | { type: 'rename-file'; fileId: string; filename: string }
-        | { type: 'move-file'; fileId: string; parentPath: string }
-        | { type: 'delete-file'; fileId: string; name: string }
-        | { type: 'extract-archive'; fileId: string; name: string }
-        | { type: 'move-files'; fileIds: string[]; parentPath: string }
-        | { type: 'delete-files'; fileIds: string[] }
-        | { type: 'rename-folder'; path: string; name: string }
-        | { type: 'move-folder'; path: string; parentPath: string }
-        | { type: 'delete-folder'; path: string; name: string },
-    ) => {
+    mutationFn: async (action: FileAction) => {
       if (!id) throw new Error('Model id is required');
       switch (action.type) {
         case 'create-folder':
@@ -146,6 +162,14 @@ export function ModelDetailPage() {
       });
     },
   });
+
+  const activeFileActionStatus = fileMutation.isPending
+    ? fileActionStatus(fileMutation.variables)
+    : undefined;
+
+  function runFileAction(action: FileAction): Promise<void> {
+    return fileMutation.mutateAsync(action).then(() => undefined);
+  }
 
   function openViewer(stl: StlFileRef) {
     setActiveStl(stl);
@@ -273,15 +297,16 @@ export function ModelDetailPage() {
               selectedImageFileId={selectedImageFileId}
               onSelectImageFile={setSelectedImageFileId}
               fileActionsDisabled={fileMutation.isPending}
+              fileActionStatus={activeFileActionStatus}
               onCreateFolder={(path) => fileMutation.mutate({ type: 'create-folder', path })}
               onRenameFile={(fileId, filename) => fileMutation.mutate({ type: 'rename-file', fileId, filename })}
-              onMoveFile={(fileId, parentPath) => fileMutation.mutate({ type: 'move-file', fileId, parentPath })}
+              onMoveFile={(fileId, parentPath) => runFileAction({ type: 'move-file', fileId, parentPath })}
               onDeleteFile={(fileId, name) => fileMutation.mutate({ type: 'delete-file', fileId, name })}
               onExtractArchive={(fileId, name) => fileMutation.mutate({ type: 'extract-archive', fileId, name })}
-              onMoveFiles={(fileIds, parentPath) => fileMutation.mutate({ type: 'move-files', fileIds, parentPath })}
+              onMoveFiles={(fileIds, parentPath) => runFileAction({ type: 'move-files', fileIds, parentPath })}
               onDeleteFiles={(fileIds) => fileMutation.mutate({ type: 'delete-files', fileIds })}
               onRenameFolder={(path, name) => fileMutation.mutate({ type: 'rename-folder', path, name })}
-              onMoveFolder={(path, parentPath) => fileMutation.mutate({ type: 'move-folder', path, parentPath })}
+              onMoveFolder={(path, parentPath) => runFileAction({ type: 'move-folder', path, parentPath })}
               onDeleteFolder={(path, name) => fileMutation.mutate({ type: 'delete-folder', path, name })}
             />
           </div>


### PR DESCRIPTION
## Summary
- show operation-specific busy status for model file and folder actions
- keep move dialogs open with disabled controls and an indeterminate spinner until mutations and refetches complete
- preserve failed moves for retry and hide dialog dismissal while a move is running
- add focused accessibility and async lifecycle coverage

## Validation
- npm test
- npm run build -w @alexandria/frontend
- npm test -w @alexandria/frontend -- src/components/models/FileTree.test.tsx