### PR TITLE
feat: add progress display to the telegram importer

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -118,7 +118,10 @@ database or storage adapter directly. Complete archives use the normal chunked u
 ZIP/RAR sets use multipart `split` mode, and preceding Telegram media is appended to the staged
 session before commit. The utility owns its SQLite restart and duplicate state and short-lived local
 downloads; Alexandria continues to own all committed files through its configured local or S3
-storage backend.
+storage backend. On an interactive terminal it renders a live progress dashboard on stderr — the
+reason it carries `rich`, its only presentation dependency — and falls back to periodic log lines
+when output is captured. That display is strictly observational: it is injected into the importer
+and cannot alter, delay, or fail an import.
 
 Duplicate detection is local to the utility's state database and has two layers. Before download, a
 signature over the complete logical model's Telegram document/photo IDs and reported sizes

--- a/docs/superpowers/specs/2026-07-25-telegram-importer-progress-design.md
+++ b/docs/superpowers/specs/2026-07-25-telegram-importer-progress-design.md
@@ -62,8 +62,8 @@ class ProgressReporter(Protocol):
     def totals(self, done: int, total: int, counts: dict[str, int]) -> None: ...
 ```
 
-`kind` is `"download"` or `"upload"`. `phase` names are `"scanning"`, `"committing"`,
-`"attachments"`.
+`kind` is `"download"` or `"upload"`. `phase` names are `"hashing"`, `"packaging"`,
+`"scanning"`, `"committing"`, `"attachments"`, and the neutral `"working"`.
 
 Three implementations:
 
@@ -86,13 +86,19 @@ parameter is optional and defaults to the no-op, so no existing construction sit
 changes.
 
 - `run` computes `total_units` (already does) and calls `progress.totals` once before
-  dispatch, then after each unit settles.
-- `_process_unit` wraps its body in `with self.progress.model(unit.logical_filename,
-  parts=len(unit.parts)) as handle:` and threads `handle` into `_resume_or_import` and
-  `_start_session`.
+  dispatch, then after each unit settles. The tally counts this run only, rather than
+  reusing `tracker.counts()`, whose rows span every run against the same state file — a
+  resumed import would otherwise open at 100%.
+- `_process_unit` wraps its body in `with guarded_model(self.progress,
+  unit.logical_filename, parts=len(unit.parts)) as handle:` and threads `handle` into
+  `_resume_or_import` and `_start_session`. It settles the outcome that `_import_unit`
+  returns.
 - `_start_session` opens a `handle.transfer("download", part.filename)` around each
   `telegram.download`, and a `handle.transfer("upload", upload_name)` around each
-  `alexandria.upload_file`.
+  `alexandria.upload_file`. Between those it reports the `hashing` and `packaging` phases,
+  which are minutes of real work on a large model and would otherwise leave the row showing
+  a stale transfer label. Leaving a `transfer` context reverts the row to a neutral
+  `working` phase for the same reason.
 - `_resume_or_import` calls `handle.phase("scanning")` before the `ready_for_review` wait
   and `handle.phase("committing")` before the `committed` wait, and updates
   `handle.attachments(done, total)` in the attachment loop.
@@ -100,9 +106,11 @@ changes.
 ### Transport hooks
 
 - `TelegramSource.download(ref, directory, *, on_progress=None)` — forwarded to Telethon's
-  `progress_callback`, which is already called on the event loop. Retries reset the
-  transfer: on `FloodWaitError` the handle is told to restart at zero so the bar does not
-  appear to jump backwards.
+  `progress_callback`, which is already called on the event loop. A retried download
+  restarts Telethon's byte count at zero; because `advance` takes absolute bytes, the
+  handles detect the rewind themselves and rebase their rate clock, so the retry's
+  `FloodWaitError` sleep is not charged against its throughput. No explicit `restart()`
+  call is needed on the transport side.
 - `AlexandriaClient.upload_file(path, upload_name, *, multipart, on_progress=None)` —
   passed through to `_upload_part`, which calls it with cumulative bytes after each 10 MB
   chunk PUT succeeds. Chunk retries do not double-count, because the callback fires after
@@ -112,21 +120,21 @@ Both parameters default to `None`, keeping the transports usable without a repor
 
 ## Rendering
 
-Dependency: `rich>=13.0` added to `[project].dependencies`. Pure Python, one transitive
-dependency (`markdown-it-py`). It is the only mainstream option that composes an overall
+Dependency: `rich>=13.0` added to `[project].dependencies`. Pure Python; it pulls
+`markdown-it-py`, `mdurl`, and `pygments`. It is the only mainstream option that composes an overall
 bar, per-worker bars, and indeterminate spinners in one live region with clean logging
 interleave. `tqdm` can stack bars but offers no phase/spinner composition.
 
-`RichDashboard` holds a single `Live` wrapping a `Group` of:
+`RichDashboard` is itself the `Live` renderable: its `__rich__` builds a `Group` of
 
-1. a total `Progress` with one task — bar, `47/143 models`, elapsed;
-2. a `Text` summary line rendered from `tracker.counts()`;
-3. a worker `Progress` — one task per active model, with `DownloadColumn` and
-   `TransferSpeedColumn` for transfers, swapped to a spinner and elapsed for
-   `scanning`/`committing`.
+1. a `Table.grid` header — a `ProgressBar` and `47/143 models`;
+2. a `Text` summary line rendered from this run's outcome tally;
+3. a `Table.grid` of worker rows, each a `ProgressBar` for transfers or a `Spinner` with
+   elapsed time for the waiting phases.
 
-Two `Progress` instances rather than one, because the total bar and worker rows need
-different column sets.
+`rich.progress.Progress` is deliberately not used. Its task model renders one fixed column
+set for every task, which cannot express rows that alternate between a byte bar and a
+spinner; composing the grids directly is both shorter and exact.
 
 All output goes to `Console(stderr=True)`. `stdout` stays clean for `describe_plan`'s
 dry-run output and the final `Import state:` line, so `--dry-run > plan.txt` is unchanged.
@@ -143,6 +151,18 @@ jump a line mid-transfer.
 
 Refresh is capped at 10 Hz. Telethon fires its callback far more often than that; rich's
 own refresh throttling absorbs it.
+
+`Live` refreshes from its own thread, so `__rich__` runs off the event loop while the
+import is adding and removing rows. The renderer takes one `list()` snapshot of the row
+values — atomic under the GIL — rather than iterating the live dict, which could raise and
+kill the refresh thread for the rest of the run. `redirect_stdout=False` keeps `Live` from
+routing standard output through the live region.
+
+`__enter__` installs the live region and then the log handler; `__exit__` reverses that
+order, because a restored handler holds the pre-redirect stream and would otherwise write
+straight through an active region. Both the live region and the handler swap unwind
+themselves if anything raises part-way, including a `KeyboardInterrupt` between removing
+the old handlers and installing the new one.
 
 ## Non-TTY fallback
 
@@ -187,10 +207,17 @@ regression.
 
 ## Error handling
 
-- The dashboard must never break an import. Every reporter call site is best-effort: the
-  `model` context manager releases its slot in a `finally`, and `RichDashboard` guards
-  `Live.start`/`stop` so a terminal that rejects the live region falls back to
-  `LogProgress` rather than aborting the run.
+- The dashboard must never break an import. Two helpers in `progress.py` enforce this at
+  the call sites: `guarded_reporter` wraps the reporter's own start/stop, and
+  `guarded_model` wraps each model row, degrading to `NullModelProgress` if the reporter
+  cannot open one. `ChannelImporter._report_totals` swallows reporter faults the same way.
+  `RichDashboard` additionally guards `Live.start`/`stop`, stopping a partially started
+  region before falling back to `LogProgress`.
+- `_settle` is called from `_process_unit`, outside `_import_unit`'s own `try`/`except`.
+  `_import_unit` returns the outcome it settled on rather than settling itself. Otherwise a
+  reporter fault raised while recording a completed model would be caught by that same
+  `except Exception`, overwriting a completed row in the state file with `failed` and
+  counting the model twice.
 - A transfer that raises mid-flight leaves its `transfer` context via `finally`, removing
   the row. The failure is reported by the existing `except Exception` handler in
   `_process_unit`.
@@ -217,8 +244,10 @@ Extensions to existing tests:
 - `test_alexandria.py` — `upload_file` invokes `on_progress` once per chunk with
   cumulative byte counts, and does not double-count across a chunk retry.
 - `test_importer.py` — a recording fake reporter asserts the phase sequence for one model
-  (`download` → `upload` → `scanning` → `committing`) and that `totals` is called after
-  each unit settles.
+  (`download` → `hashing` → `upload` → `scanning` → `committing`, with `packaging` added for
+  a bare model file) and that `totals` is called after each unit settles. Further cases
+  drive a reporter that raises from `totals`, from `model`, and from `__enter__`, and assert
+  the import still completes and settles once.
 
 `RichDashboard` is a thin adapter over rich; it gets a smoke test that constructs it with
 `Console(file=StringIO(), force_terminal=True)`, drives one model through every phase, and

--- a/docs/superpowers/specs/2026-07-25-telegram-importer-progress-design.md
+++ b/docs/superpowers/specs/2026-07-25-telegram-importer-progress-design.md
@@ -1,0 +1,232 @@
+# Telegram importer progress display — design
+
+Date: 2026-07-25
+Component: `tools/telegram-importer`
+
+## Problem
+
+The importer reports work only through `logging` at INFO level. A single model can be
+close to a gigabyte, so `Downloaded Telegram message 4821 to …` appears minutes after
+`Importing dragon-bust.zip`, with nothing in between. On a channel of a hundred-plus
+models the operator cannot tell throughput, remaining work, or whether a transfer has
+stalled.
+
+`--concurrency N` compounds this: up to N models are in flight, and their log lines
+interleave with no indication of how many are active or what each is doing.
+
+## Goal
+
+A live terminal dashboard showing overall progress, a live outcome tally, and one row per
+concurrent worker with its current phase and transfer rate. Degrade to periodic log lines
+when stderr is not a terminal.
+
+## Non-goals
+
+- Byte-level progress for attachment uploads. `append_files` hands whole files to httpx;
+  attachments get a file counter instead.
+- Progress for Alexandria-side scanning. The importer only polls; an elapsed-time spinner
+  is the honest representation.
+- Changing any import, grouping, dedupe, or recovery behavior.
+
+## Target output
+
+```
+2026-07-25 04:12:03 INFO Importing dragon-bust.zip
+2026-07-25 04:12:31 INFO Imported castle-set.7z as Alexandria model 0f3a…
+
+  Total   ━━━━━━━━━━━━━━━━━╸━━━━━━━━━━  47/143 models  0:12:31
+  44 completed · 2 duplicates · 1 failed
+
+  #1 dragon-bust.zip     upload    ━━━━━━━━━━━╸━━━  412/920 MB  8.1 MB/s
+  #2 castle-set.7z.002   download  ━━━━╸━━━━━━━━━━  180/700 MB  4.4 MB/s
+  #3 knight-armor.stl    scanning  ⠹  waiting on Alexandria  0:00:44
+```
+
+Log lines scroll above the live region; the block stays pinned at the bottom.
+
+## Architecture
+
+New module `src/alexandria_telegram_importer/progress.py`.
+
+```python
+class TransferHandle(Protocol):
+    def advance(self, received: int, total: int) -> None: ...
+
+class ModelProgress(Protocol):
+    def phase(self, name: str) -> None: ...
+    def transfer(self, kind: str, label: str) -> ContextManager[TransferHandle]: ...
+    def attachments(self, done: int, total: int) -> None: ...
+
+class ProgressReporter(Protocol):
+    def model(self, label: str, *, parts: int) -> ContextManager[ModelProgress]: ...
+    def totals(self, done: int, total: int, counts: dict[str, int]) -> None: ...
+```
+
+`kind` is `"download"` or `"upload"`. `phase` names are `"scanning"`, `"committing"`,
+`"attachments"`.
+
+Three implementations:
+
+- `NullProgress` — every method a no-op. The default, so existing callers and tests are
+  unaffected.
+- `LogProgress` — emits throttled `log.info` lines. No terminal control sequences.
+- `RichDashboard` — the live region described above.
+
+Rationale for explicit injection over an ambient contextvar or an event queue: the module
+already wires collaborators through constructor injection (`ChannelImporter` takes
+`telegram`, `alexandria`, `tracker`), and its tests substitute fakes at those seams. A
+contextvar would put implicit global state in the middle of the concurrent path; an event
+queue would add a second concurrency mechanism (backpressure, shutdown ordering,
+drain-on-exception) for a display feature.
+
+### Wiring
+
+`ChannelImporter.__init__` gains `progress: ProgressReporter = NullProgress()`. The
+parameter is optional and defaults to the no-op, so no existing construction site or test
+changes.
+
+- `run` computes `total_units` (already does) and calls `progress.totals` once before
+  dispatch, then after each unit settles.
+- `_process_unit` wraps its body in `with self.progress.model(unit.logical_filename,
+  parts=len(unit.parts)) as handle:` and threads `handle` into `_resume_or_import` and
+  `_start_session`.
+- `_start_session` opens a `handle.transfer("download", part.filename)` around each
+  `telegram.download`, and a `handle.transfer("upload", upload_name)` around each
+  `alexandria.upload_file`.
+- `_resume_or_import` calls `handle.phase("scanning")` before the `ready_for_review` wait
+  and `handle.phase("committing")` before the `committed` wait, and updates
+  `handle.attachments(done, total)` in the attachment loop.
+
+### Transport hooks
+
+- `TelegramSource.download(ref, directory, *, on_progress=None)` — forwarded to Telethon's
+  `progress_callback`, which is already called on the event loop. Retries reset the
+  transfer: on `FloodWaitError` the handle is told to restart at zero so the bar does not
+  appear to jump backwards.
+- `AlexandriaClient.upload_file(path, upload_name, *, multipart, on_progress=None)` —
+  passed through to `_upload_part`, which calls it with cumulative bytes after each 10 MB
+  chunk PUT succeeds. Chunk retries do not double-count, because the callback fires after
+  the successful PUT, not per attempt.
+
+Both parameters default to `None`, keeping the transports usable without a reporter.
+
+## Rendering
+
+Dependency: `rich>=13.0` added to `[project].dependencies`. Pure Python, one transitive
+dependency (`markdown-it-py`). It is the only mainstream option that composes an overall
+bar, per-worker bars, and indeterminate spinners in one live region with clean logging
+interleave. `tqdm` can stack bars but offers no phase/spinner composition.
+
+`RichDashboard` holds a single `Live` wrapping a `Group` of:
+
+1. a total `Progress` with one task — bar, `47/143 models`, elapsed;
+2. a `Text` summary line rendered from `tracker.counts()`;
+3. a worker `Progress` — one task per active model, with `DownloadColumn` and
+   `TransferSpeedColumn` for transfers, swapped to a spinner and elapsed for
+   `scanning`/`committing`.
+
+Two `Progress` instances rather than one, because the total bar and worker rows need
+different column sets.
+
+All output goes to `Console(stderr=True)`. `stdout` stays clean for `describe_plan`'s
+dry-run output and the final `Import state:` line, so `--dry-run > plan.txt` is unchanged.
+
+Log interleaving uses a `logging.Handler` subclass whose `emit` calls
+`console.print(self.format(record), markup=False, highlight=False)`. This preserves the
+existing `%(asctime)s %(levelname)s %(message)s` format exactly — `RichHandler` is not
+used, because it would reformat every log line. The handler replaces the default stream
+handler for the duration of the dashboard and is removed on exit.
+
+Worker rows are assigned the lowest free slot number when a model starts and release it
+when the model settles; rows sort by slot number so a finishing `#2` does not make `#3`
+jump a line mid-transfer.
+
+Refresh is capped at 10 Hz. Telethon fires its callback far more often than that; rich's
+own refresh throttling absorbs it.
+
+## Non-TTY fallback
+
+`LogProgress` emits at most one line per transfer per 10 seconds, plus a guaranteed final
+line at completion:
+
+```
+2026-07-25 04:12:31 INFO dragon-bust.zip download 45% (412/920 MB, 8.1 MB/s)
+2026-07-25 04:12:41 INFO dragon-bust.zip download 78% (718/920 MB, 8.4 MB/s)
+2026-07-25 04:12:48 INFO dragon-bust.zip download 100% (920/920 MB, 8.2 MB/s)
+```
+
+Throttling is per transfer, not global, so `--concurrency 3` produces three interleaved
+streams — consistent with how concurrent logs already read. The throttle clock is injected
+so tests do not sleep.
+
+`LogProgress` also logs the total line each time a model settles:
+`Progress: 47/143 models (44 completed, 2 duplicates, 1 failed)`.
+
+## Selection
+
+New CLI flag `--no-progress`, backed by `TELEGRAM_IMPORT_NO_PROGRESS=1`.
+
+| Condition (first match wins) | Reporter |
+|---|---|
+| `--no-progress` or `TELEGRAM_IMPORT_NO_PROGRESS=1` | `NullProgress` |
+| `--dry-run` | `NullProgress` |
+| `--verbose` | `LogProgress` |
+| `sys.stderr.isatty()` | `RichDashboard` |
+| otherwise | `LogProgress` |
+
+`--verbose` selects `LogProgress` rather than the dashboard because debug-level output
+would contend with the live region.
+
+Selection lives in a pure function `select_reporter(*, no_progress, dry_run, verbose,
+is_tty)` so it is testable without a terminal.
+
+Existing `log.info("Downloaded Telegram message %d to %s")` and
+`log.info("Uploading %s (%d bytes)")` are left unchanged. They are mildly redundant under
+the dashboard, but leaving them makes `--no-progress` a genuine no-op with no output
+regression.
+
+## Error handling
+
+- The dashboard must never break an import. Every reporter call site is best-effort: the
+  `model` context manager releases its slot in a `finally`, and `RichDashboard` guards
+  `Live.start`/`stop` so a terminal that rejects the live region falls back to
+  `LogProgress` rather than aborting the run.
+- A transfer that raises mid-flight leaves its `transfer` context via `finally`, removing
+  the row. The failure is reported by the existing `except Exception` handler in
+  `_process_unit`.
+- `on_progress` callbacks are called synchronously on the event loop and must not block.
+  They only mutate counters and rich task state.
+- Telethon may report `total=0` for some media. Transfers with an unknown total render as
+  indeterminate (spinner plus bytes transferred), not as a divide-by-zero.
+
+## Testing
+
+New `tests/test_progress.py`:
+
+- `LogProgress` throttling: with an injected clock, N rapid `advance` calls produce one
+  line; crossing the interval produces a second; completion always produces a final line.
+- Slot allocation: slots are reused lowest-first after release; concurrent models get
+  distinct slots.
+- `select_reporter` returns the right class for each row of the table above.
+- Unknown-total transfers do not raise.
+
+Extensions to existing tests:
+
+- `test_telegram_source.py` — `download` forwards `on_progress` to Telethon's
+  `progress_callback`.
+- `test_alexandria.py` — `upload_file` invokes `on_progress` once per chunk with
+  cumulative byte counts, and does not double-count across a chunk retry.
+- `test_importer.py` — a recording fake reporter asserts the phase sequence for one model
+  (`download` → `upload` → `scanning` → `committing`) and that `totals` is called after
+  each unit settles.
+
+`RichDashboard` is a thin adapter over rich; it gets a smoke test that constructs it with
+`Console(file=StringIO(), force_terminal=True)`, drives one model through every phase, and
+asserts no exception. No assertions on rendered output.
+
+## Documentation
+
+`tools/telegram-importer/README.md` gains a "Progress output" section covering the
+dashboard, the non-TTY fallback, and `--no-progress`, and the `--concurrency` section gains
+a pointer to the worker rows. The existing note that "interleaved concurrent runs make log
+output non-sequential" is amended to mention the dashboard.

