### PR TITLE
feat: split model folders into new models

### DIFF
--- a/apps/backend/src/routes/models.split.test.ts
+++ b/apps/backend/src/routes/models.split.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import Fastify, { type FastifyInstance } from 'fastify';
+
+const USER_ID = '11111111-1111-4111-8111-111111111111';
+const LIBRARY_ID = '22222222-2222-4222-8222-222222222222';
+const SOURCE_MODEL_ID = '33333333-3333-4333-8333-333333333333';
+const NEW_MODEL_ID = '44444444-4444-4444-8444-444444444444';
+
+const mocks = vi.hoisted(() => ({
+  requireAuth: vi.fn(async (request: { user?: unknown }) => {
+    request.user = { id: USER_ID };
+  }),
+  requireLibrary: vi.fn(async (request: { libraryId?: string }) => {
+    request.libraryId = LIBRARY_ID;
+  }),
+  splitModelFolder: vi.fn(),
+}));
+
+vi.mock('../middleware/auth.js', () => ({ requireAuth: mocks.requireAuth }));
+vi.mock('../middleware/library.js', () => ({ requireLibrary: mocks.requireLibrary }));
+vi.mock('../services/model.service.js', () => ({
+  modelService: {
+    splitModelFolder: mocks.splitModelFolder,
+  },
+}));
+
+import { modelRoutes } from './models.js';
+
+describe('Model folder split route', () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mocks.splitModelFolder.mockResolvedValue({
+      sourceModelId: SOURCE_MODEL_ID,
+      newModelId: NEW_MODEL_ID,
+      movedFileCount: 2,
+    });
+    app = Fastify();
+    await app.register(modelRoutes, { prefix: '/models' });
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('should validate and delegate an owned library-scoped folder split', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: `/models/${SOURCE_MODEL_ID}/folders/split`,
+      payload: { path: 'bundle/parts', name: 'Parts' },
+    });
+
+    expect(response.statusCode).toBe(201);
+    expect(mocks.requireAuth).toHaveBeenCalledOnce();
+    expect(mocks.requireLibrary).toHaveBeenCalledOnce();
+    expect(mocks.splitModelFolder).toHaveBeenCalledWith(
+      SOURCE_MODEL_ID,
+      'bundle/parts',
+      'Parts',
+      USER_ID,
+      LIBRARY_ID,
+    );
+    expect(response.json()).toEqual({
+      data: {
+        sourceModelId: SOURCE_MODEL_ID,
+        newModelId: NEW_MODEL_ID,
+        movedFileCount: 2,
+      },
+      meta: null,
+      errors: null,
+    });
+  });
+
+  it('should reject a blank model name before calling the service', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: `/models/${SOURCE_MODEL_ID}/folders/split`,
+      payload: { path: 'bundle', name: '   ' },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(mocks.splitModelFolder).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/routes/models.ts
+++ b/apps/backend/src/routes/models.ts
@@ -15,12 +15,14 @@ import type {
   UpdateModelFileRequest,
   UpdateModelFolderRequest,
   DeleteModelFolderRequest,
+  SplitModelFolderRequest,
   ExtractImportSessionArchiveRequest,
   CompleteMultipartUploadRequest,
 } from '@alexandria/shared';
 import {
   createModelFolderSchema,
   deleteModelFolderSchema,
+  splitModelFolderSchema,
   importConfigSchema,
   modelSearchParamsSchema,
   mergeModelsSchema,
@@ -673,6 +675,25 @@ export async function modelRoutes(app: FastifyInstance): Promise<void> {
       const detail = await presenterService.buildModelDetail(id);
 
       return reply.status(200).send({ data: detail, meta: null, errors: null });
+    },
+  );
+
+  // POST /:id/folders/split — move a folder's contents into a new model
+  app.post(
+    '/:id/folders/split',
+    { preHandler: [requireAuth, requireLibrary, validate(splitModelFolderSchema)] },
+    async (request, reply) => {
+      const { id } = request.params as { id: string };
+      const body = request.body as SplitModelFolderRequest;
+      const result = await modelService.splitModelFolder(
+        id,
+        body.path,
+        body.name,
+        request.user!.id,
+        request.libraryId!,
+      );
+
+      return reply.status(201).send({ data: result, meta: null, errors: null });
     },
   );
 

--- a/apps/backend/src/services/model-split.service.test.ts
+++ b/apps/backend/src/services/model-split.service.test.ts
@@ -1,0 +1,351 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { eq, inArray } from 'drizzle-orm';
+
+const storageMocks = vi.hoisted(() => ({
+  copy: vi.fn(),
+  delete: vi.fn(),
+}));
+
+vi.mock('./storage.service.js', () => ({
+  storageService: {
+    copy: storageMocks.copy,
+    delete: storageMocks.delete,
+  },
+}));
+
+import { db } from '../db/index.js';
+import {
+  libraries,
+  modelFiles,
+  modelFolders,
+  models,
+  thumbnails,
+  users,
+} from '../db/schema/index.js';
+import { ModelService } from './model.service.js';
+
+const TEST_EMAIL = 'model-split-test@example.com';
+const service = new ModelService();
+
+let userId: string;
+let libraryId: string;
+let sourceModelId: string;
+let imageFileId: string;
+
+async function deleteTestUser(): Promise<void> {
+  const rows = await db.select({ id: users.id }).from(users).where(eq(users.email, TEST_EMAIL));
+  if (rows.length === 0) return;
+  const userIds = rows.map((row) => row.id);
+  await db.delete(models).where(inArray(models.userId, userIds));
+  await db.delete(libraries).where(inArray(libraries.userId, userIds));
+  await db.delete(users).where(inArray(users.id, userIds));
+}
+
+beforeAll(async () => {
+  await deleteTestUser();
+  const [user] = await db.insert(users).values({
+    email: TEST_EMAIL,
+    displayName: 'Model Split Test',
+    passwordHash: 'not-a-real-hash',
+    role: 'admin',
+  }).returning();
+  userId = user.id;
+
+  const [library] = await db.insert(libraries).values({
+    name: 'Model Split Library',
+    slug: `model-split-library-${Date.now()}`,
+    userId,
+    isDefault: true,
+  }).returning();
+  libraryId = library.id;
+});
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  storageMocks.copy.mockResolvedValue(undefined);
+  storageMocks.delete.mockResolvedValue(undefined);
+
+  const [source] = await db.insert(models).values({
+    name: 'Source Model',
+    slug: `model-split-source-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+    userId,
+    libraryId,
+    sourceType: 'archive_upload',
+    status: 'ready',
+    fileCount: 3,
+    totalSizeBytes: 600,
+  }).returning();
+  sourceModelId = source.id;
+
+  await db.insert(modelFolders).values([
+    { modelId: sourceModelId, path: 'bundle' },
+    { modelId: sourceModelId, path: 'bundle/nested' },
+    { modelId: sourceModelId, path: 'outside-empty' },
+  ]);
+
+  const [image] = await db.insert(modelFiles).values({
+    modelId: sourceModelId,
+    filename: 'cover.png',
+    relativePath: 'bundle/cover.png',
+    fileType: 'image',
+    mimeType: 'image/png',
+    sizeBytes: 100,
+    storagePath: `models/${sourceModelId}/bundle/cover.png`,
+    hash: 'image-hash',
+  }).returning();
+  imageFileId = image.id;
+
+  await db.insert(modelFiles).values([
+    {
+      modelId: sourceModelId,
+      filename: 'part.stl',
+      relativePath: 'bundle/nested/part.stl',
+      fileType: 'stl',
+      mimeType: 'model/stl',
+      sizeBytes: 200,
+      storagePath: `models/${sourceModelId}/bundle/nested/part.stl`,
+      hash: 'part-hash',
+    },
+    {
+      modelId: sourceModelId,
+      filename: 'keep.stl',
+      relativePath: 'keep.stl',
+      fileType: 'stl',
+      mimeType: 'model/stl',
+      sizeBytes: 300,
+      storagePath: `models/${sourceModelId}/keep.stl`,
+      hash: 'keep-hash',
+    },
+  ]);
+
+  await db.insert(thumbnails).values({
+    sourceFileId: imageFileId,
+    storagePath: `thumbnails/${sourceModelId}/${imageFileId}_grid.webp`,
+    width: 400,
+    height: 400,
+    format: 'webp',
+  });
+
+  await db.update(models).set({
+    previewImageFileId: imageFileId,
+    previewCropX: 25,
+    previewCropY: 75,
+    previewCropScale: 1.5,
+  }).where(eq(models.id, sourceModelId));
+});
+
+afterEach(async () => {
+  await db.delete(models).where(eq(models.userId, userId));
+});
+
+afterAll(async () => {
+  await deleteTestUser();
+});
+
+describe('ModelService – splitModelFolder', () => {
+  it('should move a folder into a new model root and preserve its preview', async () => {
+    const result = await service.splitModelFolder(
+      sourceModelId,
+      'bundle',
+      'Separated Bundle',
+      userId,
+      libraryId,
+    );
+
+    expect(result).toEqual({
+      sourceModelId,
+      newModelId: expect.any(String),
+      movedFileCount: 2,
+    });
+
+    const [source, created] = await Promise.all([
+      service.getModelById(sourceModelId),
+      service.getModelById(result.newModelId),
+    ]);
+    expect(source).toMatchObject({
+      fileCount: 1,
+      totalSizeBytes: 300,
+      previewImageFileId: null,
+      previewCropX: null,
+      previewCropY: null,
+      previewCropScale: null,
+    });
+    expect(created).toMatchObject({
+      name: 'Separated Bundle',
+      userId,
+      libraryId,
+      sourceType: 'manual',
+      status: 'ready',
+      fileCount: 2,
+      totalSizeBytes: 300,
+      previewImageFileId: imageFileId,
+      previewCropX: 25,
+      previewCropY: 75,
+      previewCropScale: 1.5,
+    });
+
+    const [sourceFiles, createdFiles, sourceFolders, createdFolders, thumbnailRows] =
+      await Promise.all([
+        service.getModelFiles(sourceModelId),
+        service.getModelFiles(result.newModelId),
+        service.getModelFolders(sourceModelId),
+        service.getModelFolders(result.newModelId),
+        db.select().from(thumbnails).where(eq(thumbnails.sourceFileId, imageFileId)),
+      ]);
+    expect(sourceFiles.map((file) => file.relativePath)).toEqual(['keep.stl']);
+    expect(createdFiles.map((file) => file.relativePath)).toEqual(['cover.png', 'nested/part.stl']);
+    expect(createdFiles.map((file) => file.storagePath)).toEqual([
+      `models/${result.newModelId}/cover.png`,
+      `models/${result.newModelId}/nested/part.stl`,
+    ]);
+    expect(sourceFolders.map((folder) => folder.path)).toEqual(['outside-empty']);
+    expect(createdFolders.map((folder) => folder.path)).toEqual(['nested']);
+    expect(thumbnailRows[0]?.storagePath).toBe(
+      `thumbnails/${result.newModelId}/${imageFileId}_grid.webp`,
+    );
+
+    expect(storageMocks.copy).toHaveBeenCalledTimes(3);
+    expect(storageMocks.delete).toHaveBeenCalledWith(
+      `models/${sourceModelId}/bundle/cover.png`,
+    );
+    expect(storageMocks.delete).toHaveBeenCalledWith(
+      `thumbnails/${sourceModelId}/${imageFileId}_grid.webp`,
+    );
+  });
+
+  it('should leave database state unchanged and clean copied files when a copy fails', async () => {
+    storageMocks.copy
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('copy failed'));
+
+    await expect(service.splitModelFolder(
+      sourceModelId,
+      'bundle',
+      'Separated Bundle',
+      userId,
+      libraryId,
+    )).rejects.toThrow('copy failed');
+
+    const ownedModels = await db
+      .select()
+      .from(models)
+      .where(eq(models.userId, userId));
+    const sourceFiles = await service.getModelFiles(sourceModelId);
+    expect(ownedModels).toHaveLength(1);
+    expect(sourceFiles.map((file) => file.relativePath)).toEqual([
+      'bundle/cover.png',
+      'bundle/nested/part.stl',
+      'keep.stl',
+    ]);
+    expect(storageMocks.delete).toHaveBeenCalledTimes(1);
+    expect(storageMocks.delete).toHaveBeenCalledWith(
+      expect.stringMatching(/^models\/[0-9a-f-]+\/cover\.png$/),
+    );
+  });
+
+  it('should reject an empty persisted folder', async () => {
+    await expect(service.splitModelFolder(
+      sourceModelId,
+      'outside-empty',
+      'Empty',
+      userId,
+      libraryId,
+    )).rejects.toMatchObject({
+      code: 'VALIDATION_ERROR',
+      field: 'path',
+    });
+  });
+
+  it('should treat SQL wildcard characters in folder names literally', async () => {
+    await db.insert(modelFolders).values([
+      { modelId: sourceModelId, path: 'wild_%' },
+      { modelId: sourceModelId, path: 'wild-A' },
+    ]);
+    await db.insert(modelFiles).values([
+      {
+        modelId: sourceModelId,
+        filename: 'move.stl',
+        relativePath: 'wild_%/move.stl',
+        fileType: 'stl',
+        mimeType: 'model/stl',
+        sizeBytes: 10,
+        storagePath: `models/${sourceModelId}/wild_%/move.stl`,
+        hash: 'wild-move-hash',
+      },
+      {
+        modelId: sourceModelId,
+        filename: 'stay.stl',
+        relativePath: 'wild-A/stay.stl',
+        fileType: 'stl',
+        mimeType: 'model/stl',
+        sizeBytes: 20,
+        storagePath: `models/${sourceModelId}/wild-A/stay.stl`,
+        hash: 'wild-stay-hash',
+      },
+    ]);
+
+    const result = await service.splitModelFolder(
+      sourceModelId,
+      'wild_%',
+      'Wild Folder',
+      userId,
+      libraryId,
+    );
+
+    expect(result.movedFileCount).toBe(1);
+    expect((await service.getModelFiles(result.newModelId)).map((file) => file.relativePath))
+      .toEqual(['move.stl']);
+    expect((await service.getModelFiles(sourceModelId)).map((file) => file.relativePath))
+      .toContain('wild-A/stay.stl');
+  });
+
+  it('should reject a stale file rename after the file moves to another model', async () => {
+    let releaseCopy!: () => void;
+    let markCopyStarted!: () => void;
+    const copyStarted = new Promise<void>((resolve) => {
+      markCopyStarted = resolve;
+    });
+    storageMocks.copy.mockImplementationOnce(async () => {
+      markCopyStarted();
+      await new Promise<void>((resolve) => {
+        releaseCopy = resolve;
+      });
+    });
+
+    const rename = service.updateModelFileLocation(sourceModelId, imageFileId, {
+      filename: 'renamed.png',
+      parentPath: 'new-parent',
+    });
+    await copyStarted;
+
+    const [destination] = await db.insert(models).values({
+      name: 'Concurrent Destination',
+      slug: `model-split-concurrent-${Date.now()}`,
+      userId,
+      libraryId,
+      sourceType: 'manual',
+      status: 'ready',
+    }).returning();
+    await db
+      .update(modelFiles)
+      .set({ modelId: destination.id })
+      .where(eq(modelFiles.id, imageFileId));
+    releaseCopy();
+
+    await expect(rename).rejects.toMatchObject({ code: 'CONFLICT' });
+    const [movedFile] = await db
+      .select()
+      .from(modelFiles)
+      .where(eq(modelFiles.id, imageFileId));
+    expect(movedFile).toMatchObject({
+      modelId: destination.id,
+      filename: 'cover.png',
+      relativePath: 'bundle/cover.png',
+    });
+    expect(storageMocks.delete).toHaveBeenCalledWith(
+      `models/${sourceModelId}/new-parent/renamed.png`,
+    );
+    expect((await service.getModelFolders(sourceModelId)).map((folder) => folder.path))
+      .not.toContain('new-parent');
+  });
+});

--- a/apps/backend/src/services/model.service.ts
+++ b/apps/backend/src/services/model.service.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import { randomUUID } from 'node:crypto';
 import { eq, asc, and, inArray, sql } from 'drizzle-orm';
 import type {
   ModelSourceType,
@@ -6,6 +7,7 @@ import type {
   FileType,
   UpdateModelRequest,
   MergeModelsResponse,
+  SplitModelFolderResponse,
   UpdateModelFileRequest,
   UpdateModelFolderRequest,
 } from '@alexandria/shared';
@@ -24,8 +26,10 @@ import { conflict, notFound, validationError } from '../utils/errors.js';
 import type { Model } from '../db/schema/model.js';
 import { libraryService } from './library.service.js';
 import { storageService } from './storage.service.js';
+import { generateSlug } from '../utils/slug.js';
 
 export interface CreateModelData {
+  id?: string;
   name: string;
   slug: string;
   description?: string | null;
@@ -111,7 +115,12 @@ export class ModelService {
   }
 
   private descendantFilter(column: unknown, folderPath: string) {
-    return sql`${column} = ${folderPath} or ${column} like ${`${folderPath}/%`}`;
+    return sql`${column} = ${folderPath} or ${this.strictDescendantFilter(column, folderPath)}`;
+  }
+
+  private strictDescendantFilter(column: unknown, folderPath: string) {
+    const prefix = `${folderPath}/`;
+    return sql`left(${column}, ${prefix.length}) = ${prefix}`;
   }
 
   private uniqueRelativePath(requestedPath: string, usedPaths: Set<string>): string {
@@ -147,6 +156,7 @@ export class ModelService {
     const [row] = await executor
       .insert(models)
       .values({
+        ...(data.id ? { id: data.id } : {}),
         name: data.name,
         slug: data.slug,
         description: data.description ?? null,
@@ -233,8 +243,11 @@ export class ModelService {
       .where(eq(models.id, modelId));
   }
 
-  async recalculateModelStats(modelId: string): Promise<void> {
-    const [stats] = await db
+  async recalculateModelStats(
+    modelId: string,
+    executor: DatabaseExecutor = db,
+  ): Promise<void> {
+    const [stats] = await executor
       .select({
         fileCount: sql<number>`cast(count(${modelFiles.id}) as int)`,
         totalSizeBytes: sql<number>`cast(coalesce(sum(${modelFiles.sizeBytes}), 0) as bigint)`,
@@ -242,7 +255,7 @@ export class ModelService {
       .from(modelFiles)
       .where(eq(modelFiles.modelId, modelId));
 
-    await db
+    await executor
       .update(models)
       .set({
         fileCount: Number(stats?.fileCount ?? 0),
@@ -441,13 +454,17 @@ export class ModelService {
       .orderBy(asc(modelFolders.path));
   }
 
-  private async ensureFolderAncestors(modelId: string, folderPath: string): Promise<void> {
+  private async ensureFolderAncestors(
+    modelId: string,
+    folderPath: string,
+    executor: DatabaseExecutor = db,
+  ): Promise<void> {
     if (!folderPath) return;
     const paths = folderPath
       .split('/')
       .map((_, index, segments) => segments.slice(0, index + 1).join('/'));
 
-    const fileConflicts = await db
+    const fileConflicts = await executor
       .select({ id: modelFiles.id })
       .from(modelFiles)
       .where(and(eq(modelFiles.modelId, modelId), inArray(modelFiles.relativePath, paths)));
@@ -455,7 +472,7 @@ export class ModelService {
       throw conflict('A file already exists at that folder path');
     }
 
-    await db.insert(modelFolders)
+    await executor.insert(modelFolders)
       .values(paths.map((pathValue) => ({ modelId, path: pathValue })))
       .onConflictDoNothing();
   }
@@ -514,7 +531,10 @@ export class ModelService {
       db
         .select({ id: modelFiles.id, relativePath: modelFiles.relativePath })
         .from(modelFiles)
-        .where(and(eq(modelFiles.modelId, modelId), sql`${modelFiles.relativePath} like ${`${currentPath}/%`}`)),
+        .where(and(
+          eq(modelFiles.modelId, modelId),
+          this.strictDescendantFilter(modelFiles.relativePath, currentPath),
+        )),
       db
         .select({ id: modelFolders.id, path: modelFolders.path })
         .from(modelFolders)
@@ -617,20 +637,30 @@ export class ModelService {
     }
 
     await this.assertFileDestinationAvailable(modelId, relativePath, fileId);
-    if (parentPath) {
-      await this.ensureFolderAncestors(modelId, parentPath);
-    }
-
     await storageService.copy(file.storagePath, storagePath);
     try {
-      await db
-        .update(modelFiles)
-        .set({ filename, relativePath, storagePath })
-        .where(eq(modelFiles.id, file.id));
-      await db
-        .update(models)
-        .set({ updatedAt: new Date() })
-        .where(eq(models.id, modelId));
+      await db.transaction(async (tx) => {
+        if (parentPath) {
+          await this.ensureFolderAncestors(modelId, parentPath, tx);
+        }
+        const [updatedFile] = await tx
+          .update(modelFiles)
+          .set({ filename, relativePath, storagePath })
+          .where(and(
+            eq(modelFiles.id, file.id),
+            eq(modelFiles.modelId, modelId),
+            eq(modelFiles.relativePath, file.relativePath),
+            eq(modelFiles.storagePath, file.storagePath),
+          ))
+          .returning({ id: modelFiles.id });
+        if (!updatedFile) {
+          throw conflict('File changed while it was being updated; try again');
+        }
+        await tx
+          .update(models)
+          .set({ updatedAt: new Date() })
+          .where(eq(models.id, modelId));
+      });
     } catch (err) {
       await storageService.delete(storagePath).catch(() => {});
       throw err;
@@ -669,15 +699,14 @@ export class ModelService {
     }
 
     await this.assertFolderDestinationAvailable(modelId, currentPath, nextPath);
-    if (parentPath) {
-      await this.ensureFolderAncestors(modelId, parentPath);
-    }
-
     const [filesInFolder, foldersInFolder] = await Promise.all([
       db
         .select()
         .from(modelFiles)
-        .where(and(eq(modelFiles.modelId, modelId), sql`${modelFiles.relativePath} like ${`${currentPath}/%`}`))
+        .where(and(
+          eq(modelFiles.modelId, modelId),
+          this.strictDescendantFilter(modelFiles.relativePath, currentPath),
+        ))
         .orderBy(asc(modelFiles.relativePath)),
       db
         .select()
@@ -701,19 +730,39 @@ export class ModelService {
 
     try {
       await db.transaction(async (tx) => {
+        if (parentPath) {
+          await this.ensureFolderAncestors(modelId, parentPath, tx);
+        }
         for (const folderRow of foldersInFolder) {
           const pathValue = `${nextPath}${folderRow.path.slice(currentPath.length)}`;
-          await tx
+          const [updatedFolder] = await tx
             .update(modelFolders)
             .set({ path: pathValue })
-            .where(eq(modelFolders.id, folderRow.id));
+            .where(and(
+              eq(modelFolders.id, folderRow.id),
+              eq(modelFolders.modelId, modelId),
+              eq(modelFolders.path, folderRow.path),
+            ))
+            .returning({ id: modelFolders.id });
+          if (!updatedFolder) {
+            throw conflict('Folder changed while it was being updated; try again');
+          }
         }
 
         for (const move of fileMoves) {
-          await tx
+          const [updatedFile] = await tx
             .update(modelFiles)
             .set({ relativePath: move.relativePath, storagePath: move.storagePath })
-            .where(eq(modelFiles.id, move.file.id));
+            .where(and(
+              eq(modelFiles.id, move.file.id),
+              eq(modelFiles.modelId, modelId),
+              eq(modelFiles.relativePath, move.file.relativePath),
+              eq(modelFiles.storagePath, move.file.storagePath),
+            ))
+            .returning({ id: modelFiles.id });
+          if (!updatedFile) {
+            throw conflict('Folder changed while it was being updated; try again');
+          }
         }
 
         await tx
@@ -739,7 +788,18 @@ export class ModelService {
       throw notFound(`File not found: ${fileId}`);
     }
 
-    await db.delete(modelFiles).where(eq(modelFiles.id, file.id));
+    const [deletedFile] = await db
+      .delete(modelFiles)
+      .where(and(
+        eq(modelFiles.id, file.id),
+        eq(modelFiles.modelId, modelId),
+        eq(modelFiles.relativePath, file.relativePath),
+        eq(modelFiles.storagePath, file.storagePath),
+      ))
+      .returning({ id: modelFiles.id });
+    if (!deletedFile) {
+      throw conflict('File changed while it was being deleted; try again');
+    }
     await this.recalculateModelStats(modelId);
     await storageService.delete(file.storagePath).catch(() => {});
   }
@@ -758,12 +818,18 @@ export class ModelService {
     const files = await db
       .select()
       .from(modelFiles)
-      .where(and(eq(modelFiles.modelId, modelId), sql`${modelFiles.relativePath} like ${`${folderPath}/%`}`));
+      .where(and(
+        eq(modelFiles.modelId, modelId),
+        this.strictDescendantFilter(modelFiles.relativePath, folderPath),
+      ));
 
     await db.transaction(async (tx) => {
       await tx
         .delete(modelFiles)
-        .where(and(eq(modelFiles.modelId, modelId), sql`${modelFiles.relativePath} like ${`${folderPath}/%`}`));
+        .where(and(
+          eq(modelFiles.modelId, modelId),
+          this.strictDescendantFilter(modelFiles.relativePath, folderPath),
+        ));
       await tx
         .delete(modelFolders)
         .where(and(eq(modelFolders.modelId, modelId), this.descendantFilter(modelFolders.path, folderPath)));
@@ -773,11 +839,229 @@ export class ModelService {
     await Promise.all(files.map((file) => storageService.delete(file.storagePath).catch(() => {})));
   }
 
+  async splitModelFolder(
+    sourceModelId: string,
+    requestedPath: string,
+    requestedName: string,
+    userId: string,
+    libraryId: string,
+  ): Promise<SplitModelFolderResponse> {
+    const folderPath = this.normalizeFolderPath(requestedPath);
+    const name = requestedName.trim();
+    if (!name) {
+      throw validationError('Model name is required', 'name');
+    }
+    if (name.length > 255) {
+      throw validationError('Model name must be 255 characters or fewer', 'name');
+    }
+
+    const source = await this.requireOwnedModel(sourceModelId, userId, libraryId);
+    if (source.status !== 'ready') {
+      throw validationError('Source model must be ready before splitting', 'sourceModelId');
+    }
+
+    const [folder, files, folders] = await Promise.all([
+      db
+        .select({ id: modelFolders.id })
+        .from(modelFolders)
+        .where(and(eq(modelFolders.modelId, sourceModelId), eq(modelFolders.path, folderPath)))
+        .limit(1),
+      db
+        .select()
+        .from(modelFiles)
+        .where(and(
+          eq(modelFiles.modelId, sourceModelId),
+          this.strictDescendantFilter(modelFiles.relativePath, folderPath),
+        ))
+        .orderBy(asc(modelFiles.relativePath)),
+      db
+        .select()
+        .from(modelFolders)
+        .where(and(
+          eq(modelFolders.modelId, sourceModelId),
+          this.descendantFilter(modelFolders.path, folderPath),
+        ))
+        .orderBy(asc(modelFolders.path)),
+    ]);
+
+    if (folder.length === 0 && files.length === 0) {
+      throw notFound(`Folder not found: ${folderPath}`);
+    }
+    if (files.length === 0) {
+      throw validationError('Folder must contain at least one file before it can be split', 'path');
+    }
+
+    const newModelId = randomUUID();
+    const fileIds = files.map((file) => file.id);
+    const movedFileIds = new Set(fileIds);
+    const thumbnailRows = await db
+      .select()
+      .from(thumbnails)
+      .where(inArray(thumbnails.sourceFileId, fileIds));
+    const fileMoves = files.map((file) => {
+      const relativePath = file.relativePath.slice(folderPath.length + 1);
+      return {
+        file,
+        relativePath,
+        storagePath: `models/${newModelId}/${relativePath}`,
+      };
+    });
+    const thumbnailMoves = thumbnailRows.map((thumbnail) => ({
+      thumbnail,
+      storagePath: `thumbnails/${newModelId}/${path.posix.basename(thumbnail.storagePath)}`,
+    }));
+    const copiedPaths: string[] = [];
+
+    try {
+      for (const move of [...fileMoves, ...thumbnailMoves]) {
+        const sourcePath = 'file' in move ? move.file.storagePath : move.thumbnail.storagePath;
+        await storageService.copy(sourcePath, move.storagePath);
+        copiedPaths.push(move.storagePath);
+      }
+
+      await db.transaction(async (tx) => {
+        const [lockedSource] = await this.lockOwnedModels(
+          [sourceModelId],
+          userId,
+          libraryId,
+          tx,
+        );
+        if (lockedSource.status !== 'ready') {
+          throw validationError('Source model must be ready before splitting', 'sourceModelId');
+        }
+
+        const currentFiles = await tx
+          .select({
+            id: modelFiles.id,
+            relativePath: modelFiles.relativePath,
+            storagePath: modelFiles.storagePath,
+          })
+          .from(modelFiles)
+          .where(and(
+            eq(modelFiles.modelId, sourceModelId),
+            this.strictDescendantFilter(modelFiles.relativePath, folderPath),
+          ))
+          .orderBy(asc(modelFiles.relativePath))
+          .for('update');
+        const unchanged = currentFiles.length === files.length && currentFiles.every((file, index) =>
+          file.id === files[index]?.id &&
+          file.relativePath === files[index]?.relativePath &&
+          file.storagePath === files[index]?.storagePath,
+        );
+        if (!unchanged) {
+          throw conflict('Folder changed while it was being split; try again');
+        }
+
+        const currentFolders = await tx
+          .select({ id: modelFolders.id, path: modelFolders.path })
+          .from(modelFolders)
+          .where(and(
+            eq(modelFolders.modelId, sourceModelId),
+            this.descendantFilter(modelFolders.path, folderPath),
+          ))
+          .orderBy(asc(modelFolders.path))
+          .for('update');
+        const foldersUnchanged = currentFolders.length === folders.length &&
+          currentFolders.every((folderRow, index) =>
+            folderRow.id === folders[index]?.id && folderRow.path === folders[index]?.path,
+          );
+        if (!foldersUnchanged) {
+          throw conflict('Folder changed while it was being split; try again');
+        }
+
+        await this.createModel({
+          id: newModelId,
+          name,
+          slug: generateSlug(name),
+          userId,
+          libraryId,
+          sourceType: 'manual',
+          status: 'ready',
+        }, tx);
+
+        for (const folderRow of folders) {
+          if (folderRow.path === folderPath) {
+            await tx.delete(modelFolders).where(eq(modelFolders.id, folderRow.id));
+            continue;
+          }
+          await tx
+            .update(modelFolders)
+            .set({
+              modelId: newModelId,
+              path: folderRow.path.slice(folderPath.length + 1),
+            })
+            .where(eq(modelFolders.id, folderRow.id));
+        }
+
+        for (const move of fileMoves) {
+          await tx
+            .update(modelFiles)
+            .set({
+              modelId: newModelId,
+              relativePath: move.relativePath,
+              storagePath: move.storagePath,
+            })
+            .where(eq(modelFiles.id, move.file.id));
+        }
+
+        for (const move of thumbnailMoves) {
+          await tx
+            .update(thumbnails)
+            .set({ storagePath: move.storagePath })
+            .where(eq(thumbnails.id, move.thumbnail.id));
+        }
+
+        if (lockedSource.previewImageFileId && movedFileIds.has(lockedSource.previewImageFileId)) {
+          await tx
+            .update(models)
+            .set({
+              previewImageFileId: null,
+              previewCropX: null,
+              previewCropY: null,
+              previewCropScale: null,
+            })
+            .where(eq(models.id, sourceModelId));
+          await tx
+            .update(models)
+            .set({
+              previewImageFileId: lockedSource.previewImageFileId,
+              previewCropX: lockedSource.previewCropX,
+              previewCropY: lockedSource.previewCropY,
+              previewCropScale: lockedSource.previewCropScale,
+            })
+            .where(eq(models.id, newModelId));
+        }
+
+        await this.recalculateModelStats(sourceModelId, tx);
+        await this.recalculateModelStats(newModelId, tx);
+      });
+    } catch (error) {
+      await Promise.all(copiedPaths.map((storagePath) =>
+        storageService.delete(storagePath).catch(() => {})));
+      throw error;
+    }
+
+    await Promise.all([
+      ...fileMoves.map((move) => storageService.delete(move.file.storagePath).catch(() => {})),
+      ...thumbnailMoves.map((move) =>
+        storageService.delete(move.thumbnail.storagePath).catch(() => {})),
+    ]);
+
+    return {
+      sourceModelId,
+      newModelId,
+      movedFileCount: files.length,
+    };
+  }
+
   private async folderHasFiles(modelId: string, folderPath: string): Promise<boolean> {
     const [file] = await db
       .select({ id: modelFiles.id })
       .from(modelFiles)
-      .where(and(eq(modelFiles.modelId, modelId), sql`${modelFiles.relativePath} like ${`${folderPath}/%`}`))
+      .where(and(
+        eq(modelFiles.modelId, modelId),
+        this.strictDescendantFilter(modelFiles.relativePath, folderPath),
+      ))
       .limit(1);
     return Boolean(file);
   }

--- a/apps/frontend/src/api/models.test.ts
+++ b/apps/frontend/src/api/models.test.ts
@@ -11,9 +11,28 @@ vi.mock('./client', () => ({
 }));
 
 import { del, post, postForLibrary, putRaw } from './client';
-import { scanMultipartUpload, scanUpload } from './models';
+import { scanMultipartUpload, scanUpload, splitModelFolder } from './models';
 
 const envelope = <T,>(data: T) => ({ data, meta: null, errors: null });
+
+describe('splitModelFolder', () => {
+  it('posts the folder path and new model name and unwraps the response', async () => {
+    const response = {
+      sourceModelId: 'source-1',
+      newModelId: 'new-1',
+      movedFileCount: 4,
+    };
+    vi.mocked(post).mockResolvedValueOnce(envelope(response));
+
+    await expect(
+      splitModelFolder('source-1', { path: 'variants/large', name: 'Large Variant' }),
+    ).resolves.toEqual(response);
+    expect(post).toHaveBeenCalledWith('/models/source-1/folders/split', {
+      path: 'variants/large',
+      name: 'Large Variant',
+    });
+  });
+});
 
 describe('scanMultipartUpload', () => {
   beforeEach(() => {

--- a/apps/frontend/src/api/models.ts
+++ b/apps/frontend/src/api/models.ts
@@ -17,6 +17,8 @@ import type {
   CompleteMultipartUploadRequest,
   MergeModelsResponse,
   ExtractArchiveResponse,
+  SplitModelFolderRequest,
+  SplitModelFolderResponse,
 } from '@alexandria/shared';
 import { get, post, postForLibrary, patch, del, putRaw, postForm } from './client';
 import { buildQueryString } from '../lib/query';
@@ -105,6 +107,14 @@ export async function updateModelFolder(
 
 export async function deleteModelFolder(id: string, path: string): Promise<ModelDetail> {
   const response = await post<ModelDetail>(`/models/${id}/folders/delete`, { path });
+  return response.data;
+}
+
+export async function splitModelFolder(
+  id: string,
+  data: SplitModelFolderRequest,
+): Promise<SplitModelFolderResponse> {
+  const response = await post<SplitModelFolderResponse>(`/models/${id}/folders/split`, data);
   return response.data;
 }
 

--- a/apps/frontend/src/components/models/FileTree.test.tsx
+++ b/apps/frontend/src/components/models/FileTree.test.tsx
@@ -210,4 +210,32 @@ describe('FileTree', () => {
       expect(within(screen.getByRole('dialog')).getByRole('button', { name: 'Move' })).toBeEnabled();
     });
   });
+
+  it('requests a split with the full nested folder path and folder basename', () => {
+    const onSplitFolder = vi.fn();
+    render(
+      <FileTree
+        tree={[
+          {
+            name: 'variants',
+            type: 'directory',
+            children: [
+              {
+                name: 'large',
+                type: 'directory',
+                children: [{ name: 'body.stl', type: 'file', fileType: 'stl', id: 's1' }],
+              },
+            ],
+          },
+        ]}
+        modelId="m1"
+        onSplitFolder={onSplitFolder}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Actions for folder large' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Split into new model…' }));
+
+    expect(onSplitFolder).toHaveBeenCalledWith('variants/large', 'large');
+  });
 });

--- a/apps/frontend/src/components/models/FileTree.tsx
+++ b/apps/frontend/src/components/models/FileTree.tsx
@@ -16,6 +16,7 @@ import {
   Trash2,
   PackageOpen,
   Loader2,
+  Scissors,
 } from 'lucide-react';
 import type { FileTreeNode, FileType } from '@alexandria/shared';
 import { formatFileSize } from '../../lib/format';
@@ -66,6 +67,7 @@ interface FileNodeProps {
   onRenameFolder?: (path: string, name: string) => void;
   onMoveFolder?: (path: string, parentPath: string) => Promise<void>;
   onDeleteFolder?: (path: string, name: string) => void;
+  onSplitFolder?: (path: string, name: string) => void;
   selectionMode: boolean;
   onRequestMove: (request: MoveRequest) => void;
 }
@@ -339,6 +341,7 @@ function FileNode({
   onRenameFolder,
   onMoveFolder,
   onDeleteFolder,
+  onSplitFolder,
   selectionMode,
   onRequestMove,
 }: FileNodeProps) {
@@ -393,7 +396,7 @@ function FileNode({
                 <MoreHorizontal className="h-4 w-4" />
               </button>
             </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="w-40">
+            <DropdownMenuContent align="end" className="w-56">
               <DropdownMenuItem
                 onClick={() => {
                   const name = promptName('Folder name');
@@ -419,6 +422,10 @@ function FileNode({
               >
                 <FolderInput className="mr-2 h-3.5 w-3.5" />
                 Move
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => onSplitFolder?.(nodePath, node.name)}>
+                <Scissors className="mr-2 h-3.5 w-3.5" />
+                Split into new model…
               </DropdownMenuItem>
               <DropdownMenuSeparator />
               <DropdownMenuItem
@@ -459,6 +466,7 @@ function FileNode({
                 onRenameFolder={onRenameFolder}
                 onMoveFolder={onMoveFolder}
                 onDeleteFolder={onDeleteFolder}
+                onSplitFolder={onSplitFolder}
                 selectionMode={selectionMode}
                 onRequestMove={onRequestMove}
               />
@@ -702,6 +710,7 @@ interface FileTreeProps {
   onRenameFolder?: (path: string, name: string) => void;
   onMoveFolder?: (path: string, parentPath: string) => Promise<void>;
   onDeleteFolder?: (path: string, name: string) => void;
+  onSplitFolder?: (path: string, name: string) => void;
 }
 
 export function FileTree({
@@ -723,6 +732,7 @@ export function FileTree({
   onRenameFolder,
   onMoveFolder,
   onDeleteFolder,
+  onSplitFolder,
 }: FileTreeProps) {
   const totalFiles = countFiles(tree);
   const allFiles = React.useMemo(() => collectFileTargets(tree), [tree]);
@@ -1007,6 +1017,7 @@ export function FileTree({
               onRenameFolder={onRenameFolder}
               onMoveFolder={onMoveFolder}
               onDeleteFolder={onDeleteFolder}
+              onSplitFolder={onSplitFolder}
               selectionMode={selectionMode}
               onRequestMove={setMoveRequest}
             />

--- a/apps/frontend/src/components/models/ModelDetailPanel.tsx
+++ b/apps/frontend/src/components/models/ModelDetailPanel.tsx
@@ -33,6 +33,7 @@ interface ModelDetailPanelProps {
   onRenameFolder?: (path: string, name: string) => void;
   onMoveFolder?: (path: string, parentPath: string) => Promise<void>;
   onDeleteFolder?: (path: string, name: string) => void;
+  onSplitFolder?: (path: string, name: string) => void;
   allCollections: CollectionDetail[];
   collectionsLoading: boolean;
   collectionsError: boolean;
@@ -64,6 +65,7 @@ export function ModelDetailPanel({
   onRenameFolder,
   onMoveFolder,
   onDeleteFolder,
+  onSplitFolder,
   allCollections,
   collectionsLoading,
   collectionsError,
@@ -127,6 +129,7 @@ export function ModelDetailPanel({
           onRenameFolder={onRenameFolder}
           onMoveFolder={onMoveFolder}
           onDeleteFolder={onDeleteFolder}
+          onSplitFolder={onSplitFolder}
         />
       )}
     </div>

--- a/apps/frontend/src/components/models/SplitFolderDialog.test.tsx
+++ b/apps/frontend/src/components/models/SplitFolderDialog.test.tsx
@@ -1,0 +1,50 @@
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { SplitFolderDialog } from './SplitFolderDialog';
+
+function deferredPromise() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+  return { promise, resolve };
+}
+
+describe('SplitFolderDialog', () => {
+  it('explains the move, prefills the basename, and cannot close while submitting', async () => {
+    const request = deferredPromise();
+    const onConfirm = vi.fn(() => request.promise);
+    const onOpenChange = vi.fn();
+    render(
+      <SplitFolderDialog
+        open
+        folderPath="variants/large"
+        initialName="large"
+        onOpenChange={onOpenChange}
+        onConfirm={onConfirm}
+      />,
+    );
+
+    const dialog = screen.getByRole('dialog');
+    expect(screen.getByLabelText('New model name')).toHaveValue('large');
+    expect(dialog).toHaveTextContent('become its root contents');
+    expect(dialog).toHaveTextContent('Metadata and collection memberships stay with the current model');
+
+    fireEvent.change(screen.getByLabelText('New model name'), {
+      target: { value: 'Large Benchy' },
+    });
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Create Model' }));
+
+    expect(onConfirm).toHaveBeenCalledWith('Large Benchy');
+    expect(within(dialog).getByRole('button', { name: 'Splitting…' })).toBeDisabled();
+    expect(within(dialog).getByRole('button', { name: 'Cancel' })).toBeDisabled();
+    expect(dialog).toHaveAttribute('aria-busy', 'true');
+    expect(within(dialog).queryByRole('button', { name: 'Close dialog' })).not.toBeInTheDocument();
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onOpenChange).not.toHaveBeenCalled();
+
+    request.resolve();
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false));
+  });
+});

--- a/apps/frontend/src/components/models/SplitFolderDialog.tsx
+++ b/apps/frontend/src/components/models/SplitFolderDialog.tsx
@@ -1,0 +1,117 @@
+import * as React from 'react';
+import { Loader2, Scissors } from 'lucide-react';
+import { Button } from '../ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '../ui/dialog';
+import { Input } from '../ui/input';
+import { Label } from '../ui/label';
+
+interface SplitFolderDialogProps {
+  open: boolean;
+  folderPath: string;
+  initialName: string;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: (name: string) => Promise<void>;
+}
+
+export function SplitFolderDialog({
+  open,
+  folderPath,
+  initialName,
+  onOpenChange,
+  onConfirm,
+}: SplitFolderDialogProps) {
+  const [name, setName] = React.useState(initialName);
+  const [isSubmitting, setIsSubmitting] = React.useState(false);
+  const trimmedName = name.trim();
+
+  React.useEffect(() => {
+    if (open) setName(initialName);
+  }, [open, initialName, folderPath]);
+
+  async function submit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!trimmedName || isSubmitting) return;
+
+    setIsSubmitting(true);
+    try {
+      await onConfirm(trimmedName);
+      onOpenChange(false);
+    } catch {
+      // The mutation owner reports the error. Keep the dialog open for retry.
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!isSubmitting) onOpenChange(nextOpen);
+      }}
+    >
+      <DialogContent
+        className="max-w-md"
+        aria-busy={isSubmitting}
+        showCloseButton={!isSubmitting}
+      >
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Scissors className="h-4 w-4 text-primary" aria-hidden="true" />
+            Split Folder into New Model
+          </DialogTitle>
+          <DialogDescription>
+            Everything in <span className="font-medium text-foreground">{folderPath}</span> will
+            move into a new model and become its root contents.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form className="flex flex-col gap-4" onSubmit={submit}>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="split-model-name">New model name</Label>
+            <Input
+              id="split-model-name"
+              value={name}
+              onChange={(event) => setName(event.currentTarget.value)}
+              disabled={isSubmitting}
+              maxLength={255}
+              autoFocus
+            />
+          </div>
+
+          <p className="rounded-md border border-border bg-muted/40 px-3 py-2 text-xs leading-relaxed text-muted-foreground">
+            Metadata and collection memberships stay with the current model; they are not copied
+            to the new model.
+          </p>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={isSubmitting}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={!trimmedName || isSubmitting} className="gap-2">
+              {isSubmitting && (
+                <Loader2
+                  className="h-4 w-4 animate-spin motion-reduce:animate-none"
+                  aria-hidden="true"
+                />
+              )}
+              {isSubmitting ? 'Splitting…' : 'Create Model'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/frontend/src/pages/ModelDetailPage.test.tsx
+++ b/apps/frontend/src/pages/ModelDetailPage.test.tsx
@@ -27,6 +27,7 @@ vi.mock('../api/models', () => ({
   getModelFiles: vi.fn(),
   getModels: vi.fn(),
   mergeModels: vi.fn(),
+  splitModelFolder: vi.fn(),
   updateModelFile: vi.fn(),
   updateModelFolder: vi.fn(),
   uploadModelFiles: vi.fn(),
@@ -55,24 +56,30 @@ vi.mock('../components/models/ModelDetailSkeleton', () => ({
 interface DetailPanelTestProps {
   collectionAddPending: boolean;
   onAddToCollections: (collectionIds: string[]) => Promise<void>;
+  onSplitFolder: (path: string, name: string) => void;
 }
 
 vi.mock('../components/models/ModelDetailPanel', () => ({
-  ModelDetailPanel: ({ collectionAddPending, onAddToCollections }: DetailPanelTestProps) => (
-    <button
-      type="button"
-      disabled={collectionAddPending}
-      onClick={() => {
-        void onAddToCollections(['collection-fails', 'collection-delayed']).catch(() => undefined);
-      }}
-    >
-      {collectionAddPending ? 'Adding collections' : 'Add collections'}
-    </button>
+  ModelDetailPanel: ({ collectionAddPending, onAddToCollections, onSplitFolder }: DetailPanelTestProps) => (
+    <>
+      <button
+        type="button"
+        disabled={collectionAddPending}
+        onClick={() => {
+          void onAddToCollections(['collection-fails', 'collection-delayed']).catch(() => undefined);
+        }}
+      >
+        {collectionAddPending ? 'Adding collections' : 'Add collections'}
+      </button>
+      <button type="button" onClick={() => onSplitFolder('variants/large', 'large')}>
+        Split folder
+      </button>
+    </>
   ),
 }));
 
 import { addModelsToCollection, getCollections } from '../api/collections';
-import { getModel, getModelFiles } from '../api/models';
+import { getModel, getModelFiles, splitModelFolder } from '../api/models';
 
 const model: ModelDetail = {
   id: 'model-1',
@@ -109,6 +116,7 @@ function renderPage(queryClient: QueryClient) {
     <QueryClientProvider client={queryClient}>
       <MemoryRouter initialEntries={['/models/model-1']}>
         <Routes>
+          <Route path="/models/model-new" element={<div>New model destination</div>} />
           <Route path="/models/:id" element={<ModelDetailPage />} />
         </Routes>
       </MemoryRouter>
@@ -173,6 +181,48 @@ describe('ModelDetailPage collection membership', () => {
       ['smart-collection'],
       ['smart-collections'],
       ['smart-preview'],
+    ]) {
+      expect(invalidateQueries).toHaveBeenCalledWith({ queryKey });
+    }
+  });
+
+  it('splits a folder, refreshes source and discovery caches, then opens the new model', async () => {
+    vi.mocked(splitModelFolder).mockResolvedValue({
+      sourceModelId: 'model-1',
+      newModelId: 'model-new',
+      movedFileCount: 3,
+    });
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries');
+    renderPage(queryClient);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Split folder' }));
+
+    expect(screen.getByLabelText('New model name')).toHaveValue('large');
+    fireEvent.change(screen.getByLabelText('New model name'), {
+      target: { value: 'Large Benchy' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Create Model' }));
+
+    await waitFor(() => {
+      expect(splitModelFolder).toHaveBeenCalledWith('model-1', {
+        path: 'variants/large',
+        name: 'Large Benchy',
+      });
+    });
+
+    expect(await screen.findByText('New model destination')).toBeInTheDocument();
+    expect(mocks.toast).toHaveBeenCalledWith({
+      title: 'Large Benchy created',
+      description: '3 files moved to the new model.',
+    });
+    for (const queryKey of [
+      ['model', 'model-1'],
+      ['model-files', 'model-1'],
+      ['models'],
+      ['search'],
     ]) {
       expect(invalidateQueries).toHaveBeenCalledWith({ queryKey });
     }

--- a/apps/frontend/src/pages/ModelDetailPage.tsx
+++ b/apps/frontend/src/pages/ModelDetailPage.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import { useParams, Link } from 'react-router-dom';
+import { useParams, useNavigate, Link } from 'react-router-dom';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { ChevronLeft, AlertTriangle, Download, GitMerge, Loader2, Upload, X } from 'lucide-react';
-import type { ModelCard, ModelDetail } from '@alexandria/shared';
+import type { ModelCard, ModelDetail, SplitModelFolderRequest } from '@alexandria/shared';
 import { addModelsToCollection, getCollections } from '../api/collections';
 import {
   createModelFolder,
@@ -13,12 +13,14 @@ import {
   getModelFiles,
   getModels,
   mergeModels,
+  splitModelFolder,
   updateModelFile,
   updateModelFolder,
   uploadModelFiles,
 } from '../api/models';
 import { ModelHero } from '../components/models/ModelHero';
 import { ModelDetailPanel } from '../components/models/ModelDetailPanel';
+import { SplitFolderDialog } from '../components/models/SplitFolderDialog';
 import { ModelBreadcrumb } from '../components/models/ModelBreadcrumb';
 import { ModelViewer3DModal } from '../components/models/ModelViewer3DModal';
 import { TextFilePreviewModal } from '../components/models/TextFilePreviewModal';
@@ -73,6 +75,7 @@ export function ModelDetailPage() {
   const { id } = useParams<{ id: string }>();
   useAssistantTarget({ modelIds: id ? [id] : [] });
   const libPath = useLibraryPath();
+  const navigate = useNavigate();
   const queryClient = useQueryClient();
   const { toast } = useToast();
 
@@ -153,6 +156,10 @@ export function ModelDetailPage() {
   const [activeTextFile, setActiveTextFile] = React.useState<TextFileRef | null>(null);
   const [uploadDialogOpen, setUploadDialogOpen] = React.useState(false);
   const [mergeDialogOpen, setMergeDialogOpen] = React.useState(false);
+  const [splitFolderTarget, setSplitFolderTarget] = React.useState<{
+    path: string;
+    name: string;
+  } | null>(null);
   const [selectedImageFileId, setSelectedImageFileId] = React.useState<string | null>(null);
 
   const fileMutation = useMutation({
@@ -215,6 +222,33 @@ export function ModelDetailPage() {
   const activeFileActionStatus = fileMutation.isPending
     ? fileActionStatus(fileMutation.variables)
     : undefined;
+
+  const splitFolderMutation = useMutation({
+    mutationFn: async ({ path, name }: SplitModelFolderRequest) => {
+      if (!id) throw new Error('Model id is required');
+      return splitModelFolder(id, { path, name });
+    },
+    onSuccess: async (result, variables) => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['model', result.sourceModelId] }),
+        queryClient.invalidateQueries({ queryKey: ['model-files', result.sourceModelId] }),
+        queryClient.invalidateQueries({ queryKey: ['models'] }),
+        queryClient.invalidateQueries({ queryKey: ['search'] }),
+      ]);
+      toast({
+        title: `${variables.name} created`,
+        description: `${result.movedFileCount} file${result.movedFileCount === 1 ? '' : 's'} moved to the new model.`,
+      });
+      navigate(libPath(`/models/${result.newModelId}`));
+    },
+    onError: (error) => {
+      toast({
+        title: 'Could not split folder',
+        description: error instanceof Error ? error.message : undefined,
+        variant: 'destructive',
+      });
+    },
+  });
 
   function runFileAction(action: FileAction): Promise<void> {
     return fileMutation.mutateAsync(action).then(() => undefined);
@@ -357,6 +391,7 @@ export function ModelDetailPage() {
               onRenameFolder={(path, name) => fileMutation.mutate({ type: 'rename-folder', path, name })}
               onMoveFolder={(path, parentPath) => runFileAction({ type: 'move-folder', path, parentPath })}
               onDeleteFolder={(path, name) => fileMutation.mutate({ type: 'delete-folder', path, name })}
+              onSplitFolder={(path, name) => setSplitFolderTarget({ path, name })}
               allCollections={collectionsQuery.data ?? []}
               collectionsLoading={collectionsQuery.isLoading}
               collectionsError={collectionsQuery.isError}
@@ -380,6 +415,20 @@ export function ModelDetailPage() {
         open={textPreviewOpen}
         onOpenChange={setTextPreviewOpen}
         file={activeTextFile}
+      />
+      <SplitFolderDialog
+        open={Boolean(splitFolderTarget)}
+        folderPath={splitFolderTarget?.path ?? ''}
+        initialName={splitFolderTarget?.name ?? ''}
+        onOpenChange={(open) => {
+          if (!open) setSplitFolderTarget(null);
+        }}
+        onConfirm={(name) => {
+          if (!splitFolderTarget) return Promise.reject(new Error('Folder is required'));
+          return splitFolderMutation
+            .mutateAsync({ path: splitFolderTarget.path, name })
+            .then(() => undefined);
+        }}
       />
 
       {model && (

--- a/docs/API.md
+++ b/docs/API.md
@@ -1282,6 +1282,52 @@ Retrieve the file tree for a model. The flat list of `ModelFile` records is asse
 
 ---
 
+### POST /models/:id/folders/split
+
+Move all contents of one folder into a new model. The selected folder itself is removed; files directly inside it become root files in the new model, and descendant folders are rebased beneath the new root. Persisted nested folders are retained even when they are empty.
+
+**Auth required:** Yes. The source model must belong to the authenticated user and the active library selected by `X-Library-Id` (or the user's default library when the header is omitted), and it must have `status: "ready"`.
+
+**Path parameter:** `id` — source model UUID
+
+**Request body:**
+
+```json
+{
+  "path": "bundle/parts",
+  "name": "Printable Parts"
+}
+```
+
+| Field | Type | Constraints |
+|-------|------|-------------|
+| `path` | string | Required relative folder path, 1–1000 characters. Leading/trailing slashes and whitespace around path segments are normalized; empty, `.`, `..`, control-character, and over-255-character segments are rejected. The folder must exist and contain at least one file. |
+| `name` | string | Required new model name, trimmed, 1–255 characters. |
+
+**Response (201):**
+
+```json
+{
+  "data": {
+    "sourceModelId": "33333333-3333-4333-8333-333333333333",
+    "newModelId": "44444444-4444-4444-8444-444444444444",
+    "movedFileCount": 2
+  },
+  "meta": null,
+  "errors": null
+}
+```
+
+`data` is a `SplitModelFolderResponse`. Existing `ModelFile` and `Thumbnail` IDs and their associations are preserved. File and thumbnail objects are copied to storage keys belonging to the new model, then their database rows are reassigned in one transaction. If a moved image was the source model's selected preview, that selection and its crop settings move to the new model; otherwise the source preview is unchanged. File count and total size are recalculated for both models.
+
+The new model has `sourceType: "manual"` and `status: "ready"`. It starts without the source model's metadata, collection memberships, description, or original-filename provenance; those values and relationships remain on the source model.
+
+Storage copies happen before the database transaction. The transaction locks the source and confirms that the selected file and folder rows did not change while copying; a concurrent change returns `409 CONFLICT`. A copy or transaction failure leaves database state unchanged and triggers best-effort cleanup of every object whose copy completed successfully. After commit, removal of the source storage objects is best-effort and does not change the successful response.
+
+The endpoint returns `400 VALIDATION_ERROR` when the source is not ready, the name/path is invalid, or the folder contains no files. It returns `404 NOT_FOUND` when the owned active-library source or requested folder does not exist.
+
+---
+
 ### GET /models/:id/download
 
 Download all files belonging to a model as a ZIP archive. The archive is assembled and streamed from managed storage; the original directory structure is preserved and the full archive is never buffered in server memory.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -54,6 +54,7 @@ The `runSeed` function is also exported for use as a standalone CLI script (`npm
 │                                                          │
 │   ModelDetailPage: ModelBreadcrumb + ModelHero +         │
 │     ModelDetailPanel (Info/Collections/Files tabs)       │
+│     + SplitFolderDialog for file-tree folder extraction  │
 │   ModelViewer3DModal → lazy ModelViewer3DScene (three.js)│
 │   lib/model-files.ts: STL path helpers (pure)           │
 └──────────────────────┬──────────────────────────────────┘
@@ -320,9 +321,13 @@ On startup, S3 mode performs `HeadBucket` validation before database migration a
 
 ### ModelService
 
-**Owns:** Model and ModelFile CRUD. Creating, reading, updating, deleting Model records. Managing ModelFile records and their relationships to models.
+**Owns:** Model, ModelFile, and ModelFolder CRUD. Creating, reading, updating, and deleting Model records; managing file and persisted-folder relationships; and coordinating structural operations such as model merge and splitting one folder into a new model.
 
-**Does not own:** Metadata (delegates to MetadataService), ingestion pipeline, search, storage, thumbnail generation.
+**Does not own:** Metadata (delegates to MetadataService), collection membership, ingestion pipeline, search, storage implementation, or thumbnail generation. Structural file operations use StorageService's backend-independent copy/delete interface.
+
+**Folder split behavior:** `splitModelFolder` accepts one folder from an owned, ready model in the active library. The folder must contain at least one file. Its files become the root contents of a new ready, `manual` model; descendant paths are rebased by removing the selected folder prefix, while persisted nested folders, including empty descendants, are preserved. Existing ModelFile IDs and thumbnail records remain attached to their files. If the source model's selected preview is among the moved files, its preview selection and crop values transfer to the new model and are cleared on the source. Both models' file count and total size are recalculated. The new model receives the requested name but no metadata values, collection memberships, description, or other source provenance; those source relationships and values remain on the source model.
+
+The service copies file and thumbnail objects to new model-scoped storage keys before opening the database transaction. In the transaction it locks and revalidates the owned source and its exact folder contents, creates the new model, reassigns file/folder rows, updates storage keys and preview references, and recalculates both models' statistics. A concurrent folder change produces a conflict and rolls back the database work. Any pre-commit copy or transaction failure triggers best-effort removal of every object whose copy completed successfully. After a successful commit, deletion of the old storage objects is best-effort; a cleanup failure cannot roll back the committed split.
 
 ### MetadataService
 
@@ -568,6 +573,8 @@ The Collections tab lists the model's current manual-collection memberships and 
 
 The detail page also owns a per-model `MergeModelsDialog`, which keeps the current model as the merge target and searches the library for sources. The browse bar's bulk merge (see Pivot Workspace → Bulk merge) inverts that: the sources are already chosen and the dialog asks which one to keep.
 
+The Files tab passes a split callback into `FileTree`. Each directory's action menu can open `SplitFolderDialog`, prefilled with the folder name, to create a model from that directory's contents. The dialog makes the non-copying metadata/collection behavior explicit and remains open after a failed request so the user can retry. On success, `ModelDetailPage` invalidates the source model, source file tree, model browse, and search queries, shows the moved-file count, and navigates to the newly created model.
+
 ### 3D Viewer
 
 The 3D viewer is an in-browser STL renderer built on `three` + `@react-three/fiber` + `@react-three/drei`. It is composed of two layers:
@@ -622,9 +629,10 @@ Because `ModelViewer3DScene` is lazy-loaded, Vite emits three.js as a separate a
 | DELETE | /models/import-sessions/:id | Discard session + staged files | IngestionService | No (userId) |
 | GET | /models/:id/status | Processing status | JobService | No (userId) |
 | PATCH | /models/:id | Update model | ModelService → PresenterService | No (userId) |
+| POST | /models/:id/folders/split | Move one folder's contents into a new model root | ModelService → StorageService | Yes |
 | DELETE | /models/:id | Delete model + files | ModelService → StorageService | No (userId) |
 
-"Library-scoped" means the route applies the `requireLibrary` preHandler and scopes its read or write to `request.libraryId`. By-id routes are still owned by `userId` and library-scoping for detail routes is deferred to P5.
+"Library-scoped" means the route applies the `requireLibrary` preHandler and scopes its read or write to `request.libraryId`. Routes marked `No (userId)` enforce ownership but do not use the active library. The folder-split route enforces both ownership and active-library scope because it creates another model in that library.
 
 **Collections**
 | Method | Route | Purpose | Service Chain | Library-scoped |

--- a/docs/TYPES.md
+++ b/docs/TYPES.md
@@ -477,6 +477,13 @@ interface ImageFile {
   thumbnailUrl: string;
   originalUrl: string;
 }
+
+// Returned after moving one folder into a newly created model
+interface SplitModelFolderResponse {
+  sourceModelId: string;
+  newModelId: string;
+  movedFileCount: number;
+}
 ```
 
 ### File Tree Types
@@ -868,6 +875,11 @@ interface UpdateModelRequest {
   name?: string;
   description?: string | null;
   previewImageFileId?: string | null; // set to a ModelFile UUID to pin cover; null to revert to fallback
+}
+
+interface SplitModelFolderRequest {
+  path: string; // relative folder path; 1–1000 characters before service-level normalization
+  name: string; // trimmed new-model name; 1–255 characters
 }
 ```
 

--- a/packages/shared/src/types/model.ts
+++ b/packages/shared/src/types/model.ts
@@ -116,6 +116,17 @@ export interface DeleteModelFolderRequest {
   path: string;
 }
 
+export interface SplitModelFolderRequest {
+  path: string;
+  name: string;
+}
+
+export interface SplitModelFolderResponse {
+  sourceModelId: string;
+  newModelId: string;
+  movedFileCount: number;
+}
+
 export interface ExtractArchiveResponse {
   addedFileCount: number;
   destinationPath: string;

--- a/packages/shared/src/validation/model.ts
+++ b/packages/shared/src/validation/model.ts
@@ -50,3 +50,8 @@ export const updateModelFolderSchema = z
 export const deleteModelFolderSchema = z.object({
   path: relativePathSchema,
 });
+
+export const splitModelFolderSchema = z.object({
+  path: relativePathSchema,
+  name: z.string().trim().min(1).max(255),
+});


### PR DESCRIPTION
## Summary

- add an owned, active-library-scoped endpoint that moves a model folder into a new model
- preserve nested folder structure, file identities, thumbnails, selected preview settings, and model statistics
- add a folder action and retry-safe naming dialog that navigates to the new model
- document the API, architecture, and shared request/response types

## Behavior

The selected folder is removed from the source model and its contents become the new model root. The new model is ready with `sourceType: manual`; metadata, collections, description, and original-filename provenance remain on the source model.

Storage objects are copied before an atomic database reassignment, copied destinations are cleaned on failure, and stale concurrent structural mutations return a conflict rather than touching files after they move.

## Validation

- `npm test` (backend 820 tests; frontend 325 tests)
- `npm run build`
- `npm run lint`
- `git diff --check`