### PR TITLE
feat: add bulk merge action for multi-selected models

### DIFF
--- a/apps/frontend/src/components/models/BulkActions.test.tsx
+++ b/apps/frontend/src/components/models/BulkActions.test.tsx
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import type { CollectionDetail } from '@alexandria/shared';
+import type { CollectionDetail, ModelCard } from '@alexandria/shared';
 import { BulkActions } from './BulkActions';
 
 vi.mock('../../api/bulk', () => ({
@@ -19,9 +19,31 @@ vi.mock('../../api/metadata', () => ({
   getFieldValues: vi.fn(),
 }));
 
+vi.mock('../../api/models', () => ({
+  getModel: vi.fn(),
+  mergeModels: vi.fn(),
+}));
+
 import { bulkCollection, bulkDelete, bulkMetadata } from '../../api/bulk';
 import { addModelsToCollection, getCollections } from '../../api/collections';
 import { getFieldValues } from '../../api/metadata';
+import { getModel, mergeModels } from '../../api/models';
+
+function modelCard(overrides: Partial<ModelCard> & Pick<ModelCard, 'id' | 'name'>): ModelCard {
+  return {
+    slug: overrides.id,
+    thumbnailUrl: null,
+    previewCropX: null,
+    previewCropY: null,
+    previewCropScale: null,
+    metadata: [],
+    fileCount: 2,
+    totalSizeBytes: 1024,
+    status: 'ready',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
 
 const target: CollectionDetail = {
   id: '22222222-2222-4222-8222-222222222222',
@@ -54,6 +76,7 @@ describe('BulkActions', () => {
     render(
       <BulkActions
         selectedIds={new Set(['model-1', 'model-2'])}
+        models={[]}
         onClear={vi.fn()}
         onComplete={onComplete}
       />,
@@ -80,6 +103,7 @@ describe('BulkActions', () => {
     render(
       <BulkActions
         selectedIds={new Set(['model-1'])}
+        models={[]}
         onClear={vi.fn()}
         onComplete={vi.fn()}
       />,
@@ -108,6 +132,7 @@ describe('BulkActions', () => {
     render(
       <BulkActions
         selectedIds={new Set(['model-1', 'model-2'])}
+        models={[]}
         onClear={vi.fn()}
         onComplete={onComplete}
       />,
@@ -136,6 +161,7 @@ describe('BulkActions', () => {
     render(
       <BulkActions
         selectedIds={new Set(['model-1', 'model-2'])}
+        models={[]}
         onClear={vi.fn()}
         onComplete={onComplete}
       />,
@@ -160,6 +186,7 @@ describe('BulkActions', () => {
     render(
       <BulkActions
         selectedIds={new Set(['model-1'])}
+        models={[]}
         onClear={vi.fn()}
         onComplete={vi.fn()}
       />,
@@ -195,6 +222,7 @@ describe('BulkActions', () => {
     render(
       <BulkActions
         selectedIds={new Set(['model-1'])}
+        models={[]}
         onClear={vi.fn()}
         onComplete={onComplete}
       />,
@@ -208,6 +236,195 @@ describe('BulkActions', () => {
     await waitFor(() => {
       expect(bulkDelete).toHaveBeenCalledWith({ modelIds: ['model-1'] });
       expect(onComplete).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('merge', () => {
+    const dragon = modelCard({ id: 'model-1', name: 'Dragon' });
+    const knight = modelCard({ id: 'model-2', name: 'Knight' });
+
+    it('hides the merge action until at least two models are selected', () => {
+      const { rerender } = render(
+        <BulkActions
+          selectedIds={new Set(['model-1'])}
+          models={[dragon, knight]}
+          onClear={vi.fn()}
+          onComplete={vi.fn()}
+        />,
+        { wrapper: Wrapper },
+      );
+
+      expect(screen.queryByRole('button', { name: 'Merge' })).not.toBeInTheDocument();
+
+      rerender(
+        <BulkActions
+          selectedIds={new Set(['model-1', 'model-2'])}
+          models={[dragon, knight]}
+          onClear={vi.fn()}
+          onComplete={vi.fn()}
+        />,
+      );
+
+      expect(screen.getByRole('button', { name: 'Merge' })).toBeInTheDocument();
+    });
+
+    it('merges the other selected models into the chosen target', async () => {
+      vi.mocked(mergeModels).mockResolvedValue({
+        targetModelId: 'model-2',
+        mergedModelIds: ['model-1'],
+        movedFileCount: 2,
+      });
+      const onComplete = vi.fn();
+
+      render(
+        <BulkActions
+          selectedIds={new Set(['model-1', 'model-2'])}
+          models={[dragon, knight]}
+          onClear={vi.fn()}
+          onComplete={onComplete}
+        />,
+        { wrapper: Wrapper },
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: 'Merge' }));
+      fireEvent.click(screen.getByRole('radio', { name: /Knight/ }));
+      fireEvent.click(screen.getByRole('button', { name: 'Merge 1 model in' }));
+
+      await waitFor(() => {
+        expect(mergeModels).toHaveBeenCalledWith('model-2', ['model-1']);
+        expect(onComplete).toHaveBeenCalledOnce();
+      });
+    });
+
+    it('keeps merge disabled until a target is chosen', () => {
+      render(
+        <BulkActions
+          selectedIds={new Set(['model-1', 'model-2'])}
+          models={[dragon, knight]}
+          onClear={vi.fn()}
+          onComplete={vi.fn()}
+        />,
+        { wrapper: Wrapper },
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: 'Merge' }));
+
+      const dialog = screen.getByRole('dialog');
+      expect(within(dialog).getByRole('button', { name: 'Merge' })).toBeDisabled();
+    });
+
+    it('excludes models that are not ready from the merge', async () => {
+      vi.mocked(mergeModels).mockResolvedValue({
+        targetModelId: 'model-1',
+        mergedModelIds: ['model-2'],
+        movedFileCount: 2,
+      });
+      const processing = modelCard({ id: 'model-3', name: 'Wyvern', status: 'processing' });
+
+      render(
+        <BulkActions
+          selectedIds={new Set(['model-1', 'model-2', 'model-3'])}
+          models={[dragon, knight, processing]}
+          onClear={vi.fn()}
+          onComplete={vi.fn()}
+        />,
+        { wrapper: Wrapper },
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: 'Merge' }));
+
+      expect(screen.getByText('1 selected model is not ready and will be skipped.')).toBeInTheDocument();
+      expect(screen.getByRole('radio', { name: /Wyvern/ })).toBeDisabled();
+
+      fireEvent.click(screen.getByRole('radio', { name: /Dragon/ }));
+      fireEvent.click(screen.getByRole('button', { name: 'Merge 1 model in' }));
+
+      await waitFor(() => {
+        expect(mergeModels).toHaveBeenCalledWith('model-1', ['model-2']);
+      });
+    });
+
+    it('blocks the merge when a selected model outside the loaded page cannot be loaded', async () => {
+      vi.mocked(getModel).mockRejectedValue(new Error('Not found'));
+
+      render(
+        <BulkActions
+          selectedIds={new Set(['model-1', 'model-2', 'model-9'])}
+          models={[dragon, knight]}
+          onClear={vi.fn()}
+          onComplete={vi.fn()}
+        />,
+        { wrapper: Wrapper },
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: 'Merge' }));
+
+      const dialog = screen.getByRole('dialog');
+      await waitFor(() => {
+        expect(
+          screen.getByText(/1 selected model could not be loaded/),
+        ).toBeInTheDocument();
+      });
+
+      // A truncated candidate list must not be mergeable, even with a valid target picked.
+      fireEvent.click(screen.getByRole('radio', { name: /Dragon/ }));
+      expect(within(dialog).getByRole('button', { name: 'Merge' })).toBeDisabled();
+      expect(mergeModels).not.toHaveBeenCalled();
+    });
+
+    it('blocks the merge when the selection exceeds the source cap', () => {
+      const many = Array.from({ length: 103 }, (_, index) =>
+        modelCard({ id: `model-${index}`, name: `Model ${index}` }),
+      );
+
+      render(
+        <BulkActions
+          selectedIds={new Set(many.map((model) => model.id))}
+          models={many}
+          onClear={vi.fn()}
+          onComplete={vi.fn()}
+        />,
+        { wrapper: Wrapper },
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: 'Merge' }));
+      fireEvent.click(screen.getByRole('radio', { name: /Model 0 /i }));
+
+      const dialog = screen.getByRole('dialog');
+      expect(
+        screen.getByText(/At most 100 models can be merged into one at a time\. Deselect 2/),
+      ).toBeInTheDocument();
+      expect(within(dialog).getByRole('button', { name: 'Merge' })).toBeDisabled();
+    });
+
+    it('fetches selected models that are no longer in the loaded page', async () => {
+      vi.mocked(getModel).mockResolvedValue({
+        ...modelCard({ id: 'model-9', name: 'Griffin' }),
+        description: null,
+        previewImageFileId: null,
+        sourceType: 'zip_upload',
+        originalFilename: null,
+        collections: [],
+        images: [],
+        updatedAt: '2026-01-01T00:00:00.000Z',
+      });
+
+      render(
+        <BulkActions
+          selectedIds={new Set(['model-1', 'model-9'])}
+          models={[dragon]}
+          onClear={vi.fn()}
+          onComplete={vi.fn()}
+        />,
+        { wrapper: Wrapper },
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: 'Merge' }));
+
+      await waitFor(() => {
+        expect(getModel).toHaveBeenCalledWith('model-9');
+        expect(screen.getByRole('radio', { name: /Griffin/ })).toBeInTheDocument();
+      });
     });
   });
 });

--- a/apps/frontend/src/components/models/BulkActions.tsx
+++ b/apps/frontend/src/components/models/BulkActions.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { AlertCircle, FolderInput, FolderPlus, Loader2, Tag, Trash2, X } from 'lucide-react';
-import type { CollectionDetail } from '@alexandria/shared';
+import { AlertCircle, FolderInput, FolderPlus, GitMerge, Loader2, Tag, Trash2, X } from 'lucide-react';
+import type { CollectionDetail, ModelCard } from '@alexandria/shared';
 import { bulkDelete, bulkCollection, bulkMetadata } from '../../api/bulk';
 import { addModelsToCollection, getCollections } from '../../api/collections';
 import { getFieldValues } from '../../api/metadata';
@@ -9,9 +9,12 @@ import { useToast } from '../../hooks/use-toast';
 import { Button } from '../ui/button';
 import { AlertDialog } from '../ui/alert-dialog';
 import { TagAutocomplete } from '../metadata/tag-autocomplete';
+import { MergeTargetDialog } from './MergeTargetDialog';
 
 interface BulkActionsProps {
   selectedIds: Set<string>;
+  /** Models loaded by the caller, so the merge dialog can name the selection. */
+  models: ModelCard[];
   onClear: () => void;
   onComplete: () => void;
 }
@@ -234,14 +237,16 @@ function TagPicker({ selectedIds, onClose, onDone }: TagPickerProps) {
 }
 
 // --- Main BulkActions bar ---
-export function BulkActions({ selectedIds, onClear, onComplete }: BulkActionsProps) {
+export function BulkActions({ selectedIds, models, onClear, onComplete }: BulkActionsProps) {
   const { toast } = useToast();
   const queryClient = useQueryClient();
   const count = selectedIds.size;
   const addTriggerRef = useRef<HTMLButtonElement>(null);
   const moveTriggerRef = useRef<HTMLButtonElement>(null);
+  const mergeTriggerRef = useRef<HTMLButtonElement>(null);
 
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [showMergeDialog, setShowMergeDialog] = useState(false);
   const [activePicker, setActivePicker] = useState<'add' | 'move' | 'tag' | null>(null);
 
   function closeCollectionPicker(action: 'add' | 'move') {
@@ -342,6 +347,22 @@ export function BulkActions({ selectedIds, onClear, onComplete }: BulkActionsPro
           )}
         </div>
 
+        {/* Merge button — merging needs at least two models */}
+        {count >= 2 && (
+          <Button
+            ref={mergeTriggerRef}
+            size="sm"
+            variant="ghost"
+            className="text-background hover:text-background hover:bg-black/10 dark:hover:bg-white/10"
+            onClick={() => setShowMergeDialog(true)}
+            aria-haspopup="dialog"
+            aria-expanded={showMergeDialog}
+          >
+            <GitMerge className="h-4 w-4 mr-1.5" />
+            Merge
+          </Button>
+        )}
+
         {/* Delete button */}
         <Button
           size="sm"
@@ -378,6 +399,20 @@ export function BulkActions({ selectedIds, onClear, onComplete }: BulkActionsPro
           </div>
         )}
       </div>
+
+      {/* Merge target picker */}
+      <MergeTargetDialog
+        selectedIds={selectedIds}
+        models={models}
+        open={showMergeDialog}
+        onOpenChange={(open) => {
+          setShowMergeDialog(open);
+          // Dismissing without merging returns focus to the trigger; a completed
+          // merge unmounts this bar, so there is nothing to return focus to.
+          if (!open) requestAnimationFrame(() => mergeTriggerRef.current?.focus());
+        }}
+        onDone={onComplete}
+      />
 
       {/* Delete confirmation */}
       <AlertDialog

--- a/apps/frontend/src/components/models/MergeTargetDialog.tsx
+++ b/apps/frontend/src/components/models/MergeTargetDialog.tsx
@@ -1,0 +1,290 @@
+import { useEffect, useRef, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { AlertCircle, Loader2, Package } from 'lucide-react';
+import type { ModelCard, ModelDetail, ModelStatus } from '@alexandria/shared';
+import { getModel, mergeModels } from '../../api/models';
+import { useToast } from '../../hooks/use-toast';
+import { formatFileSize } from '../../lib/format';
+import { Button } from '../ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '../ui/dialog';
+
+/** Mirrors the `mergeModelsSchema` source cap in packages/shared. */
+const MAX_SOURCE_MODELS = 100;
+
+interface MergeTargetDialogProps {
+  selectedIds: Set<string>;
+  /** Models already loaded by the caller, used to name the selection without refetching. */
+  models: ModelCard[];
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onDone: () => void;
+}
+
+/** The subset of a model this dialog needs to render a row and validate a merge. */
+type MergeCandidate = Pick<
+  ModelCard,
+  'id' | 'name' | 'fileCount' | 'totalSizeBytes' | 'status' | 'thumbnailUrl'
+>;
+
+/** Why a model cannot be merged, or null when it can. New statuses are ineligible by default. */
+function ineligibleReason(status: ModelStatus): string | null {
+  if (status === 'ready') return null;
+  return status === 'processing' ? 'Processing' : 'Error';
+}
+
+function toCandidate(model: ModelCard | ModelDetail): MergeCandidate {
+  return {
+    id: model.id,
+    name: model.name,
+    fileCount: model.fileCount,
+    totalSizeBytes: model.totalSizeBytes,
+    status: model.status,
+    thumbnailUrl: model.thumbnailUrl,
+  };
+}
+
+/**
+ * Picks which of the selected models survives a bulk merge.
+ *
+ * Every other ready selection is folded into the chosen target and deleted.
+ * Models that are not ready cannot be merged by the API, so they are shown as
+ * ineligible and left out of the request.
+ */
+export function MergeTargetDialog({
+  selectedIds,
+  models,
+  open,
+  onOpenChange,
+  onDone,
+}: MergeTargetDialogProps) {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+  const [targetId, setTargetId] = useState<string | null>(null);
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const firstOptionRef = useRef<HTMLInputElement>(null);
+
+  // Selection survives filter and search changes, so a selected model is not
+  // guaranteed to still be in the caller's loaded page. Fetch only the strays.
+  const loaded = new Map(models.map((model) => [model.id, model]));
+  const missingIds = [...selectedIds].filter((id) => !loaded.has(id));
+
+  const {
+    data: fetched,
+    isLoading: isLoadingMissing,
+    isError: strayFetchFailed,
+  } = useQuery({
+    queryKey: ['merge-selection', [...missingIds].sort()],
+    queryFn: () => Promise.all(missingIds.map((id) => getModel(id))),
+    enabled: open && missingIds.length > 0,
+  });
+
+  const candidates: MergeCandidate[] = [
+    ...models.filter((model) => selectedIds.has(model.id)).map(toCandidate),
+    ...(fetched ?? []).map(toCandidate),
+  ];
+  const mergeable = candidates.filter((candidate) => ineligibleReason(candidate.status) === null);
+  const skippedCount = candidates.length - mergeable.length;
+  const sourceCount = mergeable.length - 1;
+
+  // A failed stray fetch would otherwise render a silently truncated selection,
+  // so the merge is blocked rather than folding in only part of what was picked.
+  const tooManySources = sourceCount > MAX_SOURCE_MODELS;
+  const blockingMessage = strayFetchFailed
+    ? `${missingIds.length} selected ${missingIds.length === 1 ? 'model' : 'models'} could not be loaded. Close this dialog and reselect before merging.`
+    : mergeable.length < 2
+      ? 'Merging needs at least two ready models.'
+      : tooManySources
+        ? `At most ${MAX_SOURCE_MODELS} models can be merged into one at a time. Deselect ${sourceCount - MAX_SOURCE_MODELS} to continue.`
+        : null;
+  const canMerge = blockingMessage === null;
+
+  // Clear a stale choice so a reopened dialog never merges into a model the
+  // user picked during an earlier, different selection.
+  useEffect(() => {
+    if (!open) setTargetId(null);
+  }, [open]);
+
+  // The shared dialog primitive does no focus management, so move focus in on
+  // open the same way the collection picker in BulkActions does.
+  useEffect(() => {
+    if (!open || isLoadingMissing) return;
+    if (firstOptionRef.current) firstOptionRef.current.focus();
+    else dialogRef.current?.focus();
+  }, [open, isLoadingMissing]);
+
+  const mutation = useMutation({
+    mutationFn: (target: string) =>
+      mergeModels(
+        target,
+        mergeable.map((candidate) => candidate.id).filter((id) => id !== target),
+      ),
+    onSuccess: async (result) => {
+      // Merged sources are gone: drop this dialog's own lookups instead of
+      // refetching them, so a later selection cannot resurface deleted models.
+      queryClient.removeQueries({ queryKey: ['merge-selection'] });
+      queryClient.removeQueries({ queryKey: ['merge-candidates'] });
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['model'] }),
+        queryClient.invalidateQueries({ queryKey: ['model-files'] }),
+        queryClient.invalidateQueries({ queryKey: ['models'] }),
+        queryClient.invalidateQueries({ queryKey: ['collections'] }),
+        queryClient.invalidateQueries({ queryKey: ['collection'] }),
+        queryClient.invalidateQueries({ queryKey: ['collection-models'] }),
+        queryClient.invalidateQueries({ queryKey: ['field-values'] }),
+        queryClient.invalidateQueries({ queryKey: ['search'] }),
+        queryClient.invalidateQueries({ queryKey: ['smart-collection'] }),
+        queryClient.invalidateQueries({ queryKey: ['smart-collections'] }),
+        queryClient.invalidateQueries({ queryKey: ['smart-preview'] }),
+      ]);
+      const merged = result.mergedModelIds.length;
+      toast({
+        title: `Merged ${merged} model${merged === 1 ? '' : 's'}`,
+        description: `${result.movedFileCount} file${result.movedFileCount === 1 ? '' : 's'} moved.`,
+      });
+      onOpenChange(false);
+      onDone();
+    },
+    onError: (error) => {
+      toast({
+        title: 'Merge failed',
+        description: error instanceof Error ? error.message : undefined,
+        variant: 'destructive',
+      });
+    },
+  });
+
+  let firstOptionAssigned = false;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent ref={dialogRef} tabIndex={-1} className="max-w-xl outline-none">
+        <DialogHeader>
+          <DialogTitle>Merge models</DialogTitle>
+          <DialogDescription>
+            Choose the model to keep. The other selected models are folded into it — their files,
+            tags, collections, and metadata for fields the kept model has not already filled move
+            over — and then deleted. This cannot be undone.
+          </DialogDescription>
+        </DialogHeader>
+
+        {isLoadingMissing && (
+          <div
+            className="flex h-24 items-center justify-center gap-2 text-sm text-muted-foreground"
+            role="status"
+          >
+            <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+            Loading selected models…
+          </div>
+        )}
+
+        {!isLoadingMissing && (
+          <>
+            {skippedCount > 0 && (
+              <p
+                id="merge-skipped-notice"
+                role="status"
+                className="flex items-start gap-1.5 text-xs text-muted-foreground"
+              >
+                <AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+                {skippedCount} selected {skippedCount === 1 ? 'model is' : 'models are'} not ready
+                and will be skipped.
+              </p>
+            )}
+
+            <fieldset className="max-h-72 overflow-y-auto rounded-md border">
+              <legend className="sr-only">Model to keep</legend>
+              {candidates.map((candidate) => {
+                const blockedBy = ineligibleReason(candidate.status);
+                const isMergeable = blockedBy === null;
+                const isFirstOption = isMergeable && !firstOptionAssigned;
+                if (isFirstOption) firstOptionAssigned = true;
+                return (
+                  <label
+                    key={candidate.id}
+                    className={
+                      isMergeable
+                        ? 'flex cursor-pointer items-center gap-3 border-b px-3 py-2 last:border-b-0 hover:bg-accent'
+                        : 'flex items-center gap-3 border-b px-3 py-2 last:border-b-0 opacity-50'
+                    }
+                  >
+                    <input
+                      ref={isFirstOption ? firstOptionRef : undefined}
+                      type="radio"
+                      name="merge-target"
+                      checked={targetId === candidate.id}
+                      onChange={() => setTargetId(candidate.id)}
+                      disabled={!isMergeable || mutation.isPending}
+                      className="h-4 w-4 border border-input bg-background accent-primary"
+                    />
+                    {candidate.thumbnailUrl ? (
+                      <img
+                        src={`/api${candidate.thumbnailUrl}`}
+                        alt=""
+                        className="h-10 w-10 shrink-0 rounded object-cover"
+                      />
+                    ) : (
+                      <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded bg-muted">
+                        <Package className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+                      </div>
+                    )}
+                    <div className="min-w-0 flex-1">
+                      <div className="truncate text-sm font-medium">{candidate.name}</div>
+                      <div className="text-xs text-muted-foreground">
+                        {candidate.fileCount} {candidate.fileCount === 1 ? 'file' : 'files'} ·{' '}
+                        {formatFileSize(candidate.totalSizeBytes)}
+                        {blockedBy && ` · ${blockedBy}`}
+                      </div>
+                    </div>
+                  </label>
+                );
+              })}
+            </fieldset>
+
+            {blockingMessage && (
+              <p id="merge-blocked-reason" role="status" className="text-xs text-destructive">
+                {blockingMessage}
+              </p>
+            )}
+          </>
+        )}
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={mutation.isPending}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            onClick={() => targetId && mutation.mutate(targetId)}
+            disabled={!targetId || !canMerge || mutation.isPending}
+            aria-describedby={
+              [
+                blockingMessage ? 'merge-blocked-reason' : null,
+                skippedCount > 0 ? 'merge-skipped-notice' : null,
+              ]
+                .filter(Boolean)
+                .join(' ') || undefined
+            }
+            className="gap-2"
+          >
+            {mutation.isPending && <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />}
+            {targetId && canMerge
+              ? `Merge ${sourceCount} model${sourceCount === 1 ? '' : 's'} in`
+              : 'Merge'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/frontend/src/components/pivot/PivotMain.tsx
+++ b/apps/frontend/src/components/pivot/PivotMain.tsx
@@ -427,6 +427,7 @@ export function PivotMain() {
 
       <BulkActions
         selectedIds={selected}
+        models={models}
         onClear={clear}
         onComplete={finishBulkOperation}
       />

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -510,6 +510,16 @@ The `showThumbnails` preference (also in `displayPrefs`) toggles thumbnail displ
 
 **Group view limitation:** For `axis=collections`, per-collection grouping requires collection membership on `ModelCard`, which the API does not currently return. Group view renders a single group for the collections axis. For `artists` and `tags`, grouping runs client-side on loaded models; group counts reflect loaded models only and will grow as infinite scroll loads more pages.
 
+### Bulk merge
+
+`components/models/BulkActions.tsx` — the bulk-action bar `PivotMain` mounts over the results region — shows a **Merge** action once two or more models are selected. It opens `components/models/MergeTargetDialog.tsx`, which lists the selection and asks which model to keep; every other ready selection becomes a source for a single `POST /models/:targetId/merge` request. No target is preselected, since the sources are deleted once the merge succeeds.
+
+The dialog mirrors three server-side constraints rather than discovering them through a failed request. The endpoint rejects any model that is not `ready`, so non-ready selections render as ineligible, are excluded from the request, and are reported as a skip count. `mergeModelsSchema` caps sources at 100, so a larger selection blocks with the number to deselect. And because merging needs at least two ready models, a selection that cannot reach two blocks as well.
+
+Selection outlives filter and search changes, so a selected model is not guaranteed to still be on the caller's loaded page. The dialog names candidates from the models the caller already has and fetches only the strays. If that fetch fails — a selected model deleted elsewhere, say — merging is blocked instead of silently folding in the subset that did resolve.
+
+On success the dialog drops its own `merge-selection` lookups and the detail-page dialog's `merge-candidates` searches from the cache, since those hold models the merge just deleted, and invalidates the model, collection, field-value, search, and smart-collection query families whose contents or counts the merge changed.
+
 ### Navigation
 
 Routes unchanged from P0: `/models/:id`, `/collections`, `/collections/:id`, `/upload`, `/settings`. The standalone `/collections` nav link was removed from the left rail (collections are now an axis, not a separate page), but the route itself still exists for direct navigation and is used by collection-detail links.
@@ -555,6 +565,8 @@ The Model Detail page (`pages/ModelDetailPage.tsx`) was fully redesigned in P2. 
 `components/models/ModelDetailPanel.tsx` is the tabbed right panel. `components/models/PanelTabs.tsx` is the generic full-width segmented control it uses. `PanelTabs` is typed with a string union for tab values and accepts icon components typed as `React.ComponentType<{ className?: string }>` (see the gotcha note in the Conventions doc).
 
 The Collections tab lists the model's current manual-collection memberships and can add the model to one or more additional collections without removing existing memberships. The browse bulk-action bar makes the same distinction explicit: **Add to collection** preserves existing memberships, while **Move** replaces them.
+
+The detail page also owns a per-model `MergeModelsDialog`, which keeps the current model as the merge target and searches the library for sources. The browse bar's bulk merge (see Pivot Workspace → Bulk merge) inverts that: the sources are already chosen and the dialog asks which one to keep.
 
 ### 3D Viewer
 


### PR DESCRIPTION
## What

Adds a **Merge** action to the browse bulk-action bar. When two or more models are selected, it opens a modal that lists the selection and asks which model to keep — every other ready selection is folded into it and deleted.

Previously the bar could tag, move, and delete a selection but not merge it. Merging several models into one meant opening the keeper's detail page and re-finding the others by search, one at a time.

## How

Frontend only — this reuses the existing `POST /models/:targetId/merge` endpoint, which already folds N sources into one target. No backend, shared-type, or API-client changes.

- **`MergeTargetDialog.tsx`** (new) — radio list of the selected models (thumbnail, name, file count, size). The picked model is the target; the rest are sources for one request.
- **`BulkActions.tsx`** — `GitMerge` button between Tag and Delete, rendered only at 2+ selected; takes a new `models` prop; returns focus to the trigger on dismiss.
- **`PivotMain.tsx`** — passes its already-loaded `models` through.

## Notes for review

**The dialog mirrors the server's constraints instead of discovering them through a failed request.** The endpoint rejects any model that is not `ready`, so non-ready selections render as ineligible, are excluded from the request, and are reported as a skip count. `mergeModelsSchema` caps sources at 100, so a larger selection blocks with the number to deselect — reachable today, since select-all spans every accumulated infinite-scroll page and `DEFAULT_PAGE_SIZE` is 50. A selection that cannot reach two ready models blocks as well.

**No target is preselected** — the sources are deleted on success, so the destructive choice is always explicit. There is no second confirmation step, matching the existing detail-page merge dialog.

**Stale selections.** Selection outlives filter and search changes, so a selected model is not guaranteed to still be on the caller's loaded page. Candidates are named from the models the caller already has, and only the strays are fetched (normally zero). If that fetch fails — a model deleted in another tab, say — merging is **blocked** rather than silently folding in the subset that resolved, which would contradict the dialog's own "cannot be undone" copy.

**Cache eviction.** On success, `merge-selection` and the detail page's `merge-candidates` are removed (they hold models the merge just deleted, and would otherwise re-offer them as sources), and the model, collection, `field-values`, search, and smart-collection families are invalidated. `field-values` matters because merging moves `model_tags` rows and changes the per-value counts on the pivot artist/tag axes.

## Known follow-up, deliberately not in this PR

There are now two merge UIs calling `mergeModels` — this one and the per-model dialog on the detail page — each with its own hand-maintained invalidation list and near-identical success toast. Extracting a `useMergeModels()` hook shared by both would prevent the two lists from drifting, but it means reworking the detail-page dialog and was out of scope here. Happy to do it as its own change.

## Testing

`npx tsc -b` clean. `npx vitest run` in `apps/frontend`: 41 files, 321 tests passing. `BulkActions.test.tsx` goes from 6 to 13 tests, covering the 2+ gate, the target→sources mapping, disabled-until-a-target-is-chosen, non-ready exclusion, the stray-fetch path, the stray-fetch **failure** path, and the source cap.

Not manually exercised in a running app — the change is covered by unit tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)