--- a/tools/telegram-importer/.env.example
+++ b/tools/telegram-importer/.env.example
@@ -12,3 +12,6 @@ ALEXANDRIA_LIBRARY_ID=
 # Optional paths. Defaults live under the platform user-data directory.
 # TELEGRAM_SESSION_PATH=/path/to/alexandria-telegram.session
 # TELEGRAM_IMPORT_STATE_PATH=/path/to/import-state.sqlite3
+
+# Optional. Set to 1 to disable the progress display entirely.
+# TELEGRAM_IMPORT_NO_PROGRESS=1

--- a/tools/telegram-importer/README.md
+++ b/tools/telegram-importer/README.md
@@ -94,7 +94,47 @@ Raising it overlaps the slow parts of independent models — one model downloads
 
 Parts of one split archive are still downloaded and uploaded one at a time, which bounds disk use per model and preserves the abort path when a set turns out to be a duplicate. Attachments for a model are likewise appended one at a time. Concurrency applies between logical models, not inside one.
 
-Interleaved concurrent runs make log output non-sequential; every import log line names the model it refers to. The final `Import state:` summary is unaffected.
+Interleaved concurrent runs make log output non-sequential; every import log line names the model it refers to. The progress display gives each concurrent model its own numbered row, and the final `Import state:` summary is unaffected.
+
+## Progress output
+
+In an interactive terminal the importer pins a live block below the scrolling log: an overall bar, a running tally of this run's outcomes, and one row per model being imported.
+
+```
+2026-07-25 04:12:03 INFO Importing dragon-bust.zip
+2026-07-25 04:12:31 INFO Imported castle-set.7z as Alexandria model 0f3adc12
+
+  Total   ━━━━━━━━━━━━━━━━━╸━━━━━━━━━━  47/143 models
+  44 completed · 2 duplicates · 1 failed
+
+  #1 dragon-bust.zip     upload    ━━━━━━━━━━━╸━━━  412.0 MB/920.0 MB  8.1 MB/s
+  #2 castle-set.7z.002   download  ━━━━╸━━━━━━━━━━  180.0 MB/700.0 MB  4.4 MB/s
+  #3 knight-armor.stl    scanning  ⠹  waiting on Alexandria  0:00:44
+```
+
+Row numbers are stable slots: a model that finishes frees its number for the next one, so rows do not jump around mid-transfer. Each row names the phase it is in — `download`, `hashing`, `packaging`, `upload`, `attachments`, `scanning`, or `committing`. Only downloads and uploads have byte-level progress; the rest show elapsed time, because the importer is waiting on Alexandria rather than moving bytes. Attachments show a file count rather than a bar, since they are uploaded whole rather than in chunks.
+
+The tally counts this run only. Re-running against an existing state database opens at zero and counts already-imported models as `skipped`, rather than starting at the state file's historical totals.
+
+Progress goes to standard error, leaving standard output free for `--dry-run` plans and the final `Import state:` line.
+
+### Non-interactive output
+
+When standard error is not a terminal — `docker compose logs`, CI, or a redirect to a file — the live block is replaced by periodic log lines, so captured logs stay readable and free of terminal escape codes:
+
+```
+2026-07-25 04:12:31 INFO dragon-bust.zip download 45% (412.0 MB/920.0 MB, 8.1 MB/s)
+2026-07-25 04:12:41 INFO dragon-bust.zip download 78% (718.0 MB/920.0 MB, 8.4 MB/s)
+2026-07-25 04:12:48 INFO dragon-bust.zip download 100% (920.0 MB/920.0 MB, 8.2 MB/s)
+```
+
+Each transfer logs at most once every ten seconds, plus a final line when it finishes or stops early. The throttle is per transfer, so a concurrent run produces one interleaved stream per active model.
+
+`--verbose` also uses these lines rather than the live block, because debug output would contend with it for the same terminal.
+
+### Turning it off
+
+`--no-progress`, or `TELEGRAM_IMPORT_NO_PROGRESS=1`, disables both modes and restores the log output of earlier versions. A terminal that refuses the live region falls back to the periodic lines on its own; a display problem never interrupts an import.
 
 ## Exact grouping rules
 

--- a/tools/telegram-importer/pyproject.toml
+++ b/tools/telegram-importer/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
   "filelock>=3.20.0",
   "httpx>=0.28.0",
   "python-dotenv>=1.0.0",
+  "rich>=13.0.0",
   "telethon>=1.42.0",
 ]
 

--- a/tools/telegram-importer/src/alexandria_telegram_importer/alexandria.py
+++ b/tools/telegram-importer/src/alexandria_telegram_importer/alexandria.py
@@ -5,6 +5,7 @@ import ipaddress
 import logging
 import math
 import mimetypes
+from collections.abc import Callable
 from contextlib import ExitStack
 from pathlib import Path
 from typing import Any
