### PR TITLE
refactor: drop unused models.file_hash column

### DIFF
--- a/apps/backend/src/db/migrations/0014_drop_model_file_hash.sql
+++ b/apps/backend/src/db/migrations/0014_drop_model_file_hash.sql
@@ -1,0 +1,13 @@
+-- Drop models.file_hash. The column was documented as "SHA-256 hash of the
+-- archive/source, for deduplication detection" but was never written by any
+-- ingestion path, never read or queried, and never indexed — it advertised a
+-- deduplication capability that does not exist.
+--
+-- An archive-level hash is also the wrong basis for dedup here: folder imports
+-- have no archive at all, and re-compressing identical content yields a
+-- different digest, so it cannot recognise the same model arriving from a
+-- different source. If server-side deduplication is added later, the sound
+-- basis is model_files.hash (per-file SHA-256, NOT NULL, populated on every
+-- ingestion path), which is content-derived and recompression-proof.
+
+ALTER TABLE "models" DROP COLUMN "file_hash";

--- a/apps/backend/src/db/migrations/meta/_journal.json
+++ b/apps/backend/src/db/migrations/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1784771952000,
       "tag": "0013_add_import_session_draft_metadata",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1784771953000,
+      "tag": "0014_drop_model_file_hash",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/backend/src/db/schema/model.ts
+++ b/apps/backend/src/db/schema/model.ts
@@ -35,8 +35,6 @@ export const models = pgTable(
     // bigint for file sizes that may exceed 2GB
     totalSizeBytes: bigint('total_size_bytes', { mode: 'number' }).notNull().default(0),
     fileCount: integer('file_count').notNull().default(0),
-    // SHA-256 hash of the archive/source, for deduplication detection
-    fileHash: varchar('file_hash', { length: 64 }),
     createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
     updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
     // Populated and maintained by the models_search_vector_update trigger.

--- a/apps/backend/src/services/model.service.test.ts
+++ b/apps/backend/src/services/model.service.test.ts
@@ -70,7 +70,6 @@ describe('ModelService – getModelById', () => {
       originalFilename: 'my-model.zip',
       totalSizeBytes: 1024,
       fileCount: 3,
-      fileHash: null,
       createdAt: new Date(),
       updatedAt: new Date(),
     };

--- a/apps/backend/src/services/model.service.ts
+++ b/apps/backend/src/services/model.service.ts
@@ -59,7 +59,6 @@ export interface CreateThumbnailData {
 export interface UpdateModelStatusData {
   totalSizeBytes?: number;
   fileCount?: number;
-  fileHash?: string;
 }
 
 export class ModelService {
@@ -230,7 +229,6 @@ export class ModelService {
         updatedAt: new Date(),
         ...(updates?.totalSizeBytes !== undefined && { totalSizeBytes: updates.totalSizeBytes }),
         ...(updates?.fileCount !== undefined && { fileCount: updates.fileCount }),
-        ...(updates?.fileHash !== undefined && { fileHash: updates.fileHash }),
       })
       .where(eq(models.id, modelId));
   }

--- a/docs/TYPES.md
+++ b/docs/TYPES.md
@@ -77,7 +77,6 @@ interface Model {
   originalFilename: string | null;
   totalSizeBytes: number;
   fileCount: number;
-  fileHash: string | null;
   previewImageFileId: string | null; // user-selected cover image; null = first-image fallback
   createdAt: string;
   updatedAt: string;

--- a/packages/shared/src/types/model.ts
+++ b/packages/shared/src/types/model.ts
@@ -13,7 +13,6 @@ export interface Model {
   originalFilename: string | null;
   totalSizeBytes: number;
   fileCount: number;
-  fileHash: string | null;
   previewImageFileId: string | null;
   previewCropX: number | null;
   previewCropY: number | null;


### PR DESCRIPTION
## Summary

`models.file_hash` was declared as `varchar(64)` with the comment *\"SHA-256 hash of the archive/source, for deduplication detection\"*, but it was dead weight:

- **Never written.** All three `updateModelStatus(..., 'ready', ...)` call sites in `IngestionService` (archive commit, zip upload, folder import) pass only `totalSizeBytes` and `fileCount`. The `updates?.fileHash` branch in `ModelService.updateModelStatus` had no caller.
- **Never read.** No query, filter, or response in `apps/backend/src` touched it.
- **Never indexed.** The `models` table config defines ~10 indexes; none covered `file_hash`.

The column is removed rather than wired up, because wiring it up would not have delivered the capability its comment advertised.

## Why not implement server-side dedup on it

An archive-level digest cannot recognise the same model arriving from a different source, which is the case that actually matters:

- `folder_import` has no archive at all, so the column would stay `NULL` on that path.
- Re-compressing identical content yields a different digest. The Telegram importer re-zips bare files before upload, so the same STL uploaded manually and imported via Telegram would produce two different hashes and still be stored twice.

If server-side deduplication is added later, the sound basis is `model_files.hash` — a per-file SHA-256, `NOT NULL`, already populated on **every** ingestion path, content-derived rather than container-derived, and therefore recompression-proof. `docs/ARCHITECTURE.md` already describes that column as the substrate for future dedup. This is left as a deliberate follow-up rather than being designed speculatively here.

## Scope of the Telegram importer

`tools/telegram-importer` keeps its local `content_signature` deduplication in the SQLite state file unchanged. Cross-instance deduplication (a model already in Alexandria via manual upload or another machine) remains an open gap — this PR does not close it, it just stops the schema from implying it is already closed.

## Changes

- `0014_drop_model_file_hash.sql` — `ALTER TABLE models DROP COLUMN file_hash`, with the rationale recorded in the migration
- `apps/backend/src/db/schema/model.ts` — column and comment removed
- `apps/backend/src/services/model.service.ts` — `fileHash` removed from `UpdateModelStatusData` and the update builder
- `packages/shared/src/types/model.ts`, `docs/TYPES.md` — `fileHash` removed from the `Model` contract
- `apps/backend/src/services/model.service.test.ts` — fixture updated

## Testing

- `npm run build` — clean across all three workspaces
- `npx vitest run` — 769 tests / 42 files passing
- Migration applied and verified against both `alexandria` and `alexandria_test`; `file_hash` is gone from both

🤖 Generated with [Claude Code](https://claude.com/claude-code)