### PR TITLE
feat: add model collection membership controls

### DIFF
--- a/apps/frontend/src/components/models/BulkActions.test.tsx
+++ b/apps/frontend/src/components/models/BulkActions.test.tsx
@@ -11,6 +11,7 @@ vi.mock('../../api/bulk', () => ({
 }));
 
 vi.mock('../../api/collections', () => ({
+  addModelsToCollection: vi.fn(),
   getCollections: vi.fn(),
 }));
 
@@ -19,7 +20,7 @@ vi.mock('../../api/metadata', () => ({
 }));
 
 import { bulkCollection, bulkDelete, bulkMetadata } from '../../api/bulk';
-import { getCollections } from '../../api/collections';
+import { addModelsToCollection, getCollections } from '../../api/collections';
 import { getFieldValues } from '../../api/metadata';
 
 const target: CollectionDetail = {
@@ -124,6 +125,66 @@ describe('BulkActions', () => {
         collectionId: target.id,
       });
       expect(onComplete).toHaveBeenCalledOnce();
+    });
+  });
+
+  it('should add selected models while keeping their existing collection memberships', async () => {
+    vi.mocked(getCollections).mockResolvedValue({ data: [target], meta: null, errors: null });
+    vi.mocked(addModelsToCollection).mockResolvedValue(undefined);
+    const onComplete = vi.fn();
+
+    render(
+      <BulkActions
+        selectedIds={new Set(['model-1', 'model-2'])}
+        onClear={vi.fn()}
+        onComplete={onComplete}
+      />,
+      { wrapper: Wrapper },
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add to collection' }));
+    expect(screen.getByText('Existing collection memberships will be kept.')).toBeInTheDocument();
+    const targetButton = await screen.findByRole('button', { name: 'Add to Print Queue' });
+    fireEvent.click(targetButton);
+
+    await waitFor(() => {
+      expect(addModelsToCollection).toHaveBeenCalledWith(target.id, ['model-1', 'model-2']);
+      expect(bulkCollection).not.toHaveBeenCalled();
+      expect(onComplete).toHaveBeenCalledOnce();
+    });
+  });
+
+  it('should expose picker state and restore trigger focus when Escape closes it', async () => {
+    vi.mocked(getCollections).mockResolvedValue({ data: [target], meta: null, errors: null });
+
+    render(
+      <BulkActions
+        selectedIds={new Set(['model-1'])}
+        onClear={vi.fn()}
+        onComplete={vi.fn()}
+      />,
+      { wrapper: Wrapper },
+    );
+
+    const trigger = screen.getByRole('button', { name: 'Add to collection' });
+    expect(trigger).toHaveAttribute('aria-haspopup', 'dialog');
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+
+    fireEvent.click(trigger);
+
+    const picker = await screen.findByRole('dialog', { name: 'Add models to collection' });
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    expect(trigger).toHaveAttribute('aria-controls', picker.id);
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Add to Print Queue' })).toHaveFocus();
+    });
+
+    fireEvent.keyDown(picker, { key: 'Escape' });
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog', { name: 'Add models to collection' })).not.toBeInTheDocument();
+      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+      expect(trigger).toHaveFocus();
     });
   });
 

--- a/apps/frontend/src/components/models/BulkActions.tsx
+++ b/apps/frontend/src/components/models/BulkActions.tsx
@@ -1,9 +1,9 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { Trash2, FolderInput, Tag, X } from 'lucide-react';
+import { AlertCircle, FolderInput, FolderPlus, Loader2, Tag, Trash2, X } from 'lucide-react';
 import type { CollectionDetail } from '@alexandria/shared';
 import { bulkDelete, bulkCollection, bulkMetadata } from '../../api/bulk';
-import { getCollections } from '../../api/collections';
+import { addModelsToCollection, getCollections } from '../../api/collections';
 import { getFieldValues } from '../../api/metadata';
 import { useToast } from '../../hooks/use-toast';
 import { Button } from '../ui/button';
@@ -16,59 +16,128 @@ interface BulkActionsProps {
   onComplete: () => void;
 }
 