@@ -90,7 +91,12 @@ class AlexandriaClient:
         log.info("Logged into Alexandria as %s", user.get("email", email))
 
     async def _upload_part(
-        self, path: Path, upload_filename: str, *, multipart: bool
+        self,
+        path: Path,
+        upload_filename: str,
+        *,
+        multipart: bool,
+        on_progress: Callable[[int, int], None] | None = None,
     ) -> str:
         size = path.stat().st_size
         total_chunks = max(1, math.ceil(size / CHUNK_SIZE))
@@ -108,6 +114,9 @@ class AlexandriaClient:
         )
         upload_id = self._data(response)["uploadId"]
 
+        if on_progress:
+            on_progress(0, size)
+        sent = 0
         with path.open("rb") as handle:
             for index in range(total_chunks):
                 chunk = handle.read(CHUNK_SIZE)
@@ -124,6 +133,11 @@ class AlexandriaClient:
                         if attempt == 2:
                             raise
                         await asyncio.sleep(2**attempt)
+                # Reported after the successful PUT, so retried chunks are
+                # counted once.
+                sent += len(chunk)
+                if on_progress:
+                    on_progress(sent, size)
         return upload_id
 
     async def upload_archive(
@@ -150,10 +164,17 @@ class AlexandriaClient:
             raise
 
     async def upload_file(
-        self, path: Path, upload_name: str, *, multipart: bool
+        self,
+        path: Path,
+        upload_name: str,
+        *,
+        multipart: bool,
+        on_progress: Callable[[int, int], None] | None = None,
     ) -> str:
         log.info("Uploading %s (%d bytes)", upload_name, path.stat().st_size)
-        return await self._upload_part(path, upload_name, multipart=multipart)
+        return await self._upload_part(
+            path, upload_name, multipart=multipart, on_progress=on_progress
+        )
 
     async def complete_upload(self, upload_ids: list[str], *, multipart: bool) -> str:
         if multipart:

--- a/tools/telegram-importer/src/alexandria_telegram_importer/cli.py
+++ b/tools/telegram-importer/src/alexandria_telegram_importer/cli.py
@@ -11,6 +11,7 @@ from dotenv import load_dotenv
 
 from .alexandria import AlexandriaClient
 from .importer import ChannelImporter, describe_plan
+from .progress import reporter_from_args
 from .telegram_source import TelegramSource
 from .tracker import ImportTracker
 
@@ -31,6 +32,10 @@ def _concurrency(value: str) -> int:
     if parsed < 1:
         raise argparse.ArgumentTypeError("concurrency must be at least 1")
     return parsed
+
+
+def _flag_env(name: str) -> bool:
+    return os.getenv(name, "").strip().lower() not in {"", "0", "false", "no"}
 
 
 def _channel(value: str | None) -> str | int | None:
@@ -85,6 +90,12 @@ def parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Show grouping without downloading or uploading",
     )
+    result.add_argument(
+        "--no-progress",
+        action="store_true",
+        default=_flag_env("TELEGRAM_IMPORT_NO_PROGRESS"),
+        help=("Disable the progress display entirely and log as earlier versions did"),
+    )
     result.add_argument("--verbose", action="store_true")
     return result
 
@@ -132,6 +143,11 @@ async def run(args: argparse.Namespace) -> int:
             tracker=tracker,
             work_root=args.state.parent / f"{args.state.name}.work",
             concurrency=args.concurrency,
+            progress=reporter_from_args(
+                no_progress=args.no_progress,
+                dry_run=args.dry_run,
+                verbose=args.verbose,
+            ),
         ).run(refs)
         print(
             "Import state: "

--- a/tools/telegram-importer/src/alexandria_telegram_importer/importer.py
+++ b/tools/telegram-importer/src/alexandria_telegram_importer/importer.py
@@ -6,6 +6,7 @@ import logging
 import shutil
 import tempfile
 import zipfile
+from collections import Counter
 from collections.abc import Iterable, Iterator
 from contextlib import AsyncExitStack
 from pathlib import Path
@@ -22,6 +23,13 @@ from .grouping import (
     validate_logical_model,
 )
 from .models import ImportBundle, LogicalModel, MediaRef
+from .progress import (
+    ModelProgress,
+    NullProgress,
+    ProgressReporter,
+    guarded_model,
+    guarded_reporter,
+)
 from .telegram_source import TelegramSource
 from .tracker import ImportRecord, ImportTracker
 
@@ -167,6 +175,7 @@ class ChannelImporter:
         tracker: ImportTracker,
         work_root: Path | None = None,
         concurrency: int = 1,
+        progress: ProgressReporter | None = None,
     ) -> None:
         if concurrency < 1:
             raise ValueError("Import concurrency must be at least 1")
@@ -175,7 +184,13 @@ class ChannelImporter:
         self.tracker = tracker
         self.work_root = work_root
         self.concurrency = concurrency
+        self.progress: ProgressReporter = progress or NullProgress()
         self._signatures = SignatureGate()
+        # Outcomes for this run only. The tracker's counts span every run against
+        # the same state file, so a resumed import would otherwise open at 100%.
+        self._outcomes: Counter[str] = Counter()
+        self._settled = 0
+        self._total_units = 0
 
     async def run(self, refs: list[MediaRef]) -> dict[str, int]:
         self._cleanup_stale_work()
@@ -187,6 +202,9 @@ class ChannelImporter:
             len(bundles),
             self.concurrency,
         )
+        self._outcomes = Counter()
+        self._settled = 0
+        self._total_units = total_units
         # Semaphore acquisition is FIFO, so a concurrency of 1 keeps the original
         # strict discovery order.
         slots = asyncio.Semaphore(self.concurrency)
@@ -199,10 +217,12 @@ class ChannelImporter:
             async with slots:
                 await self._process_unit(unit, attachments, related)
 
-        results = await asyncio.gather(
-            *(guarded(*item) for item in _work_items(bundles)),
-            return_exceptions=True,
-        )
+        with guarded_reporter(self.progress):
+            self._report_totals()
+            results = await asyncio.gather(
+                *(guarded(*item) for item in _work_items(bundles)),
+                return_exceptions=True,
+            )
         # Plain gather propagates the first failure while its siblings keep
         # running, which would leave tasks writing to a tracker and HTTP client
         # the caller is about to close. Collect every result, then re-raise.
@@ -210,6 +230,18 @@ class ChannelImporter:
             if isinstance(result, BaseException):
                 raise result
         return self.tracker.counts()
+
+    def _settle(self, outcome: str) -> None:
+        """Record one logical model reaching a terminal state, exactly once."""
+        self._outcomes[outcome] += 1
+        self._settled += 1
+        self._report_totals()
+
+    def _report_totals(self) -> None:
+        try:
+            self.progress.totals(self._settled, self._total_units, dict(self._outcomes))
+        except Exception as error:  # noqa: BLE001 - a display fault is not an import fault
+            log.debug("Progress reporter could not record totals: %s", error)
 
     async def _process_unit(
         self,
@@ -229,9 +261,29 @@ class ChannelImporter:
         )
         if record.status == "completed":
             log.info("Skipping completed model %s", unit.logical_filename)
+            self._settle("skipped")
             return
 
         log.info("Importing %s", unit.logical_filename)
+        with guarded_model(
+            self.progress, unit.logical_filename, parts=len(unit.parts)
+        ) as handle:
+            # Settling outside _import_unit keeps the tally out of the reach of
+            # its own error handling: a reporter fault during the tally update
+            # must not be re-read as an import failure.
+            self._settle(
+                await self._import_unit(unit, attachments, related, record, handle)
+            )
+
+    async def _import_unit(
+        self,
+        unit: LogicalModel,
+        attachments: tuple[MediaRef, ...],
+        related: tuple[LogicalModel, ...],
+        record: ImportRecord,
+        handle: ModelProgress,
+    ) -> str:
+        """Import one logical model, returning the outcome it settled on."""
         try:
             validate_logical_model(unit)
             # Signatures are held for the rest of this import so a concurrent twin
@@ -261,7 +313,7 @@ class ChannelImporter:
                         self._record_duplicate(
                             unit, duplicate, "Telegram media identity"
                         )
-                        return
+                        return "duplicates"
                 with tempfile.TemporaryDirectory(
                     prefix=f"alexandria-tg-{unit.key[:8]}-",
                     dir=self.work_root,
@@ -273,9 +325,12 @@ class ChannelImporter:
                         record,
                         Path(temp),
                         holds,
+                        handle,
                     )
+            return "completed"
         except DuplicateModelFound as duplicate:
             self._record_duplicate(unit, duplicate.original, duplicate.signature_type)
+            return "duplicates"
         except CompletionUncertain as error:
             self.tracker.update(unit.key, "completion_uncertain", error=str(error))
             log.error(
@@ -283,10 +338,12 @@ class ChannelImporter:
                 unit.logical_filename,
                 error,
             )
+            return "uncertain"
         # One bad Telegram post must not prevent independent later models from importing.
         except Exception as error:  # noqa: BLE001
             self.tracker.update(unit.key, "failed", error=str(error))
             log.error("Failed to import %s: %s", unit.logical_filename, error)
+            return "failed"
 
     def _record_duplicate(
         self,
@@ -353,10 +410,11 @@ class ChannelImporter:
         record: ImportRecord,
         work_dir: Path,
         holds: AsyncExitStack,
+        handle: ModelProgress,
     ) -> None:
         session = await self._recover_session(record)
         if session is None:
-            session = await self._start_session(unit, work_dir, holds)
+            session = await self._start_session(unit, work_dir, holds, handle)
             record = self.tracker.update(
                 unit.key,
                 "scanning",
@@ -384,6 +442,7 @@ class ChannelImporter:
             await self._handle_error_session(unit, session)
 
         if status == "scanning":
+            handle.phase("scanning")
             session = await self.alexandria.wait_for_session(
                 session_id,
                 {"ready_for_review", "committed"},
@@ -408,6 +467,8 @@ class ChannelImporter:
                     for item in attachments
                     if attachment_upload_name(item) not in present_names
                 )
+                uploaded = 0
+                handle.attachments(uploaded, len(missing))
                 for offset in range(0, len(missing), 100):
                     batch = missing[offset : offset + 100]
                     for item in batch:
@@ -420,6 +481,8 @@ class ChannelImporter:
                             )
                         finally:
                             attachment_path.unlink(missing_ok=True)
+                        uploaded += 1
+                        handle.attachments(uploaded, len(missing))
                 self.tracker.update(
                     unit.key, "attachments_uploaded", session_id=session_id
                 )
@@ -441,6 +504,7 @@ class ChannelImporter:
             status = "committing"
 
         if status == "committing":
+            handle.phase("committing")
             session = await self.alexandria.wait_for_session(session_id, {"committed"})
             if session["status"] == "error":
                 await self._handle_error_session(unit, session)
@@ -488,7 +552,11 @@ class ChannelImporter:
         return session
 
     async def _start_session(
-        self, unit: LogicalModel, work_dir: Path, holds: AsyncExitStack
+        self,
+        unit: LogicalModel,
+        work_dir: Path,
+        holds: AsyncExitStack,
+        handle: ModelProgress,
     ) -> dict[str, Any]:
         self.tracker.update(unit.key, "downloading")
         multipart = unit.multipart
@@ -497,10 +565,14 @@ class ChannelImporter:
         content_hashes: list[str] = []
         try:
             for part, name in zip(unit.parts, names, strict=True):
-                downloaded = await self.telegram.download(part, work_dir)
+                with handle.transfer("download", part.filename) as transfer:
+                    downloaded = await self.telegram.download(
+                        part, work_dir, on_progress=transfer.advance
+                    )
                 upload_path = downloaded
                 upload_name = name
                 try:
+                    handle.phase("hashing")
                     part_hash, actual_size = await asyncio.to_thread(
                         _hash_file, downloaded
                     )
@@ -528,6 +600,7 @@ class ChannelImporter:
                     if not multipart and not unit.logical_filename.lower().endswith(
                         ARCHIVE_EXTENSIONS
                     ):
+                        handle.phase("packaging")
                         upload_path = work_dir / upload_filename(
                             self.telegram.channel_id, unit
                         )
@@ -542,13 +615,15 @@ class ChannelImporter:
                             )
                         upload_name = upload_path.name
                     self.tracker.update(unit.key, "uploading")
-                    upload_ids.append(
-                        await self.alexandria.upload_file(
-                            upload_path,
-                            upload_name,
-                            multipart=multipart,
-                        ),
-                    )
+                    with handle.transfer("upload", upload_name) as transfer:
+                        upload_ids.append(
+                            await self.alexandria.upload_file(
+                                upload_path,
+                                upload_name,
+                                multipart=multipart,
+                                on_progress=transfer.advance,
+                            ),
+                        )
                 finally:
                     downloaded.unlink(missing_ok=True)
                     if upload_path != downloaded:

