### PR TITLE
Show full file and folder names in FileTree tooltips

### DIFF
--- a/apps/frontend/src/components/models/FileTree.test.tsx
+++ b/apps/frontend/src/components/models/FileTree.test.tsx
@@ -25,6 +25,14 @@ function deferredPromise() {
 }
 
 describe('FileTree', () => {
+  it('shows full file and folder names as hover tooltips', () => {
+    render(<FileTree tree={TREE} modelId="m1" />);
+
+    expect(screen.getByText('parts')).toHaveAttribute('title', 'parts');
+    expect(screen.getByText('body.stl')).toHaveAttribute('title', 'body.stl');
+    expect(screen.getByText('readme.txt')).toHaveAttribute('title', 'readme.txt');
+  });
+
   it('fires onOpenStl with the reconstructed relative path for a nested STL', () => {
     const onOpenStl = vi.fn();
     render(<FileTree tree={TREE} modelId="m1" onOpenStl={onOpenStl} />);

--- a/apps/frontend/src/components/models/FileTree.tsx
+++ b/apps/frontend/src/components/models/FileTree.tsx
@@ -372,7 +372,9 @@ function FileNode({
             ) : (
               <Folder className="h-4 w-4 text-muted-foreground flex-shrink-0" />
             )}
-            <span className="font-medium text-foreground truncate">{node.name}</span>
+            <span className="font-medium text-foreground truncate" title={node.name}>
+              {node.name}
+            </span>
             {node.children && (
               <span className="text-xs text-muted-foreground ml-auto">
                 {node.children.length}
@@ -536,6 +538,7 @@ function FileNode({
           'truncate flex-1 min-w-0',
           isSelectedImage ? 'text-primary font-medium' : 'text-foreground',
         )}
+        title={node.name}
       >
         {node.name}
       </span>


### PR DESCRIPTION
## Summary
- Add hover tooltips showing complete file and folder names in the FileTree
- Cover tooltip attributes with frontend unit tests

## Testing
- Added and ran FileTree unit tests