-interface MovePickerProps {
+interface CollectionPickerProps {
   selectedIds: string[];
+  action: 'add' | 'move';
+  id: string;
   onClose: () => void;
   onDone: () => void;
 }
 
-function MovePicker({ selectedIds, onClose, onDone }: MovePickerProps) {
+function CollectionPicker({ selectedIds, action, id, onClose, onDone }: CollectionPickerProps) {
   const { toast } = useToast();
   const queryClient = useQueryClient();
+  const panelRef = useRef<HTMLDivElement>(null);
+  const firstOptionRef = useRef<HTMLButtonElement>(null);
 
-  const { data } = useQuery({
+  const { data, isLoading, isError, refetch } = useQuery({
     queryKey: ['collections'],
     queryFn: () => getCollections().then((response) => response.data),
   });
 
   const collections: CollectionDetail[] = data ?? [];
+  const isAdd = action === 'add';
 
-  const moveMutation = useMutation({
+  useEffect(() => {
+    if (!isLoading && collections.length > 0) firstOptionRef.current?.focus();
+    else panelRef.current?.focus();
+  }, [collections.length, isLoading]);
+
+  const collectionMutation = useMutation({
     mutationFn: (collectionId: string) =>
-      bulkCollection({ modelIds: selectedIds, action: 'move', collectionId }),
+      isAdd
+        ? addModelsToCollection(collectionId, selectedIds)
+        : bulkCollection({ modelIds: selectedIds, action: 'move', collectionId }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['collections'] });
+      queryClient.invalidateQueries({ queryKey: ['collection'] });
+      queryClient.invalidateQueries({ queryKey: ['collection-models'] });
+      queryClient.invalidateQueries({ queryKey: ['model'] });
       queryClient.invalidateQueries({ queryKey: ['models'] });
-      toast({ title: `Moved ${selectedIds.length} model${selectedIds.length === 1 ? '' : 's'}` });
+      queryClient.invalidateQueries({ queryKey: ['search'] });
+      queryClient.invalidateQueries({ queryKey: ['smart-collection'] });
+      queryClient.invalidateQueries({ queryKey: ['smart-collections'] });
+      queryClient.invalidateQueries({ queryKey: ['smart-preview'] });
+      toast({
+        title: isAdd
+          ? `Added ${selectedIds.length} model${selectedIds.length === 1 ? '' : 's'} to collection`
+          : `Moved ${selectedIds.length} model${selectedIds.length === 1 ? '' : 's'}`,
+      });
       onDone();
     },
     onError: () => {
-      toast({ title: 'Failed to move models', variant: 'destructive' });
+      toast({
+        title: isAdd ? 'Failed to add models to collection' : 'Failed to move models',
+        variant: 'destructive',
+      });
     },
   });
 
   return (
-    <div className="bg-popover text-popover-foreground border rounded-lg shadow-lg p-4 w-64 flex flex-col gap-3">
+    <div
+      ref={panelRef}
+      id={id}
+      role="dialog"
+      aria-label={isAdd ? 'Add models to collection' : 'Move models to collection'}
+      tabIndex={-1}
+      onKeyDown={(event) => {
+        if (event.key === 'Escape') {
+          event.preventDefault();
+          onClose();
+        }
+      }}
+      className="bg-popover text-popover-foreground border rounded-lg shadow-lg p-4 w-64 max-w-[calc(100vw-2rem)] flex flex-col gap-3 outline-none"
+    >
       <div className="flex items-center justify-between">
-        <span className="text-sm font-medium">Move to collection</span>
-        <button type="button" onClick={onClose} className="text-muted-foreground hover:text-foreground" aria-label="Close collection picker">
+        <span className="text-sm font-medium">
+          {isAdd ? 'Add to collection' : 'Move to collection'}
+        </span>
+        <button
+          type="button"
+          onClick={onClose}
+          className="text-muted-foreground hover:text-foreground"
+          aria-label={`Close ${isAdd ? 'add' : 'move'} collection picker`}
+        >
           <X className="h-4 w-4" />
         </button>
       </div>
       <p className="text-xs text-muted-foreground">
-        Existing collection memberships will be replaced.
+        {isAdd
+          ? 'Existing collection memberships will be kept.'
+          : 'Existing collection memberships will be replaced.'}
       </p>
-      {collections.length === 0 ? (
+
+      {isLoading && (
+        <div className="flex h-20 items-center justify-center gap-2 text-sm text-muted-foreground" role="status">
+          <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+          Loading collections…
+        </div>
+      )}
+      {!isLoading && isError && (
+        <div className="flex flex-col items-start gap-2 rounded-md border border-destructive/30 bg-destructive/5 p-2">
+          <p className="flex items-center gap-1.5 text-xs text-destructive">
+            <AlertCircle className="h-3.5 w-3.5" aria-hidden="true" />
+            Collections could not be loaded.
+          </p>
+          <Button type="button" size="sm" variant="outline" onClick={() => void refetch()}>
+            Try again
+          </Button>
+        </div>
+      )}
+      {!isLoading && !isError && collections.length === 0 ? (
         <p className="text-sm text-muted-foreground">No collections found.</p>
-      ) : (
+      ) : null}
+      {!isLoading && !isError && collections.length > 0 && (
         <ul className="flex flex-col gap-1 max-h-48 overflow-y-auto">
           {collections.map((col) => (
             <li key={col.id}>
               <button
+                ref={col === collections[0] ? firstOptionRef : undefined}
                 type="button"
                 className="w-full text-left rounded-md px-3 py-1.5 text-sm hover:bg-accent transition-colors"
-                onClick={() => moveMutation.mutate(col.id)}
-                disabled={moveMutation.isPending}
+                onClick={() => collectionMutation.mutate(col.id)}
+                disabled={collectionMutation.isPending}
+                aria-label={`${isAdd ? 'Add to' : 'Move to'} ${col.name}`}
               >
                 {col.name}
                 <span className="text-muted-foreground ml-1 text-xs">({col.modelCount})</span>
@@ -169,10 +238,18 @@ export function BulkActions({ selectedIds, onClear, onComplete }: BulkActionsPro
   const { toast } = useToast();
   const queryClient = useQueryClient();
   const count = selectedIds.size;
+  const addTriggerRef = useRef<HTMLButtonElement>(null);
+  const moveTriggerRef = useRef<HTMLButtonElement>(null);
 
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
-  const [showMovePicker, setShowMovePicker] = useState(false);
-  const [showTagPicker, setShowTagPicker] = useState(false);
+  const [activePicker, setActivePicker] = useState<'add' | 'move' | 'tag' | null>(null);
+
+  function closeCollectionPicker(action: 'add' | 'move') {
+    setActivePicker(null);
+    requestAnimationFrame(() => {
+      (action === 'add' ? addTriggerRef : moveTriggerRef).current?.focus();
+    });
+  }
 
   const deleteMutation = useMutation({
     mutationFn: () => bulkDelete({ modelIds: Array.from(selectedIds) }),
@@ -193,39 +270,54 @@ export function BulkActions({ selectedIds, onClear, onComplete }: BulkActionsPro
   return (
     <>
       <div
-        className="absolute bottom-6 left-1/2 -translate-x-1/2 z-40 flex items-center gap-3 bg-foreground text-background rounded-lg px-5 py-3 shadow-xl"
+        className="absolute bottom-6 left-1/2 z-40 flex w-max max-w-[calc(100%_-_2rem)] -translate-x-1/2 flex-wrap items-center justify-center gap-x-1 gap-y-1 rounded-lg bg-foreground px-3 py-2 text-background shadow-xl sm:gap-x-2 sm:px-4 sm:py-3"
         role="toolbar"
         aria-label="Bulk model actions"
       >
-        <span className="text-sm font-medium tabular-nums">
+        <span className="whitespace-nowrap px-1 text-sm font-medium tabular-nums">
           {count} {count === 1 ? 'model' : 'models'} selected
         </span>
 
-        <div className="h-4 w-px bg-background/20" />
+        <div className="hidden h-4 w-px bg-background/20 sm:block" />
 
-        {/* Move button */}
-        <div className="relative">
+        {/* Add-to-collection button */}
+        <div>
           <Button
+            ref={addTriggerRef}
             size="sm"
             variant="ghost"
             className="text-background hover:text-background hover:bg-black/10 dark:hover:bg-white/10"
             onClick={() => {
-              setShowTagPicker(false);
-              setShowMovePicker((open) => !open);
+              setActivePicker((current) => (current === 'add' ? null : 'add'));
             }}
+            aria-expanded={activePicker === 'add'}
+            aria-controls="bulk-add-collection-picker"
+            aria-haspopup="dialog"
+            aria-label="Add to collection"
+            title="Add to collection"
+          >
+            <FolderPlus className="h-4 w-4 mr-1.5" />
+            Add
+          </Button>
+        </div>
+
+        {/* Move button */}
+        <div className="relative">
+          <Button
+            ref={moveTriggerRef}
+            size="sm"
+            variant="ghost"
+            className="text-background hover:text-background hover:bg-black/10 dark:hover:bg-white/10"
+            onClick={() => {
+              setActivePicker((current) => (current === 'move' ? null : 'move'));
+            }}
+            aria-expanded={activePicker === 'move'}
+            aria-controls="bulk-move-collection-picker"
+            aria-haspopup="dialog"
           >
             <FolderInput className="h-4 w-4 mr-1.5" />
             Move
           </Button>
-          {showMovePicker && (
-            <div className="absolute bottom-full left-0 mb-2">
-              <MovePicker
-                selectedIds={Array.from(selectedIds)}
-                onClose={() => setShowMovePicker(false)}
-                onDone={onComplete}
-              />
-            </div>
-          )}
         </div>
 
         {/* Tag button */}
@@ -234,19 +326,16 @@ export function BulkActions({ selectedIds, onClear, onComplete }: BulkActionsPro
             size="sm"
             variant="ghost"
             className="text-background hover:text-background hover:bg-black/10 dark:hover:bg-white/10"
-            onClick={() => {
-              setShowMovePicker(false);
-              setShowTagPicker((open) => !open);
-            }}
+            onClick={() => setActivePicker((current) => (current === 'tag' ? null : 'tag'))}
           >
             <Tag className="h-4 w-4 mr-1.5" />
             Tag
           </Button>
-          {showTagPicker && (
+          {activePicker === 'tag' && (
             <div className="absolute bottom-full left-0 mb-2">
               <TagPicker
                 selectedIds={Array.from(selectedIds)}
-                onClose={() => setShowTagPicker(false)}
+                onClose={() => setActivePicker(null)}
                 onDone={onComplete}
               />
             </div>
@@ -264,7 +353,7 @@ export function BulkActions({ selectedIds, onClear, onComplete }: BulkActionsPro
           Delete
         </Button>
 
-        <div className="h-4 w-px bg-background/20" />
+        <div className="hidden h-4 w-px bg-background/20 sm:block" />
 
         {/* Clear selection */}
         <button
@@ -275,6 +364,19 @@ export function BulkActions({ selectedIds, onClear, onComplete }: BulkActionsPro
         >
           <X className="h-4 w-4" />
         </button>
+
+        {(activePicker === 'add' || activePicker === 'move') && (
+          <div className="absolute bottom-full left-1/2 mb-2 -translate-x-1/2">
+            <CollectionPicker
+              key={activePicker}
+              selectedIds={Array.from(selectedIds)}
+              action={activePicker}
+              id={`bulk-${activePicker}-collection-picker`}
+              onClose={() => closeCollectionPicker(activePicker)}
+              onDone={onComplete}
+            />
+          </div>
+        )}
       </div>
 
       {/* Delete confirmation */}

--- a/apps/frontend/src/components/models/CollectionsList.test.tsx
+++ b/apps/frontend/src/components/models/CollectionsList.test.tsx
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import type { CollectionDetail, CollectionSummary } from '@alexandria/shared';
+import { CollectionsList } from './CollectionsList';
+
+function makeCollection(
+  id: string,
+  name: string,
+  overrides: Partial<CollectionDetail> = {},
+): CollectionDetail {
+  return {
+    id,
+    name,
+    slug: name.toLowerCase().replaceAll(' ', '-'),
+    description: null,
+    parentCollectionId: null,
+    children: [],
+    modelCount: 0,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+const existingCollection: CollectionSummary = {
+  id: 'collection-existing',
+  name: 'Favorites',
+  slug: 'favorites',
+};
+const allCollections = [
+  makeCollection(existingCollection.id, existingCollection.name),
+  makeCollection('collection-print-queue', 'Print Queue'),
+  makeCollection('collection-weekend', 'Weekend Projects'),
+];
+
+const defaultProps = {
+  collections: [existingCollection],
+  allCollections,
+  isLoading: false,
+  isError: false,
+  isAdding: false,
+  onRetry: vi.fn(),
+  onAdd: vi.fn<(_collectionIds: string[]) => Promise<void>>(),
+};
+
+function renderList(overrides: Partial<React.ComponentProps<typeof CollectionsList>> = {}) {
+  return render(
+    <MemoryRouter>
+      <CollectionsList {...defaultProps} {...overrides} />
+    </MemoryRouter>,
+  );
+}
+
+describe('CollectionsList', () => {
+  it('should keep existing memberships checked and disabled while adding only new selections', async () => {
+    const onAdd = vi.fn<(_collectionIds: string[]) => Promise<void>>().mockResolvedValue(undefined);
+    renderList({ onAdd });
+
+    const existing = screen.getByRole('checkbox', { name: 'Favorites' });
+    expect(existing).toBeChecked();
+    expect(existing).toBeDisabled();
+    expect(screen.getByText('Already added')).toBeInTheDocument();
+    expect(screen.getByText('Existing memberships are kept.')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Print Queue' }));
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Weekend Projects' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Add to 2 collections' }));
+
+    await waitFor(() => {
+      expect(onAdd).toHaveBeenCalledWith([
+        'collection-print-queue',
+        'collection-weekend',
+      ]);
+    });
+    expect(onAdd).toHaveBeenCalledOnce();
+    expect(screen.getByRole('button', { name: 'Select collections' })).toBeDisabled();
+  });
+
+  it('should disable collection choices and submission while an add is pending', () => {
+    const { rerender } = renderList();
+
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Print Queue' }));
+
+    rerender(
+      <MemoryRouter>
+        <CollectionsList {...defaultProps} isAdding />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole('checkbox', { name: 'Print Queue' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Add to 1 collection' })).toBeDisabled();
+  });
+
+  it('should show an actionable error when adding to selected collections fails', async () => {
+    const onAdd = vi
+      .fn<(_collectionIds: string[]) => Promise<void>>()
+      .mockRejectedValue(new Error('request failed'));
+    renderList({ onAdd });
+
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Print Queue' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Add to 1 collection' }));
+
+    expect(
+      await screen.findByRole('alert'),
+    ).toHaveTextContent('The model could not be added to every selected collection. Try again.');
+  });
+
+  it('should offer a retry when collections cannot be loaded', () => {
+    const onRetry = vi.fn();
+    renderList({ isError: true, onRetry });
+
+    expect(screen.getByText('Collections could not be loaded.')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Try again' }));
+
+    expect(onRetry).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/frontend/src/components/models/CollectionsList.tsx
+++ b/apps/frontend/src/components/models/CollectionsList.tsx
@@ -1,14 +1,72 @@
+import * as React from 'react';
 import { Link } from 'react-router-dom';
-import { FolderOpen } from 'lucide-react';
-import type { CollectionSummary } from '@alexandria/shared';
+import { AlertCircle, Check, FolderOpen, Loader2, Plus } from 'lucide-react';
+import type { CollectionDetail, CollectionSummary } from '@alexandria/shared';
 import { useLibraryPath } from '../../hooks/use-libraries';
+import { Button } from '../ui/button';
+import { Checkbox } from '../ui/checkbox';
 
 interface CollectionsListProps {
   collections: CollectionSummary[];
+  allCollections: CollectionDetail[];
+  isLoading: boolean;
+  isError: boolean;
+  isAdding: boolean;
+  onRetry: () => void;
+  onAdd: (collectionIds: string[]) => Promise<void>;
 }
 
-export function CollectionsList({ collections }: CollectionsListProps) {
+export function CollectionsList({
+  collections,
+  allCollections,
+  isLoading,
+  isError,
+  isAdding,
+  onRetry,
+  onAdd,
+}: CollectionsListProps) {
   const libPath = useLibraryPath();
+  const [selectedIds, setSelectedIds] = React.useState<Set<string>>(new Set());
+  const [submitError, setSubmitError] = React.useState(false);
+  const existingIds = React.useMemo(
+    () => new Set(collections.map((collection) => collection.id)),
+    [collections],
+  );
+  const sortedCollections = React.useMemo(
+    () => [...allCollections].sort((a, b) => a.name.localeCompare(b.name)),
+    [allCollections],
+  );
+
+  React.useEffect(() => {
+    setSelectedIds((current) => {
+      const next = new Set(
+        [...current].filter((id) => !existingIds.has(id) && allCollections.some((item) => item.id === id)),
+      );
+      return next.size === current.size ? current : next;
+    });
+  }, [allCollections, existingIds]);
+
+  function toggleCollection(id: string, checked: boolean) {
+    setSubmitError(false);
+    setSelectedIds((current) => {
+      const next = new Set(current);
+      if (checked) next.add(id);
+      else next.delete(id);
+      return next;
+    });
+  }
+
+  async function addSelectedCollections() {
+    if (selectedIds.size === 0) return;
+    setSubmitError(false);
+    try {
+      await onAdd([...selectedIds]);
+      setSelectedIds(new Set());
+    } catch {
+      setSubmitError(true);
+    }
+  }
+
   return (
     <div className="rounded-xl border border-border bg-card overflow-hidden">
       <div className="flex items-center justify-between px-4 py-3 border-b border-border bg-muted/30">
@@ -18,7 +76,7 @@ export function CollectionsList({ collections }: CollectionsListProps) {
 
       <div className="px-4 py-3">
         {collections.length === 0 ? (
-          <p className="text-sm text-muted-foreground">Not in any collection.</p>
+          <p className="text-sm text-muted-foreground">Not in any collection yet.</p>
         ) : (
           <ul className="flex flex-col gap-1">
             {collections.map((col) => (
@@ -33,6 +91,95 @@ export function CollectionsList({ collections }: CollectionsListProps) {
               </li>
             ))}
           </ul>
+        )}
+      </div>
+
+      <div className="border-t border-border bg-muted/15 px-4 py-3">
+        <div className="mb-3 flex items-start justify-between gap-3">
+          <div>
+            <h3 className="text-sm font-semibold text-foreground">Add to collections</h3>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              Existing memberships are kept.
+            </p>
+          </div>
+          <Plus className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+        </div>
+
+        {isLoading && (
+          <div
+            className="flex min-h-20 items-center justify-center gap-2 text-sm text-muted-foreground"
+            role="status"
+          >
+            <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+            Loading collections…
+          </div>
+        )}
+
+        {!isLoading && isError && (
+          <div className="flex flex-col items-start gap-2 rounded-lg border border-destructive/30 bg-destructive/5 p-3">
+            <p className="flex items-center gap-2 text-sm text-destructive">
+              <AlertCircle className="h-4 w-4" aria-hidden="true" />
+              Collections could not be loaded.
+            </p>
+            <Button type="button" size="sm" variant="outline" onClick={onRetry}>
+              Try again
+            </Button>
+          </div>
+        )}
+
+        {!isLoading && !isError && sortedCollections.length === 0 && (
+          <p className="text-sm text-muted-foreground">No collections are available yet.</p>
+        )}
+
+        {!isLoading && !isError && sortedCollections.length > 0 && (
+          <>
+            <fieldset disabled={isAdding} aria-label="Collections to add">
+              <ul className="max-h-56 space-y-1 overflow-y-auto pr-1">
+                {sortedCollections.map((collection) => {
+                  const isExisting = existingIds.has(collection.id);
+                  return (
+                    <li
+                      key={collection.id}
+                      className="flex min-h-9 items-center justify-between gap-3 rounded-lg px-2 py-1.5 hover:bg-accent/50"
+                    >
+                      <Checkbox
+                        id={`model-collection-${collection.id}`}
+                        label={collection.name}
+                        checked={isExisting || selectedIds.has(collection.id)}
+                        disabled={isExisting || isAdding}
+                        onChange={(event) => toggleCollection(collection.id, event.currentTarget.checked)}
+                      />
+                      {isExisting && (
+                        <span className="flex shrink-0 items-center gap-1 text-[11px] font-medium text-muted-foreground">
+                          <Check className="h-3 w-3" aria-hidden="true" />
+                          Already added
+                        </span>
+                      )}
+                    </li>
+                  );
+                })}
+              </ul>
+            </fieldset>
+
+            {submitError && (
+              <p className="mt-2 text-xs text-destructive" role="alert">
+                The model could not be added to every selected collection. Try again.
+              </p>
+            )}
+
+            <Button
+              type="button"
+              size="sm"
+              className="mt-3 w-full gap-2"
+              disabled={selectedIds.size === 0 || isAdding}
+              onClick={addSelectedCollections}
+            >
+              {isAdding && <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />}
+              {selectedIds.size === 0
+                ? 'Select collections'
+                : `Add to ${selectedIds.size} collection${selectedIds.size === 1 ? '' : 's'}`}
+            </Button>
+          </>
         )}
       </div>
     </div>

--- a/apps/frontend/src/components/models/ModelDetailPanel.tsx
+++ b/apps/frontend/src/components/models/ModelDetailPanel.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import type { ModelDetail, FileTreeNode } from '@alexandria/shared';
+import type { CollectionDetail, ModelDetail, FileTreeNode } from '@alexandria/shared';
 import { ModelInfo } from './ModelInfo';
 import { MetadataPanel } from './MetadataPanel';
 import { CollectionsList } from './CollectionsList';
@@ -33,6 +33,12 @@ interface ModelDetailPanelProps {
   onRenameFolder?: (path: string, name: string) => void;
   onMoveFolder?: (path: string, parentPath: string) => Promise<void>;
   onDeleteFolder?: (path: string, name: string) => void;
+  allCollections: CollectionDetail[];
+  collectionsLoading: boolean;
+  collectionsError: boolean;
+  collectionAddPending: boolean;
+  onRetryCollections: () => void;
+  onAddToCollections: (collectionIds: string[]) => Promise<void>;
 }
 
 /**
@@ -58,6 +64,12 @@ export function ModelDetailPanel({
   onRenameFolder,
   onMoveFolder,
   onDeleteFolder,
+  allCollections,
+  collectionsLoading,
+  collectionsError,
+  collectionAddPending,
+  onRetryCollections,
+  onAddToCollections,
 }: ModelDetailPanelProps) {
   const [tab, setTab] = React.useState<PanelTabValue>('info');
 
@@ -83,7 +95,17 @@ export function ModelDetailPanel({
         </div>
       )}
 
-      {tab === 'collections' && <CollectionsList collections={model.collections} />}
+      {tab === 'collections' && (
+        <CollectionsList
+          collections={model.collections}
+          allCollections={allCollections}
+          isLoading={collectionsLoading}
+          isError={collectionsError}
+          isAdding={collectionAddPending}
+          onRetry={onRetryCollections}
+          onAdd={onAddToCollections}
+        />
+      )}
 
       {tab === 'files' && (
         <FileTree

--- a/apps/frontend/src/pages/ModelDetailPage.test.tsx
+++ b/apps/frontend/src/pages/ModelDetailPage.test.tsx
@@ -1,0 +1,180 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import type { ModelDetail } from '@alexandria/shared';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ModelDetailPage } from './ModelDetailPage';
+
+const mocks = vi.hoisted(() => ({
+  toast: vi.fn(),
+}));
+
+vi.mock('../hooks/use-toast', () => ({
+  useToast: () => ({ toast: mocks.toast }),
+}));
+
+vi.mock('../api/collections', () => ({
+  addModelsToCollection: vi.fn(),
+  getCollections: vi.fn(),
+}));
+
+vi.mock('../api/models', () => ({
+  createModelFolder: vi.fn(),
+  deleteModelFile: vi.fn(),
+  deleteModelFolder: vi.fn(),
+  extractModelArchive: vi.fn(),
+  getModel: vi.fn(),
+  getModelFiles: vi.fn(),
+  getModels: vi.fn(),
+  mergeModels: vi.fn(),
+  updateModelFile: vi.fn(),
+  updateModelFolder: vi.fn(),
+  uploadModelFiles: vi.fn(),
+}));
+
+vi.mock('../components/models/ModelHero', () => ({
+  ModelHero: () => <div>Model hero</div>,
+}));
+
+vi.mock('../components/models/ModelBreadcrumb', () => ({
+  ModelBreadcrumb: () => <div>Model breadcrumb</div>,
+}));
+
+vi.mock('../components/models/ModelViewer3DModal', () => ({
+  ModelViewer3DModal: () => null,
+}));
+
+vi.mock('../components/models/TextFilePreviewModal', () => ({
+  TextFilePreviewModal: () => null,
+}));
+
+vi.mock('../components/models/ModelDetailSkeleton', () => ({
+  ModelDetailSkeleton: () => <div>Loading model</div>,
+}));
+
+interface DetailPanelTestProps {
+  collectionAddPending: boolean;
+  onAddToCollections: (collectionIds: string[]) => Promise<void>;
+}
+
+vi.mock('../components/models/ModelDetailPanel', () => ({
+  ModelDetailPanel: ({ collectionAddPending, onAddToCollections }: DetailPanelTestProps) => (
+    <button
+      type="button"
+      disabled={collectionAddPending}
+      onClick={() => {
+        void onAddToCollections(['collection-fails', 'collection-delayed']).catch(() => undefined);
+      }}
+    >
+      {collectionAddPending ? 'Adding collections' : 'Add collections'}
+    </button>
+  ),
+}));
+
+import { addModelsToCollection, getCollections } from '../api/collections';
+import { getModel, getModelFiles } from '../api/models';
+
+const model: ModelDetail = {
+  id: 'model-1',
+  name: 'Benchy',
+  slug: 'benchy',
+  description: null,
+  thumbnailUrl: null,
+  previewImageFileId: null,
+  previewCropX: null,
+  previewCropY: null,
+  previewCropScale: null,
+  metadata: [],
+  sourceType: 'manual',
+  originalFilename: null,
+  fileCount: 0,
+  totalSizeBytes: 0,
+  status: 'ready',
+  collections: [],
+  images: [],
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+};
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+  return { promise, resolve };
+}
+
+function renderPage(queryClient: QueryClient) {
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={['/models/model-1']}>
+        <Routes>
+          <Route path="/models/:id" element={<ModelDetailPage />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe('ModelDetailPage collection membership', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getModel).mockResolvedValue(model);
+    vi.mocked(getModelFiles).mockResolvedValue([]);
+    vi.mocked(getCollections).mockResolvedValue({ data: [], meta: null, errors: null });
+  });
+
+  it('should wait for every collection request before reporting a partial failure and invalidating caches', async () => {
+    const delayedRequest = deferred<void>();
+    vi.mocked(addModelsToCollection)
+      .mockRejectedValueOnce(new Error('first request failed'))
+      .mockReturnValueOnce(delayedRequest.promise);
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries');
+    renderPage(queryClient);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Add collections' }));
+
+    await waitFor(() => {
+      expect(addModelsToCollection).toHaveBeenNthCalledWith(
+        1,
+        'collection-fails',
+        ['model-1'],
+      );
+      expect(addModelsToCollection).toHaveBeenNthCalledWith(
+        2,
+        'collection-delayed',
+        ['model-1'],
+      );
+      expect(screen.getByRole('button', { name: 'Adding collections' })).toBeDisabled();
+    });
+    expect(mocks.toast).not.toHaveBeenCalled();
+    expect(invalidateQueries).not.toHaveBeenCalled();
+
+    delayedRequest.resolve();
+
+    await waitFor(() => {
+      expect(mocks.toast).toHaveBeenCalledWith({
+        title: 'Could not add to collections',
+        description: '1 of 2 collection updates failed.',
+        variant: 'destructive',
+      });
+    });
+
+    for (const queryKey of [
+      ['model', 'model-1'],
+      ['models'],
+      ['collections'],
+      ['collection'],
+      ['collection-models'],
+      ['search'],
+      ['smart-collection'],
+      ['smart-collections'],
+      ['smart-preview'],
+    ]) {
+      expect(invalidateQueries).toHaveBeenCalledWith({ queryKey });
+    }
+  });
+});

--- a/apps/frontend/src/pages/ModelDetailPage.tsx
+++ b/apps/frontend/src/pages/ModelDetailPage.tsx
@@ -3,6 +3,7 @@ import { useParams, Link } from 'react-router-dom';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { ChevronLeft, AlertTriangle, Download, GitMerge, Loader2, Upload, X } from 'lucide-react';
 import type { ModelCard, ModelDetail } from '@alexandria/shared';
+import { addModelsToCollection, getCollections } from '../api/collections';
 import {
   createModelFolder,
   deleteModelFile,
@@ -88,6 +89,52 @@ export function ModelDetailPage() {
     queryKey: ['model-files', id],
     queryFn: () => getModelFiles(id!),
     enabled: Boolean(id),
+  });
+
+  const collectionsQuery = useQuery({
+    queryKey: ['collections'],
+    queryFn: () => getCollections().then((response) => response.data),
+    enabled: Boolean(model),
+  });
+
+  const addToCollectionsMutation = useMutation({
+    mutationFn: async (collectionIds: string[]) => {
+      if (!id) throw new Error('Model id is required');
+      const results = await Promise.allSettled(
+        collectionIds.map((collectionId) => addModelsToCollection(collectionId, [id])),
+      );
+      const failureCount = results.filter((result) => result.status === 'rejected').length;
+      if (failureCount > 0) {
+        throw new Error(
+          `${failureCount} of ${collectionIds.length} collection update${collectionIds.length === 1 ? '' : 's'} failed.`,
+        );
+      }
+    },
+    onSuccess: (_, collectionIds) => {
+      toast({
+        title: `Added to ${collectionIds.length} collection${collectionIds.length === 1 ? '' : 's'}`,
+      });
+    },
+    onError: (error) => {
+      toast({
+        title: 'Could not add to collections',
+        description: error instanceof Error ? error.message : undefined,
+        variant: 'destructive',
+      });
+    },
+    onSettled: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['model', id] }),
+        queryClient.invalidateQueries({ queryKey: ['models'] }),
+        queryClient.invalidateQueries({ queryKey: ['collections'] }),
+        queryClient.invalidateQueries({ queryKey: ['collection'] }),
+        queryClient.invalidateQueries({ queryKey: ['collection-models'] }),
+        queryClient.invalidateQueries({ queryKey: ['search'] }),
+        queryClient.invalidateQueries({ queryKey: ['smart-collection'] }),
+        queryClient.invalidateQueries({ queryKey: ['smart-collections'] }),
+        queryClient.invalidateQueries({ queryKey: ['smart-preview'] }),
+      ]);
+    },
   });
 
   const isLoading = modelLoading || filesLoading;
@@ -308,6 +355,14 @@ export function ModelDetailPage() {
               onRenameFolder={(path, name) => fileMutation.mutate({ type: 'rename-folder', path, name })}
               onMoveFolder={(path, parentPath) => runFileAction({ type: 'move-folder', path, parentPath })}
               onDeleteFolder={(path, name) => fileMutation.mutate({ type: 'delete-folder', path, name })}
+              allCollections={collectionsQuery.data ?? []}
+              collectionsLoading={collectionsQuery.isLoading}
+              collectionsError={collectionsQuery.isError}
+              collectionAddPending={addToCollectionsMutation.isPending}
+              onRetryCollections={() => void collectionsQuery.refetch()}
+              onAddToCollections={(collectionIds) =>
+                addToCollectionsMutation.mutateAsync(collectionIds).then(() => undefined)
+              }
             />
           </div>
         </div>

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -478,6 +478,8 @@ The Model Detail page (`pages/ModelDetailPage.tsx`) was fully redesigned in P2. 
 
 `components/models/ModelDetailPanel.tsx` is the tabbed right panel. `components/models/PanelTabs.tsx` is the generic full-width segmented control it uses. `PanelTabs` is typed with a string union for tab values and accepts icon components typed as `React.ComponentType<{ className?: string }>` (see the gotcha note in the Conventions doc).
 
+The Collections tab lists the model's current manual-collection memberships and can add the model to one or more additional collections without removing existing memberships. The browse bulk-action bar makes the same distinction explicit: **Add to collection** preserves existing memberships, while **Move** replaces them.
+
 ### 3D Viewer
 
 The 3D viewer is an in-browser STL renderer built on `three` + `@react-three/fiber` + `@react-three/drei`. It is composed of two layers:
@@ -606,7 +608,7 @@ All provider routes apply `requireAuth` and enforce provider ownership in `AiPro
 | Method | Route | Purpose | Service Chain |
 |--------|-------|---------|---------------|
 | POST | /bulk/metadata | Metadata changes on multiple models | MetadataService |
-| POST | /bulk/collection | Add/remove models from collections | CollectionService |
+| POST | /bulk/collection | Add/remove models or move them by replacing all existing collection memberships | CollectionService |
 | POST | /bulk/delete | Delete multiple models | ModelService → StorageService |
 
 ---

--- a/docs/TYPES.md
+++ b/docs/TYPES.md
@@ -936,7 +936,7 @@ interface BulkMetadataOperation {
 
 interface BulkCollectionRequest {
   modelIds: string[];
-  action: 'add' | 'remove';
+  action: 'add' | 'remove' | 'move'; // move replaces every existing collection membership
   collectionId: string;
 }
 


### PR DESCRIPTION
## What changed

- add a multi-select collection membership control to the model detail Collections tab
- show existing memberships as checked and unavailable for duplicate selection
- add an additive **Add** action to the bulk toolbar while preserving the existing destructive **Move** behavior
- make the bulk picker responsive and keyboard accessible
- invalidate model, collection, search, and smart-collection caches after membership changes
- document additive versus replacement collection semantics

## Why

Models already support many-to-many collection membership, but the UI only exposed moving models, which replaced their existing memberships. This surfaces the existing additive API in both single-model and bulk workflows.

## Validation

- `npm test` — 40 backend test files / 671 tests and 39 frontend test files / 282 tests passed
- `npm run build -w @alexandria/frontend`
- reviewer re-review: no remaining actionable findings
- `git diff --check`