--- a/tools/telegram-importer/src/alexandria_telegram_importer/progress.py
+++ b/tools/telegram-importer/src/alexandria_telegram_importer/progress.py
@@ -1,0 +1,626 @@
+"""Progress reporting for long-running Telegram imports.
+
+The importer reports work through a `ProgressReporter`, which it receives by
+constructor injection. Transport code takes a plain ``on_progress(received,
+total)`` callback and never learns which reporter, if any, is listening.
+
+Three reporters exist: `RichDashboard` draws a live terminal region,
+`LogProgress` emits throttled log lines for non-terminal output, and
+`NullProgress` does nothing.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+import time
+from collections.abc import Callable, Iterator, Mapping
+from contextlib import AbstractContextManager, contextmanager
+from dataclasses import dataclass
+from datetime import timedelta
+from typing import Protocol, Self
+
+from rich.console import Console, Group, RenderableType
+from rich.live import Live
+from rich.progress_bar import ProgressBar
+from rich.spinner import Spinner
+from rich.table import Table
+from rich.text import Text
+
+log = logging.getLogger(__name__)
+
+LOG_INTERVAL_SECONDS = 10.0
+LABEL_WIDTH = 28
+BAR_WIDTH = 15
+TOTAL_BAR_WIDTH = 30
+
+#: Order in which outcome counts appear in the summary line.
+OUTCOME_ORDER = ("completed", "duplicates", "skipped", "failed", "uncertain")
+
+PHASE_DETAIL = {
+    "scanning": "waiting on Alexandria",
+    "committing": "committing to Alexandria",
+    "hashing": "hashing for duplicate check",
+    "packaging": "packaging as zip",
+    "starting": "starting",
+    "working": "",
+}
+
+#: Below this, a transfer rate is dominated by measurement noise, so it is
+#: withheld rather than reported as an implausible number.
+MIN_SPEED_SECONDS = 1.0
+
+
+def format_bytes(value: float) -> str:
+    amount = float(max(value, 0))
+    for unit in ("B", "KB", "MB", "GB"):
+        if amount < 1024 or unit == "GB":
+            precision = 0 if unit in {"B", "KB"} else 1
+            return f"{amount:.{precision}f} {unit}"
+        amount /= 1024
+    raise AssertionError("unreachable")
+
+
+def format_duration(seconds: float) -> str:
+    return str(timedelta(seconds=int(max(seconds, 0))))
+
+
+def format_counts(counts: Mapping[str, int]) -> str:
+    parts = [f"{counts[name]} {name}" for name in OUTCOME_ORDER if counts.get(name)]
+    extra = sorted(set(counts) - set(OUTCOME_ORDER))
+    parts.extend(f"{counts[name]} {name}" for name in extra if counts[name])
+    return " · ".join(parts)
+
+
+class TransferHandle(Protocol):
+    def advance(self, received: int, total: int) -> None:
+        """Report absolute bytes transferred so far.
+
+        Absolute rather than incremental so that a retried transfer, which
+        restarts its byte count at zero, rewinds the display instead of
+        double-counting.
+        """
+
+
+class ModelProgress(Protocol):
+    def phase(self, name: str) -> None: ...
+
+    def transfer(self, kind: str, label: str) -> AbstractContextManager[TransferHandle]:
+        """Context manager scoping one download or upload."""
+
+    def attachments(self, done: int, total: int) -> None: ...
+
+
+class ProgressReporter(Protocol):
+    def __enter__(self) -> Self: ...
+
+    def __exit__(self, *exc_info: object) -> bool: ...
+
+    def model(self, label: str, *, parts: int) -> AbstractContextManager[ModelProgress]:
+        """Context manager scoping one logical model's import."""
+
+    def totals(self, done: int, total: int, counts: Mapping[str, int]) -> None: ...
+
+
+class NullTransfer:
+    def advance(self, received: int, total: int) -> None:
+        pass
+
+
+class NullModelProgress:
+    def phase(self, name: str) -> None:
+        pass
+
+    @contextmanager
+    def transfer(self, kind: str, label: str) -> Iterator[TransferHandle]:
+        yield NullTransfer()
+
+    def attachments(self, done: int, total: int) -> None:
+        pass
+
+
+class NullProgress:
+    """Reporter that produces no output, leaving today's logging untouched."""
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, *exc_info: object) -> bool:
+        return False
+
+    @contextmanager
+    def model(self, label: str, *, parts: int) -> Iterator[ModelProgress]:
+        yield NullModelProgress()
+
+    def totals(self, done: int, total: int, counts: Mapping[str, int]) -> None:
+        pass
+
+
+class _LogTransfer:
+    """Throttled log lines for one transfer.
+
+    Throttling is per transfer rather than global so that concurrent imports
+    each keep reporting, matching how the importer's existing log lines
+    interleave.
+    """
+
+    def __init__(
+        self,
+        label: str,
+        kind: str,
+        *,
+        clock: Callable[[], float],
+        interval: float,
+    ) -> None:
+        self._label = label
+        self._kind = kind
+        self._clock = clock
+        self._interval = interval
+        self._started = clock()
+        self._last_logged: float | None = None
+        self._last_reported: int | None = None
+        self._received = 0
+        self._total = 0
+
+    def advance(self, received: int, total: int) -> None:
+        now = self._clock()
+        # A retried transfer restarts its byte count at zero. Without rebasing
+        # the clock, the retry's wait (a FloodWaitError sleep runs to minutes)
+        # would be charged against the new attempt and halve its reported rate.
+        if received < self._received:
+            self._started = now
+        self._received = received
+        self._total = total
+        if received >= total > 0:
+            self._emit(now)
+            return
+        if self._last_logged is not None and now - self._last_logged < self._interval:
+            return
+        self._emit(now)
+
+    def close(self) -> None:
+        """Report where an unfinished transfer stopped, without repeating itself."""
+        if self._last_reported != self._received:
+            self._emit(self._clock())
+
+    def _emit(self, now: float) -> None:
+        self._last_logged = now
+        self._last_reported = self._received
+        elapsed = now - self._started
+        speed = (
+            f", {format_bytes(self._received / elapsed)}/s"
+            if elapsed >= MIN_SPEED_SECONDS
+            else ""
+        )
+        if self._total > 0:
+            percent = min(int(self._received * 100 / self._total), 100)
+            log.info(
+                "%s %s %d%% (%s/%s%s)",
+                self._label,
+                self._kind,
+                percent,
+                format_bytes(self._received),
+                format_bytes(self._total),
+                speed,
+            )
+        else:
+            log.info(
+                "%s %s %s%s",
+                self._label,
+                self._kind,
+                format_bytes(self._received),
+                speed,
+            )
+
+
+class _LogModelProgress:
+    def __init__(self, label: str, *, clock: Callable[[], float], interval: float):
+        self._label = label
+        self._clock = clock
+        self._interval = interval
+
+    def phase(self, name: str) -> None:
+        pass
+
+    @contextmanager
+    def transfer(self, kind: str, label: str) -> Iterator[TransferHandle]:
+        handle = _LogTransfer(label, kind, clock=self._clock, interval=self._interval)
+        try:
+            yield handle
+        finally:
+            handle.close()
+
+    def attachments(self, done: int, total: int) -> None:
+        pass
+
+
+class LogProgress:
+    """Reporter for non-terminal output: periodic log lines, no escape codes."""
+
+    def __init__(
+        self,
+        *,
+        clock: Callable[[], float] = time.monotonic,
+        interval: float = LOG_INTERVAL_SECONDS,
+    ) -> None:
+        self._clock = clock
+        self._interval = interval
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, *exc_info: object) -> bool:
+        return False
+
+    @contextmanager
+    def model(self, label: str, *, parts: int) -> Iterator[ModelProgress]:
+        yield _LogModelProgress(label, clock=self._clock, interval=self._interval)
+
+    def totals(self, done: int, total: int, counts: Mapping[str, int]) -> None:
+        summary = format_counts(counts)
+        log.info(
+            "Progress: %d/%d models%s",
+            done,
+            total,
+            f" ({summary})" if summary else "",
+        )
+
+
+@dataclass
+class _Row:
+    slot: int
+    label: str
+    started: float
+    phase: str = "starting"
+    mode: str = "phase"
+    phase_started: float = 0.0
+    received: int = 0
+    total: int = 0
+    transfer_started: float = 0.0
+    detail: str = ""
+
+
+class _DashboardTransfer:
+    def __init__(self, dashboard: RichDashboard, row: _Row) -> None:
+        self._dashboard = dashboard
+        self._row = row
+
+    def advance(self, received: int, total: int) -> None:
+        # See _LogTransfer.advance: a rewind means a retry, so the rate clock
+        # restarts rather than absorbing the retry's wait.
+        if received < self._row.received:
+            self._row.transfer_started = self._dashboard.clock()
+        self._row.received = received
+        self._row.total = total
+
+
+class _DashboardModelProgress:
+    def __init__(self, dashboard: RichDashboard, row: _Row) -> None:
+        self._dashboard = dashboard
+        self._row = row
+
+    def phase(self, name: str) -> None:
+        self._row.mode = "phase"
+        self._row.phase = name
+        self._row.phase_started = self._dashboard.clock()
+        self._row.detail = PHASE_DETAIL.get(name, name)
+
+    @contextmanager
+    def transfer(self, kind: str, label: str) -> Iterator[TransferHandle]:
+        row = self._row
+        row.mode = "transfer"
+        row.phase = kind
+        row.received = 0
+        row.total = 0
+        row.transfer_started = self._dashboard.clock()
+        try:
+            yield _DashboardTransfer(self._dashboard, row)
+        finally:
+            # Leaving the transfer's own label up would misreport the work that
+            # follows it, so the row reverts to a neutral phase until the
+            # importer names the next one.
+            self.phase("working")
+
+    def attachments(self, done: int, total: int) -> None:
+        self._row.mode = "phase"
+        self._row.phase = "attachments"
+        self._row.detail = f"{done}/{total} files"
+
+
+class RichDashboard:
+    """A pinned live region: a total bar, an outcome tally, and one row per worker.
+
+    Falls back to `LogProgress` when the terminal refuses the live region, so a
+    display problem can never abort an import.
+    """
+
+    def __init__(
+        self,
+        *,
+        console: Console | None = None,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._console = console or Console(stderr=True)
+        self.clock = clock
+        self._rows: dict[int, _Row] = {}
+        self._done = 0
+        self._total = 0
+        self._counts: Mapping[str, int] = {}
+        self._spinner = Spinner("dots")
+        self._live: Live | None = None
+        self._fallback: LogProgress | None = None
+        self._log_handler: logging.Handler | None = None
+        self._saved_handlers: list[logging.Handler] = []
+
+    def __enter__(self) -> Self:
+        try:
+            self._live = Live(
+                self,
+                console=self._console,
+                refresh_per_second=10,
+                transient=False,
+                # The console already writes to stderr; redirecting stdout too
+                # would route the dry-run plan and the final summary through the
+                # live region.
+                redirect_stdout=False,
+            )
+            self._live.start()
+            self._capture_logging()
+        except Exception as error:  # noqa: BLE001 - display must never break imports
+            log.debug("Falling back to log progress: %s", error)
+            self._teardown()
+            self._fallback = LogProgress()
+        return self
+
+    def __exit__(self, *exc_info: object) -> bool:
+        self._teardown()
+        return False
+
+    def _teardown(self) -> None:
+        """Undo everything `__enter__` installed, in reverse order.
+
+        The live region is stopped before log handlers are restored: a restored
+        handler holds the pre-redirect stream and would write straight through
+        an active region.
+        """
+        if self._live is not None:
+            try:
+                self._live.stop()
+            except Exception as error:  # noqa: BLE001
+                log.debug("Could not stop the progress display: %s", error)
+            self._live = None
+        self._release_logging()
+
+    def _capture_logging(self) -> None:
+        """Route log records through the console so they scroll above the region.
+
+        The existing formatter is reused, so log lines keep the format the
+        importer already emits.
+        """
+        root = logging.getLogger()
+        if not root.handlers:
+            return
+        formatter = root.handlers[0].formatter
+        handler = _ConsoleLogHandler(self._console)
+        handler.setFormatter(formatter)
+        handler.setLevel(root.handlers[0].level)
+        saved = list(root.handlers)
+        # Recorded before the first removal so that an interruption part-way
+        # through cannot leave the root logger with no handlers at all.
+        self._saved_handlers = saved
+        try:
+            for existing in saved:
+                root.removeHandler(existing)
+            root.addHandler(handler)
+            self._log_handler = handler
+        except BaseException:
+            self._release_logging()
+            raise
+
+    def _release_logging(self) -> None:
+        if not self._saved_handlers:
+            return
+        root = logging.getLogger()
+        self._log_handler = None
+        # Restore the exact list that was captured, rather than re-adding the
+        # missing ones, so handler order survives an interrupted capture.
+        for existing in list(root.handlers):
+            root.removeHandler(existing)
+        for existing in self._saved_handlers:
+            root.addHandler(existing)
+        self._saved_handlers = []
+
+    @contextmanager
+    def model(self, label: str, *, parts: int) -> Iterator[ModelProgress]:
+        if self._fallback is not None:
+            with self._fallback.model(label, parts=parts) as delegate:
+                yield delegate
+            return
+        slot = self._claim_slot()
+        row = _Row(
+            slot=slot,
+            label=label,
+            started=self.clock(),
+            phase_started=self.clock(),
+            detail=PHASE_DETAIL["starting"],
+        )
+        self._rows[slot] = row
+        try:
+            yield _DashboardModelProgress(self, row)
+        finally:
+            self._rows.pop(slot, None)
+
+    def _claim_slot(self) -> int:
+        slot = 1
+        while slot in self._rows:
+            slot += 1
+        return slot
+
+    def totals(self, done: int, total: int, counts: Mapping[str, int]) -> None:
+        if self._fallback is not None:
+            self._fallback.totals(done, total, counts)
+            return
+        self._done = done
+        self._total = total
+        self._counts = dict(counts)
+
+    def __rich__(self) -> RenderableType:
+        return self._render()
+
+    def _render(self) -> RenderableType:
+        now = self.clock()
+        # rich refreshes on its own thread while the import mutates _rows on the
+        # event loop. list() of a dict view is atomic under the GIL, so this
+        # snapshot cannot see a half-removed row; iterating the live dict could
+        # raise and would kill the refresh thread for the rest of the run.
+        rows = sorted(self._rows.values(), key=lambda row: row.slot)
+        header = Table.grid(padding=(0, 2))
+        header.add_row(
+            Text("  Total", style="bold"),
+            ProgressBar(
+                total=max(self._total, 1),
+                completed=self._done,
+                width=TOTAL_BAR_WIDTH,
+            ),
+            Text(f"{self._done}/{self._total} models"),
+        )
+        summary = format_counts(self._counts)
+        blocks: list[RenderableType] = [header]
+        if summary:
+            blocks.append(Text(f"  {summary}", style="dim"))
+        if rows:
+            blocks.append(Text(""))
+            blocks.append(self._render_rows(rows, now))
+        return Group(*blocks)
+
+    def _render_rows(self, rows: list[_Row], now: float) -> RenderableType:
+        table = Table.grid(padding=(0, 2))
+        for row in rows:
+            slot = row.slot
+            table.add_row(
+                Text(f"  #{slot}", style="dim"),
+                Text(_truncate(row.label, LABEL_WIDTH)),
+                Text(row.phase, style="cyan"),
+                self._render_indicator(row, now),
+                Text(self._render_detail(row, now)),
+            )
+        return table
+
+    def _render_indicator(self, row: _Row, now: float) -> RenderableType:
+        if row.mode != "transfer":
+            return self._spinner.render(now)
+        if row.total <= 0:
+            return self._spinner.render(now)
+        return ProgressBar(total=row.total, completed=row.received, width=BAR_WIDTH)
+
+    def _render_detail(self, row: _Row, now: float) -> str:
+        if row.mode != "transfer":
+            elapsed = format_duration(now - (row.phase_started or row.started))
+            return f"{row.detail}  {elapsed}" if row.detail else elapsed
+        elapsed = now - row.transfer_started
+        speed = (
+            f"  {format_bytes(row.received / elapsed)}/s"
+            if elapsed >= MIN_SPEED_SECONDS
+            else ""
+        )
+        if row.total > 0:
+            return f"{format_bytes(row.received)}/{format_bytes(row.total)}{speed}"
+        return f"{format_bytes(row.received)}{speed}"
+
+
+class _ConsoleLogHandler(logging.Handler):
+    def __init__(self, console: Console) -> None:
+        super().__init__()
+        self._console = console
+
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            self._console.print(self.format(record), markup=False, highlight=False)
+        except Exception:  # noqa: BLE001 - logging must not raise into the importer
+            self.handleError(record)
+
+
+def _truncate(value: str, width: int) -> str:
+    return value if len(value) <= width else value[: width - 1] + "…"
+
+
+@contextmanager
+def guarded_reporter(reporter: ProgressReporter) -> Iterator[None]:
+    """Start and stop a reporter without letting a display fault end the run.
+
+    A reporter that fails to start is simply never started; its later calls are
+    no-ops on an inactive object rather than errors.
+    """
+    started = False
+    try:
+        reporter.__enter__()
+        started = True
+    except Exception as error:  # noqa: BLE001
+        log.debug("Progress reporter could not start: %s", error)
+    try:
+        yield
+    finally:
+        if started:
+            try:
+                reporter.__exit__(None, None, None)
+            except Exception as error:  # noqa: BLE001
+                log.debug("Progress reporter could not stop: %s", error)
+
+
+@contextmanager
+def guarded_model(
+    reporter: ProgressReporter, label: str, *, parts: int
+) -> Iterator[ModelProgress]:
+    """Open a model row without letting a display fault end the run.
+
+    The importer contains its own failures per model, so an exception escaping
+    a reporter would otherwise propagate out of `asyncio.gather` and abort every
+    remaining import for the sake of a progress bar.
+    """
+    try:
+        manager = reporter.model(label, parts=parts)
+        handle = manager.__enter__()
+    except Exception as error:  # noqa: BLE001
+        log.debug("Progress reporter could not open %s: %s", label, error)
+        yield NullModelProgress()
+        return
+    try:
+        yield handle
+    finally:
+        try:
+            manager.__exit__(None, None, None)
+        except Exception as error:  # noqa: BLE001
+            log.debug("Progress reporter could not close %s: %s", label, error)
+
+
+def select_reporter(
+    *,
+    no_progress: bool,
+    dry_run: bool,
+    verbose: bool,
+    is_tty: bool,
+    console: Console | None = None,
+) -> ProgressReporter:
+    """Choose a reporter. First matching condition wins."""
+    if no_progress or dry_run:
+        return NullProgress()
+    # Debug-level output would contend with a live region for the same lines.
+    if verbose:
+        return LogProgress()
+    if is_tty:
+        return RichDashboard(console=console)
+    return LogProgress()
+
+
+def reporter_from_args(
+    *,
+    no_progress: bool,
+    dry_run: bool,
+    verbose: bool,
+) -> ProgressReporter:
+    return select_reporter(
+        no_progress=no_progress,
+        dry_run=dry_run,
+        verbose=verbose,
+        is_tty=sys.stderr.isatty(),
+    )

--- a/tools/telegram-importer/src/alexandria_telegram_importer/telegram_source.py
+++ b/tools/telegram-importer/src/alexandria_telegram_importer/telegram_source.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -112,7 +113,13 @@ class TelegramSource:
             )
         return refs
 
-    async def download(self, ref: MediaRef, directory: Path) -> Path:
+    async def download(
+        self,
+        ref: MediaRef,
+        directory: Path,
+        *,
+        on_progress: Callable[[int, int], None] | None = None,
+    ) -> Path:
         directory.mkdir(parents=True, exist_ok=True)
         target = directory / f"{ref.message_id}_{safe_filename(ref.filename, 'media')}"
         for attempt in range(3):
@@ -125,7 +132,7 @@ class TelegramSource:
                         f"Telegram message {ref.message_id} no longer exists"
                     )
                 downloaded = await self._client.download_media(
-                    message, file=str(target)
+                    message, file=str(target), progress_callback=on_progress
                 )
                 if not downloaded:
                     raise RuntimeError(

--- a/tools/telegram-importer/tests/test_alexandria.py
+++ b/tools/telegram-importer/tests/test_alexandria.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import httpx
 import pytest
+
+from alexandria_telegram_importer import alexandria as alexandria_module
 from alexandria_telegram_importer.alexandria import AlexandriaClient, session_filenames
 
 
@@ -46,3 +49,74 @@ def test_should_collect_session_filenames_from_nested_folder_structure() -> None
 
 def test_should_return_no_filenames_when_session_detection_is_absent() -> None:
     assert session_filenames({"detected": None}) == set()
+
+
+def upload_client(monkeypatch, *, failures: int = 0) -> AlexandriaClient:
+    """Client whose chunk PUTs fail `failures` times before succeeding."""
+    monkeypatch.setattr(alexandria_module, "CHUNK_SIZE", 10)
+    client = AlexandriaClient("http://127.0.0.1:3000")
+    remaining = {"failures": failures}
+
+    async def fake_request(method: str, url: str, **_kwargs):
+        if method == "POST":
+            return httpx.Response(
+                200,
+                json={"data": {"uploadId": "upload-1"}},
+                request=httpx.Request(method, url),
+            )
+        if remaining["failures"]:
+            remaining["failures"] -= 1
+            raise httpx.ConnectError("chunk upload failed")
+        return httpx.Response(
+            200, json={"data": {}}, request=httpx.Request(method, url)
+        )
+
+    monkeypatch.setattr(client, "_request", fake_request)
+    return client
+
+
+@pytest.mark.asyncio
+async def test_should_report_cumulative_upload_progress_per_chunk(
+    tmp_path, monkeypatch
+) -> None:
+    path = tmp_path / "model.zip"
+    path.write_bytes(b"x" * 25)
+    client = upload_client(monkeypatch)
+    seen: list[tuple[int, int]] = []
+    try:
+        await client.upload_file(
+            path,
+            "model.zip",
+            multipart=False,
+            on_progress=lambda a, b: seen.append((a, b)),
+        )
+    finally:
+        await client.close()
+
+    # An opening call so the total is known before any bytes move, then one per
+    # 10-byte chunk.
+    assert seen == [(0, 25), (10, 25), (20, 25), (25, 25)]
+
+
+@pytest.mark.asyncio
+async def test_should_not_double_count_a_retried_chunk(tmp_path, monkeypatch) -> None:
+    path = tmp_path / "model.zip"
+    path.write_bytes(b"x" * 25)
+    client = upload_client(monkeypatch, failures=2)
+    monkeypatch.setattr(alexandria_module.asyncio, "sleep", _no_sleep)
+    seen: list[tuple[int, int]] = []
+    try:
+        await client.upload_file(
+            path,
+            "model.zip",
+            multipart=False,
+            on_progress=lambda a, b: seen.append((a, b)),
+        )
+    finally:
+        await client.close()
+
+    assert seen == [(0, 25), (10, 25), (20, 25), (25, 25)]
+
+
+async def _no_sleep(_seconds: float) -> None:
+    return None

--- a/tools/telegram-importer/tests/test_cli.py
+++ b/tools/telegram-importer/tests/test_cli.py
@@ -35,3 +35,25 @@ def test_should_reject_an_unusable_concurrency_from_the_environment(
 
     with pytest.raises(SystemExit):
         parser().parse_args([])
+
+
+def test_should_enable_the_progress_display_by_default() -> None:
+    assert parser().parse_args([]).no_progress is False
+
+
+def test_should_accept_an_explicit_progress_opt_out() -> None:
+    assert parser().parse_args(["--no-progress"]).no_progress is True
+
+
+@pytest.mark.parametrize("value", ["1", "true", "yes"])
+def test_should_opt_out_of_progress_from_the_environment(monkeypatch, value) -> None:
+    monkeypatch.setenv("TELEGRAM_IMPORT_NO_PROGRESS", value)
+
+    assert parser().parse_args([]).no_progress is True
+
+
+@pytest.mark.parametrize("value", ["", "0", "false", "no"])
+def test_should_keep_progress_for_falsey_environment_values(monkeypatch, value) -> None:
+    monkeypatch.setenv("TELEGRAM_IMPORT_NO_PROGRESS", value)
+
+    assert parser().parse_args([]).no_progress is False

--- a/tools/telegram-importer/tests/test_importer.py
+++ b/tools/telegram-importer/tests/test_importer.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import sqlite3
-from contextlib import AsyncExitStack
+from contextlib import AsyncExitStack, contextmanager
 
 import pytest
 
@@ -18,6 +18,7 @@ from alexandria_telegram_importer.importer import (
     telegram_media_signature,
     upload_filename,
 )
+from alexandria_telegram_importer.progress import NullModelProgress
 from alexandria_telegram_importer.tracker import ImportRecord, ImportTracker
 
 
@@ -213,7 +214,7 @@ class DedupTelegram:
         self.payloads = payloads or {}
         self.download_calls: list[int] = []
 
-    async def download(self, ref, directory):
+    async def download(self, ref, directory, *, on_progress=None):
         self.download_calls.append(ref.message_id)
         if ref.message_id not in self.payloads:
             raise AssertionError("duplicate should have been skipped before download")
@@ -251,7 +252,9 @@ class DedupAlexandria:
     async def get_session(self, session_id: str):
         return self.sessions[session_id]
 
-    async def upload_file(self, _path, upload_name: str, *, multipart: bool):
+    async def upload_file(
+        self, _path, upload_name: str, *, multipart: bool, on_progress=None
+    ):
         self.upload_calls.append(upload_name)
         return f"upload-{len(self.upload_calls)}"
 
@@ -511,7 +514,9 @@ async def test_should_abort_first_multipart_upload_when_final_hash_finds_duplica
 
         with pytest.raises(DuplicateModelFound, match=prior.import_key):
             async with AsyncExitStack() as holds:
-                await importer._start_session(unit, work_dir, holds)
+                await importer._start_session(
+                    unit, work_dir, holds, NullModelProgress()
+                )
 
         assert telegram.download_calls == [1, 2]
         assert len(alexandria.upload_calls) == 1
@@ -541,7 +546,7 @@ class PipelineTelegram:
         self.in_flight = 0
         self.max_in_flight = 0
 
-    async def download(self, ref, directory):
+    async def download(self, ref, directory, *, on_progress=None):
         self.download_calls.append(ref.message_id)
         self.in_flight += 1
         self.max_in_flight = max(self.max_in_flight, self.in_flight)
@@ -577,7 +582,9 @@ class PipelineAlexandria:
     async def find_session_by_filename(self, _filename: str):
         return None
 
-    async def upload_file(self, _path, upload_name: str, *, multipart: bool):
+    async def upload_file(
+        self, _path, upload_name: str, *, multipart: bool, on_progress=None
+    ):
         if self.upload_delay:
             await asyncio.sleep(self.upload_delay)
         self._uploads += 1
@@ -612,7 +619,7 @@ class PipelineAlexandria:
         return model_id
 
 
-def pipeline_importer(tmp_path, telegram, alexandria, concurrency: int):
+def pipeline_importer(tmp_path, telegram, alexandria, concurrency: int, progress=None):
     tracker = ImportTracker(tmp_path / "state.sqlite3")
     importer = ChannelImporter(
         telegram=telegram,  # type: ignore[arg-type]
@@ -620,8 +627,86 @@ def pipeline_importer(tmp_path, telegram, alexandria, concurrency: int):
         tracker=tracker,
         work_root=tmp_path / "work",
         concurrency=concurrency,
+        progress=progress,
     )
     return importer, tracker
+
+
+class RecordingTransfer:
+    def __init__(self, events: list, kind: str, label: str) -> None:
+        self.events = events
+        self.kind = kind
+        self.label = label
+
+    def advance(self, received: int, total: int) -> None:
+        self.events.append(("advance", self.kind, self.label, received, total))
+
+
+class RecordingModelProgress:
+    def __init__(self, events: list, label: str) -> None:
+        self.events = events
+        self.label = label
+
+    def phase(self, name: str) -> None:
+        self.events.append(("phase", self.label, name))
+
+    @contextmanager
+    def transfer(self, kind: str, label: str):
+        self.events.append(("transfer_start", self.label, kind, label))
+        try:
+            yield RecordingTransfer(self.events, kind, label)
+        finally:
+            self.events.append(("transfer_end", self.label, kind, label))
+
+    def attachments(self, done: int, total: int) -> None:
+        self.events.append(("attachments", self.label, done, total))
+
+
+class RecordingProgress:
+    """Reporter double that records the sequence the importer drives it through."""
+
+    def __init__(self) -> None:
+        self.events: list = []
+        self.totals_calls: list[tuple[int, int, dict]] = []
+        self.entered = False
+        self.exited = False
+        self.open_models = 0
+        self.max_open_models = 0
+
+    def __enter__(self):
+        self.entered = True
+        return self
+
+    def __exit__(self, *exc_info):
+        self.exited = True
+        return False
+
+    @contextmanager
+    def model(self, label: str, *, parts: int):
+        self.events.append(("model_start", label, parts))
+        self.open_models += 1
+        self.max_open_models = max(self.max_open_models, self.open_models)
+        try:
+            yield RecordingModelProgress(self.events, label)
+        finally:
+            self.open_models -= 1
+            self.events.append(("model_end", label))
+
+    def totals(self, done: int, total: int, counts) -> None:
+        self.totals_calls.append((done, total, dict(counts)))
+
+
+def phases_for(progress: RecordingProgress, label: str) -> list[str]:
+    sequence = []
+    for event in progress.events:
+        if (
+            event[0] == "transfer_start"
+            and event[1] == label
+            or event[0] == "phase"
+            and event[1] == label
+        ):
+            sequence.append(event[2])
+    return sequence
 
 
 def test_should_reject_a_concurrency_below_one() -> None:
@@ -757,10 +842,10 @@ async def test_should_keep_importing_later_models_when_one_fails(
     media_ref,
 ) -> None:
     class FailingTelegram(PipelineTelegram):
-        async def download(self, ref, directory):
+        async def download(self, ref, directory, *, on_progress=None):
             if ref.message_id == 2:
                 raise RuntimeError("telegram refused the download")
-            return await super().download(ref, directory)
+            return await super().download(ref, directory, on_progress=on_progress)
 
     telegram = FailingTelegram(delay=0.01)
     alexandria = PipelineAlexandria()
@@ -825,5 +910,255 @@ async def test_should_let_every_task_settle_before_reporting_an_unexpected_failu
         assert tracker.counts() == {"completed": 2}
         assert len(alexandria.committed_models) == 2
         assert telegram.in_flight == 0
+    finally:
+        tracker.close()
+
+
+@pytest.mark.asyncio
+async def test_should_drive_progress_through_every_phase_of_one_model(
+    tmp_path,
+    media_ref,
+) -> None:
+    telegram = PipelineTelegram()
+    alexandria = PipelineAlexandria()
+    progress = RecordingProgress()
+    importer, tracker = pipeline_importer(tmp_path, telegram, alexandria, 1, progress)
+    try:
+        await importer.run([media_ref(1, "model-1.zip")])
+
+        assert progress.entered and progress.exited
+        assert phases_for(progress, "model-1.zip") == [
+            "download",
+            "hashing",
+            "upload",
+            "committing",
+        ]
+        assert ("model_end", "model-1.zip") in progress.events
+    finally:
+        tracker.close()
+
+
+@pytest.mark.asyncio
+async def test_should_report_run_totals_as_each_model_settles(
+    tmp_path,
+    media_ref,
+) -> None:
+    telegram = PipelineTelegram()
+    alexandria = PipelineAlexandria()
+    progress = RecordingProgress()
+    importer, tracker = pipeline_importer(tmp_path, telegram, alexandria, 1, progress)
+    try:
+        await importer.run(
+            [media_ref(index, f"model-{index}.zip") for index in range(1, 4)]
+        )
+
+        assert progress.totals_calls[0] == (0, 3, {})
+        assert progress.totals_calls[-1] == (3, 3, {"completed": 3})
+        assert [call[0] for call in progress.totals_calls] == [0, 1, 2, 3]
+    finally:
+        tracker.close()
+
+
+@pytest.mark.asyncio
+async def test_should_count_a_failed_model_separately_in_run_totals(
+    tmp_path,
+    media_ref,
+) -> None:
+    class FailingTelegram(PipelineTelegram):
+        async def download(self, ref, directory, *, on_progress=None):
+            if ref.message_id == 2:
+                raise RuntimeError("telegram refused the download")
+            return await super().download(ref, directory, on_progress=on_progress)
+
+    telegram = FailingTelegram()
+    alexandria = PipelineAlexandria()
+    progress = RecordingProgress()
+    importer, tracker = pipeline_importer(tmp_path, telegram, alexandria, 1, progress)
+    try:
+        await importer.run(
+            [media_ref(index, f"model-{index}.zip") for index in range(1, 4)]
+        )
+
+        assert progress.totals_calls[-1] == (3, 3, {"completed": 2, "failed": 1})
+    finally:
+        tracker.close()
+
+
+@pytest.mark.asyncio
+async def test_should_count_a_resumed_run_from_zero_rather_than_the_state_file(
+    tmp_path,
+    media_ref,
+) -> None:
+    telegram = PipelineTelegram()
+    alexandria = PipelineAlexandria()
+    progress = RecordingProgress()
+    importer, tracker = pipeline_importer(tmp_path, telegram, alexandria, 1, progress)
+    refs = [media_ref(index, f"model-{index}.zip") for index in range(1, 3)]
+    try:
+        await importer.run(refs)
+        progress.totals_calls.clear()
+
+        await importer.run(refs)
+
+        # The tracker already holds two completed rows from the first run; the
+        # second run must still open at zero and settle them as skipped.
+        assert progress.totals_calls[0] == (0, 2, {})
+        assert progress.totals_calls[-1] == (2, 2, {"skipped": 2})
+    finally:
+        tracker.close()
+
+
+@pytest.mark.asyncio
+async def test_should_open_one_progress_model_per_concurrent_import(
+    tmp_path,
+    media_ref,
+) -> None:
+    telegram = PipelineTelegram(delay=0.02)
+    alexandria = PipelineAlexandria()
+    progress = RecordingProgress()
+    importer, tracker = pipeline_importer(tmp_path, telegram, alexandria, 3, progress)
+    try:
+        await importer.run(
+            [media_ref(index, f"model-{index}.zip") for index in range(1, 5)]
+        )
+
+        assert progress.max_open_models == 3
+        assert progress.open_models == 0
+    finally:
+        tracker.close()
+
+
+@pytest.mark.asyncio
+async def test_should_report_the_packaging_phase_for_a_bare_model_file(
+    tmp_path,
+    media_ref,
+) -> None:
+    telegram = PipelineTelegram()
+    alexandria = PipelineAlexandria()
+    progress = RecordingProgress()
+    importer, tracker = pipeline_importer(tmp_path, telegram, alexandria, 1, progress)
+    try:
+        # A bare .stl is zipped before upload, unlike an archive that ships as-is.
+        await importer.run([media_ref(1, "model-1.stl")])
+
+        assert phases_for(progress, "model-1.stl") == [
+            "download",
+            "hashing",
+            "packaging",
+            "upload",
+            "committing",
+        ]
+    finally:
+        tracker.close()
+
+
+@pytest.mark.asyncio
+async def test_should_report_the_scanning_phase_while_alexandria_scans(
+    tmp_path,
+    media_ref,
+) -> None:
+    class ScanningAlexandria(PipelineAlexandria):
+        async def complete_upload(self, upload_ids, *, multipart: bool):
+            session_id = await super().complete_upload(upload_ids, multipart=multipart)
+            # A real session starts in "scanning" and only later becomes
+            # reviewable, which is what puts a model on the scanning phase.
+            self.sessions[session_id]["status"] = "scanning"
+            return session_id
+
+        async def wait_for_session(self, session_id: str, statuses, **kwargs):
+            session = self.sessions[session_id]
+            session["status"] = (
+                "ready_for_review" if "ready_for_review" in statuses else "committed"
+            )
+            return session
+
+    telegram = PipelineTelegram()
+    alexandria = ScanningAlexandria()
+    progress = RecordingProgress()
+    importer, tracker = pipeline_importer(tmp_path, telegram, alexandria, 1, progress)
+    try:
+        await importer.run([media_ref(1, "model-1.zip")])
+
+        assert phases_for(progress, "model-1.zip") == [
+            "download",
+            "hashing",
+            "upload",
+            "scanning",
+            "committing",
+        ]
+    finally:
+        tracker.close()
+
+
+@pytest.mark.asyncio
+async def test_should_still_settle_a_model_when_the_reporter_fails(
+    tmp_path,
+    media_ref,
+) -> None:
+    class BrokenProgress(RecordingProgress):
+        def totals(self, done: int, total: int, counts) -> None:
+            super().totals(done, total, counts)
+            raise RuntimeError("the display exploded")
+
+    telegram = PipelineTelegram()
+    alexandria = PipelineAlexandria()
+    progress = BrokenProgress()
+    importer, tracker = pipeline_importer(tmp_path, telegram, alexandria, 1, progress)
+    try:
+        counts = await importer.run([media_ref(1, "model-1.zip")])
+
+        # A display fault must not be re-read as an import failure, nor counted
+        # twice on the way back out.
+        assert counts == {"completed": 1}
+        assert progress.totals_calls[-1] == (1, 1, {"completed": 1})
+    finally:
+        tracker.close()
+
+
+@pytest.mark.asyncio
+async def test_should_import_every_model_when_the_reporter_cannot_open_rows(
+    tmp_path,
+    media_ref,
+) -> None:
+    class UnopenableProgress(RecordingProgress):
+        @contextmanager
+        def model(self, label: str, *, parts: int):
+            raise RuntimeError("the display exploded")
+            yield  # pragma: no cover - unreachable, keeps this a generator
+
+    telegram = PipelineTelegram()
+    alexandria = PipelineAlexandria()
+    importer, tracker = pipeline_importer(
+        tmp_path, telegram, alexandria, 2, UnopenableProgress()
+    )
+    try:
+        counts = await importer.run(
+            [media_ref(index, f"model-{index}.zip") for index in range(1, 4)]
+        )
+
+        assert counts == {"completed": 3}
+    finally:
+        tracker.close()
+
+
+@pytest.mark.asyncio
+async def test_should_import_every_model_when_the_reporter_cannot_start(
+    tmp_path,
+    media_ref,
+) -> None:
+    class UnstartableProgress(RecordingProgress):
+        def __enter__(self):
+            raise RuntimeError("the display exploded")
+
+    telegram = PipelineTelegram()
+    alexandria = PipelineAlexandria()
+    progress = UnstartableProgress()
+    importer, tracker = pipeline_importer(tmp_path, telegram, alexandria, 1, progress)
+    try:
+        counts = await importer.run([media_ref(1, "model-1.zip")])
+
+        assert counts == {"completed": 1}
+        # Never started, so it is never stopped either.
+        assert progress.exited is False
     finally:
         tracker.close()

--- a/tools/telegram-importer/tests/test_progress.py
+++ b/tools/telegram-importer/tests/test_progress.py
@@ -1,0 +1,463 @@
+from __future__ import annotations
+
+import logging
+import sys
+import threading
+from contextlib import contextmanager
+from io import StringIO
+
+import pytest
+from rich.console import Console
+
+from alexandria_telegram_importer.progress import (
+    LogProgress,
+    NullModelProgress,
+    NullProgress,
+    RichDashboard,
+    format_bytes,
+    format_counts,
+    guarded_model,
+    select_reporter,
+)
+
+
+class FakeClock:
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+def transfer_lines(caplog) -> list[str]:
+    return [
+        record.getMessage()
+        for record in caplog.records
+        if "download" in record.getMessage() or "upload" in record.getMessage()
+    ]
+
+
+def test_should_throttle_rapid_progress_within_one_interval(caplog) -> None:
+    clock = FakeClock()
+    progress = LogProgress(clock=clock, interval=10.0)
+
+    with caplog.at_level(logging.INFO):
+        with progress.model("dragon.zip", parts=1) as handle:
+            with handle.transfer("download", "dragon.zip") as transfer:
+                transfer.advance(10, 100)
+                clock.advance(1.0)
+                transfer.advance(20, 100)
+                clock.advance(1.0)
+                transfer.advance(30, 100)
+
+    # The two mid-interval updates are collapsed into the closing line.
+    lines = transfer_lines(caplog)
+    assert len(lines) == 2
+    assert "10%" in lines[0]
+    assert "30%" in lines[1]
+
+
+def test_should_log_again_once_the_interval_elapses(caplog) -> None:
+    clock = FakeClock()
+    progress = LogProgress(clock=clock, interval=10.0)
+
+    with caplog.at_level(logging.INFO):
+        with progress.model("dragon.zip", parts=1) as handle:
+            with handle.transfer("download", "dragon.zip") as transfer:
+                transfer.advance(10, 100)
+                clock.advance(11.0)
+                transfer.advance(50, 100)
+
+    lines = transfer_lines(caplog)
+    assert len(lines) == 2
+    assert "50%" in lines[1]
+
+
+def test_should_always_log_a_final_line_at_completion(caplog) -> None:
+    clock = FakeClock()
+    progress = LogProgress(clock=clock, interval=10.0)
+
+    with caplog.at_level(logging.INFO):
+        with progress.model("dragon.zip", parts=1) as handle:
+            with handle.transfer("upload", "dragon.zip") as transfer:
+                transfer.advance(10, 100)
+                clock.advance(0.5)
+                transfer.advance(100, 100)
+
+    lines = transfer_lines(caplog)
+    assert "100%" in lines[-1]
+
+
+def test_should_log_a_closing_line_for_a_transfer_that_never_completed(caplog) -> None:
+    clock = FakeClock()
+    progress = LogProgress(clock=clock, interval=10.0)
+
+    with caplog.at_level(logging.INFO):
+        with progress.model("dragon.zip", parts=1) as handle:
+            with handle.transfer("download", "dragon.zip") as transfer:
+                transfer.advance(10, 100)
+                clock.advance(2.0)
+                transfer.advance(40, 100)
+
+    lines = transfer_lines(caplog)
+    assert len(lines) == 2
+    assert "40%" in lines[-1]
+
+
+def test_should_report_transfers_of_unknown_total_size_without_a_percentage(
+    caplog,
+) -> None:
+    clock = FakeClock()
+    progress = LogProgress(clock=clock, interval=10.0)
+
+    with caplog.at_level(logging.INFO):
+        with progress.model("photo.jpg", parts=1) as handle:
+            with handle.transfer("download", "photo.jpg") as transfer:
+                transfer.advance(2048, 0)
+
+    line = transfer_lines(caplog)[0]
+    assert "%" not in line
+    assert "2 KB" in line
+
+
+def test_should_throttle_concurrent_transfers_independently(caplog) -> None:
+    clock = FakeClock()
+    progress = LogProgress(clock=clock, interval=10.0)
+
+    with caplog.at_level(logging.INFO):
+        with progress.model("a.zip", parts=1) as first_handle:
+            with progress.model("b.zip", parts=1) as second_handle:
+                with first_handle.transfer("download", "a.zip") as first:
+                    with second_handle.transfer("download", "b.zip") as second:
+                        first.advance(10, 100)
+                        second.advance(10, 100)
+
+    lines = transfer_lines(caplog)
+    assert sum("a.zip" in line for line in lines) == 1
+    assert sum("b.zip" in line for line in lines) == 1
+
+
+def test_should_log_run_totals_with_the_outcome_tally(caplog) -> None:
+    with caplog.at_level(logging.INFO):
+        LogProgress().totals(47, 143, {"completed": 44, "duplicates": 2, "failed": 1})
+
+    assert "47/143 models (44 completed · 2 duplicates · 1 failed)" in caplog.text
+
+
+def test_should_reuse_the_lowest_free_dashboard_slot() -> None:
+    dashboard = RichDashboard(console=Console(file=StringIO(), force_terminal=True))
+
+    with dashboard.model("first.zip", parts=1):
+        with dashboard.model("second.zip", parts=1):
+            with dashboard.model("third.zip", parts=1):
+                assert sorted(dashboard._rows) == [1, 2, 3]
+            assert sorted(dashboard._rows) == [1, 2]
+        # The freed middle slot is taken before a new one is opened, so rows
+        # keep stable positions.
+        with dashboard.model("fourth.zip", parts=1):
+            assert sorted(dashboard._rows) == [1, 2]
+            assert dashboard._rows[2].label == "fourth.zip"
+    assert dashboard._rows == {}
+
+
+def test_should_release_a_dashboard_slot_when_a_model_fails() -> None:
+    dashboard = RichDashboard(console=Console(file=StringIO(), force_terminal=True))
+
+    with pytest.raises(RuntimeError), dashboard.model("doomed.zip", parts=1):
+        raise RuntimeError("import blew up")
+
+    assert dashboard._rows == {}
+
+
+def test_should_render_every_phase_without_raising() -> None:
+    output = StringIO()
+    console = Console(file=output, force_terminal=True, width=120)
+    clock = FakeClock()
+    dashboard = RichDashboard(console=console, clock=clock)
+
+    with dashboard:
+        dashboard.totals(1, 3, {"completed": 1})
+        with dashboard.model("dragon-bust.zip", parts=2) as handle:
+            with handle.transfer("download", "dragon-bust.zip") as transfer:
+                transfer.advance(412, 920)
+                console.print(dashboard)
+            with handle.transfer("upload", "dragon-bust.zip") as transfer:
+                transfer.advance(0, 0)
+                console.print(dashboard)
+            handle.phase("scanning")
+            clock.advance(44)
+            console.print(dashboard)
+            handle.attachments(2, 5)
+            console.print(dashboard)
+            handle.phase("committing")
+            console.print(dashboard)
+
+    rendered = output.getvalue()
+    assert "dragon-bust.zip" in rendered
+    assert "scanning" in rendered
+
+
+def test_should_fall_back_to_log_progress_when_the_live_region_fails(
+    monkeypatch, caplog
+) -> None:
+    def explode(*_args, **_kwargs):
+        raise RuntimeError("terminal refused the live region")
+
+    monkeypatch.setattr("alexandria_telegram_importer.progress.Live", explode)
+    dashboard = RichDashboard(console=Console(file=StringIO(), force_terminal=True))
+
+    with caplog.at_level(logging.INFO), dashboard:
+        dashboard.totals(1, 2, {"completed": 1})
+        with dashboard.model("dragon.zip", parts=1) as handle:
+            with handle.transfer("download", "dragon.zip") as transfer:
+                transfer.advance(50, 100)
+
+    assert "1/2 models" in caplog.text
+    assert any("dragon.zip download" in line for line in transfer_lines(caplog))
+
+
+def test_should_restore_logging_handlers_after_the_dashboard_exits() -> None:
+    root = logging.getLogger()
+    before = list(root.handlers)
+    dashboard = RichDashboard(console=Console(file=StringIO(), force_terminal=True))
+
+    with dashboard:
+        pass
+
+    assert root.handlers == before
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "expected"),
+    [
+        (
+            {"no_progress": True, "dry_run": False, "verbose": False, "is_tty": True},
+            NullProgress,
+        ),
+        (
+            {"no_progress": False, "dry_run": True, "verbose": False, "is_tty": True},
+            NullProgress,
+        ),
+        (
+            {"no_progress": False, "dry_run": False, "verbose": True, "is_tty": True},
+            LogProgress,
+        ),
+        (
+            {"no_progress": False, "dry_run": False, "verbose": False, "is_tty": True},
+            RichDashboard,
+        ),
+        (
+            {"no_progress": False, "dry_run": False, "verbose": False, "is_tty": False},
+            LogProgress,
+        ),
+    ],
+)
+def test_should_select_the_reporter_that_suits_the_output(kwargs, expected) -> None:
+    assert isinstance(select_reporter(**kwargs), expected)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [(0, "0 B"), (512, "512 B"), (2048, "2 KB"), (5 * 1024**2, "5.0 MB")],
+)
+def test_should_format_byte_counts_for_humans(value: int, expected: str) -> None:
+    assert format_bytes(value) == expected
+
+
+def test_should_omit_zero_outcomes_from_the_tally() -> None:
+    assert format_counts({"completed": 3, "failed": 0, "duplicates": 1}) == (
+        "3 completed · 1 duplicates"
+    )
+    assert format_counts({}) == ""
+
+
+def test_null_progress_should_accept_every_call() -> None:
+    with NullProgress() as progress:
+        progress.totals(1, 2, {"completed": 1})
+        with progress.model("dragon.zip", parts=1) as handle:
+            handle.phase("scanning")
+            handle.attachments(1, 2)
+            with handle.transfer("download", "dragon.zip") as transfer:
+                transfer.advance(10, 100)
+
+
+def test_should_not_leave_a_finished_transfer_labelling_the_next_phase() -> None:
+    dashboard = RichDashboard(console=Console(file=StringIO(), force_terminal=True))
+
+    with dashboard.model("dragon.zip", parts=1) as handle:
+        with handle.transfer("download", "dragon.zip") as transfer:
+            transfer.advance(50, 100)
+            assert dashboard._rows[1].phase == "download"
+        # Hashing and zipping happen here; the row must not still say "download".
+        assert dashboard._rows[1].phase == "working"
+        assert dashboard._rows[1].mode == "phase"
+
+
+def test_should_withhold_an_unmeasurable_transfer_rate() -> None:
+    clock = FakeClock()
+    dashboard = RichDashboard(
+        console=Console(file=StringIO(), force_terminal=True), clock=clock
+    )
+
+    with dashboard.model("dragon.zip", parts=1) as handle:
+        with handle.transfer("download", "dragon.zip") as transfer:
+            transfer.advance(500, 1000)
+            row = dashboard._rows[1]
+            assert "/s" not in dashboard._render_detail(row, clock.now)
+            clock.advance(10.0)
+            assert "50 B/s" in dashboard._render_detail(row, clock.now)
+
+
+def test_should_render_while_rows_are_added_and_removed_concurrently() -> None:
+    """rich refreshes on its own thread while the import mutates rows."""
+    dashboard = RichDashboard(console=Console(file=StringIO(), force_terminal=True))
+    failures: list[BaseException] = []
+    stop = threading.Event()
+
+    def render_forever() -> None:
+        while not stop.is_set():
+            try:
+                dashboard._render()
+            except BaseException as error:  # noqa: BLE001
+                failures.append(error)
+                return
+
+    renderer = threading.Thread(target=render_forever)
+    renderer.start()
+    try:
+        for _ in range(2000):
+            with dashboard.model("a.zip", parts=1), dashboard.model("b.zip", parts=1):
+                pass
+    finally:
+        stop.set()
+        renderer.join(timeout=5)
+
+    assert failures == []
+
+
+def test_should_rebase_the_transfer_rate_clock_after_a_retry() -> None:
+    clock = FakeClock()
+    dashboard = RichDashboard(
+        console=Console(file=StringIO(), force_terminal=True), clock=clock
+    )
+
+    with dashboard.model("dragon.zip", parts=1) as handle:
+        with handle.transfer("download", "dragon.zip") as transfer:
+            transfer.advance(400, 1000)
+            # A FloodWaitError sleeps for minutes, then the retry restarts at 0.
+            clock.advance(300.0)
+            transfer.advance(0, 1000)
+            clock.advance(10.0)
+            transfer.advance(500, 1000)
+            row = dashboard._rows[1]
+            # 500 B over the retry's own 10s, not over the 310s since the first
+            # attempt began.
+            assert "50 B/s" in dashboard._render_detail(row, clock.now)
+
+
+def test_should_rebase_the_logged_transfer_rate_after_a_retry(caplog) -> None:
+    clock = FakeClock()
+    progress = LogProgress(clock=clock, interval=10.0)
+
+    with caplog.at_level(logging.INFO):
+        with progress.model("dragon.zip", parts=1) as handle:
+            with handle.transfer("download", "dragon.zip") as transfer:
+                transfer.advance(400, 1000)
+                clock.advance(300.0)
+                transfer.advance(0, 1000)
+                clock.advance(10.0)
+                transfer.advance(500, 1000)
+
+    assert "50 B/s" in transfer_lines(caplog)[-1]
+
+
+def test_should_leave_stdout_alone_while_the_live_region_runs() -> None:
+    dashboard = RichDashboard(console=Console(file=StringIO(), force_terminal=True))
+    before = sys.stdout
+
+    with dashboard:
+        during = sys.stdout
+
+    assert during is before
+    assert sys.stdout is before
+
+
+def test_should_restore_logging_handlers_when_capture_is_interrupted(
+    monkeypatch,
+) -> None:
+    """A SIGINT can land between removing the old handlers and adding the new."""
+    root = logging.getLogger()
+    extra = logging.StreamHandler(StringIO())
+    root.addHandler(extra)
+    before = list(root.handlers)
+    real_remove = logging.Logger.removeHandler
+    calls = {"count": 0}
+
+    def interrupted_remove(self, handler) -> None:
+        calls["count"] += 1
+        real_remove(self, handler)
+        if calls["count"] == 1:
+            raise KeyboardInterrupt
+
+    dashboard = RichDashboard(console=Console(file=StringIO(), force_terminal=True))
+    monkeypatch.setattr(logging.Logger, "removeHandler", interrupted_remove)
+    try:
+        with pytest.raises(KeyboardInterrupt):
+            dashboard._capture_logging()
+    finally:
+        monkeypatch.undo()
+
+    try:
+        assert root.handlers == before
+    finally:
+        root.removeHandler(extra)
+
+
+def test_should_stop_a_partially_started_live_region_before_falling_back(
+    monkeypatch,
+) -> None:
+    stopped: list[bool] = []
+
+    class HalfStartedLive:
+        def __init__(self, *_args, **_kwargs) -> None:
+            pass
+
+        def start(self) -> None:
+            raise RuntimeError("terminal refused the live region")
+
+        def stop(self) -> None:
+            stopped.append(True)
+
+    monkeypatch.setattr("alexandria_telegram_importer.progress.Live", HalfStartedLive)
+    dashboard = RichDashboard(console=Console(file=StringIO(), force_terminal=True))
+
+    with dashboard:
+        pass
+
+    assert stopped == [True]
+    assert dashboard._fallback is not None
+
+
+def test_guarded_model_should_survive_a_reporter_that_cannot_open_a_row() -> None:
+    class BrokenReporter:
+        def model(self, label: str, *, parts: int):
+            raise RuntimeError("reporter is broken")
+
+    with guarded_model(BrokenReporter(), "dragon.zip", parts=1) as handle:
+        handle.phase("scanning")
+        with handle.transfer("download", "dragon.zip") as transfer:
+            transfer.advance(1, 2)
+
+
+def test_guarded_model_should_survive_a_reporter_that_cannot_close_a_row() -> None:
+    class BrokenExit:
+        @contextmanager
+        def model(self, label: str, *, parts: int):
+            yield NullModelProgress()
+            raise RuntimeError("reporter blew up on exit")
+
+    with guarded_model(BrokenExit(), "dragon.zip", parts=1) as handle:
+        handle.phase("scanning")

--- a/tools/telegram-importer/tests/test_telegram_source.py
+++ b/tools/telegram-importer/tests/test_telegram_source.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
+from alexandria_telegram_importer.models import MediaKind, MediaRef
 from alexandria_telegram_importer.telegram_source import TelegramSource
 
 
@@ -27,3 +31,48 @@ def test_should_distinguish_photo_identity_and_missing_media() -> None:
 
     assert TelegramSource._media_identity(photo) == "photo:987654321:2048"
     assert TelegramSource._media_identity(missing) is None
+
+
+class RecordingTelethonClient:
+    """Stands in for telethon's client, capturing the download arguments."""
+
+    def __init__(self) -> None:
+        self.progress_callback = None
+
+    async def get_messages(self, _entity, ids: int):
+        return SimpleNamespace(id=ids)
+
+    async def download_media(self, _message, file: str, progress_callback=None):
+        self.progress_callback = progress_callback
+        Path(file).write_bytes(b"payload")
+        return file
+
+
+@pytest.mark.asyncio
+async def test_should_forward_the_progress_callback_to_telethon(tmp_path) -> None:
+    source = TelegramSource.__new__(TelegramSource)
+    client = RecordingTelethonClient()
+    source._client = client
+    source.entity = object()
+    ref = MediaRef(message_id=7, filename="dragon.zip", kind=MediaKind.MODEL)
+    seen: list[tuple[int, int]] = []
+
+    await source.download(ref, tmp_path, on_progress=lambda a, b: seen.append((a, b)))
+
+    assert client.progress_callback is not None
+    client.progress_callback(5, 10)
+    assert seen == [(5, 10)]
+
+
+@pytest.mark.asyncio
+async def test_should_download_without_a_progress_callback(tmp_path) -> None:
+    source = TelegramSource.__new__(TelegramSource)
+    client = RecordingTelethonClient()
+    source._client = client
+    source.entity = object()
+    ref = MediaRef(message_id=7, filename="dragon.zip", kind=MediaKind.MODEL)
+
+    path = await source.download(ref, tmp_path)
+
+    assert path.exists()
+    assert client.progress_callback is None

--- a/tools/telegram-importer/uv.lock
+++ b/tools/telegram-importer/uv.lock
@@ -11,6 +11,7 @@ dependencies = [
     { name = "filelock" },
     { name = "httpx" },
     { name = "python-dotenv" },
+    { name = "rich" },
     { name = "telethon" },
 ]
 
@@ -28,6 +29,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.25.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
+    { name = "rich", specifier = ">=13.0.0" },
     { name = "telethon", specifier = ">=1.42.0" },
 ]
 provides-extras = ["test"]
@@ -161,6 +163,27 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.2"
 source = { registry = "https://pypi.org/simple" }
@@ -238,6 +261,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why

A single Telegram model can be close to a gigabyte. Today the importer logs `Importing dragon-bust.zip` and then says nothing until `Downloaded Telegram message 4821 to …` minutes later — no throughput, no remaining work, no way to tell a slow transfer from a stalled one. `--concurrency N` compounds it: N models are in flight and their log lines interleave with no indication of how many are active or what each is doing.

## What

A `ProgressReporter` injected into `ChannelImporter`. On an interactive terminal, `RichDashboard` pins a live block below the scrolling log:

```
2026-07-25 04:12:03 INFO Importing dragon-bust.zip
2026-07-25 04:12:31 INFO Imported castle-set.7z as Alexandria model 0f3adc12

  Total  ━━━━━━━━━╸━━━━━━━━━━━━━━━━━━━━  47/143 models
  44 completed · 2 duplicates · 1 failed

  #1  dragon-bust.zip    upload    ━━━━━━╸━━━━━━━━  412.0 MB/920.0 MB  8.1 MB/s
  #2  castle-set.7z.002  download  ━━━╸━━━━━━━━━━━  180.0 MB/700.0 MB  4.4 MB/s
  #3  knight-armor.stl   scanning  ⠋                waiting on Alexandria  0:00:44
```

Rows use stable slot numbers, so a finishing `#2` does not shift `#3` mid-transfer. Phases are `download`, `hashing`, `packaging`, `upload`, `attachments`, `scanning`, `committing`. Only transfers get byte bars; the rest show elapsed time, because the importer is waiting on Alexandria rather than moving bytes.

Off a terminal — `docker compose logs`, CI, a redirect — `LogProgress` emits throttled lines instead, at most one per transfer per 10s plus a guaranteed final line, so captured logs stay free of escape codes. `--verbose` uses these too, since debug output would contend with the live region. `--no-progress` (or `TELEGRAM_IMPORT_NO_PROGRESS=1`) restores the previous output exactly.

## The display cannot break an import

This was the main design constraint, and several fixes in this PR came from reviewing against it:

- `guarded_reporter` and `guarded_model` contain reporter faults at the call sites; `_report_totals` does the same for the tally.
- `_import_unit` now *returns* its outcome and `_process_unit` settles it, outside `_import_unit`'s own `except Exception`. Previously a reporter fault while recording a completed model would have been caught there — overwriting a completed row in the state file with `failed` and counting the model twice.
- `Live` refreshes on its own thread, so `__rich__` runs off the event loop while rows are added and removed. The renderer takes one atomic snapshot rather than iterating the live dict, which could raise and silently kill the refresh thread for the rest of the run.
- A partially started live region is stopped before falling back to `LogProgress`, so a failed start cannot orphan a hidden cursor and redirected streams.
- The log-handler swap unwinds itself if interrupted part-way, and `__exit__` stops the live region before restoring handlers.

## Notes

- Adds `rich>=13.0` as a dependency of this tool only (nothing in `apps/` or `packages/` changes).
- The tally counts the current run. A resumed import opens at zero and counts already-imported models as `skipped`, rather than starting from the state file's historical totals.
- Attachments show a file counter rather than a bar: `append_files` hands whole files to httpx, so there is no chunk boundary to hook.
- Progress goes to stderr, leaving stdout free for `--dry-run` plans and the final `Import state:` line.

## Testing

130 tests pass (`uv run pytest`), up from 106. New coverage includes throttle timing on an injected clock, slot allocation and release-on-failure, the reporter-selection table, upload progress not double-counting a retried chunk, rate-clock rebasing after a Telegram retry, a threaded render race regression test, and imports completing normally against reporters that raise from `__enter__`, `model`, and `totals`.

Design doc: `docs/superpowers/specs/2026-07-25-telegram-importer-progress-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)