### PR TITLE
Add 7z folder compression

### DIFF
--- a/apps/backend/src/routes/models.folder-compress.test.ts
+++ b/apps/backend/src/routes/models.folder-compress.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import Fastify, { type FastifyInstance } from 'fastify';
+import { errorHandler } from '../middleware/error-handler.js';
+import { notFound } from '../utils/errors.js';
+
+vi.mock('../middleware/auth.js', () => ({
+  requireAuth: async (request: { user: unknown }) => {
+    request.user = { id: 'user-1' };
+  },
+}));
+
+vi.mock('../middleware/library.js', () => ({
+  requireLibrary: async (request: { libraryId: string | null }) => {
+    request.libraryId = 'library-1';
+  },
+}));
+
+vi.mock('../services/model.service.js', () => ({
+  modelService: {
+    requireOwnedModel: vi.fn(),
+  },
+}));
+
+vi.mock('../services/model-folder-archive.service.js', () => ({
+  modelFolderArchiveService: {
+    compressFolder: vi.fn(),
+  },
+}));
+
+import { modelRoutes } from './models.js';
+import { modelService } from '../services/model.service.js';
+import { modelFolderArchiveService } from '../services/model-folder-archive.service.js';
+
+describe('model folder compression route', () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    app = Fastify();
+    app.decorateRequest('user', null);
+    app.decorateRequest('libraryId', null);
+    app.setErrorHandler(errorHandler);
+    await app.register(modelRoutes, { prefix: '/models' });
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('returns the created archive and enforces user/library ownership', async () => {
+    vi.mocked(modelFolderArchiveService.compressFolder).mockResolvedValue({
+      archiveFileId: 'archive-file-1',
+      archivePath: 'extras/parts.7z',
+      sizeBytes: 2048,
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/models/model-1/folders/compress',
+      payload: { path: 'extras/parts' },
+    });
+
+    expect(response.statusCode).toBe(201);
+    expect(response.json()).toEqual({
+      data: {
+        archiveFileId: 'archive-file-1',
+        archivePath: 'extras/parts.7z',
+        sizeBytes: 2048,
+      },
+      meta: null,
+      errors: null,
+    });
+    expect(modelService.requireOwnedModel).toHaveBeenCalledWith(
+      'model-1',
+      'user-1',
+      'library-1',
+    );
+    expect(modelFolderArchiveService.compressFolder).toHaveBeenCalledWith(
+      'model-1',
+      'extras/parts',
+    );
+  });
+
+  it.each([
+    ['missing path', {}],
+    ['empty path', { path: '' }],
+    ['oversized path', { path: 'x'.repeat(1001) }],
+  ])('rejects an invalid request with a validation envelope: %s', async (_label, payload) => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/models/model-1/folders/compress',
+      payload,
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json()).toMatchObject({
+      data: null,
+      meta: null,
+      errors: [{ code: 'VALIDATION_ERROR' }],
+    });
+    expect(modelService.requireOwnedModel).not.toHaveBeenCalled();
+    expect(modelFolderArchiveService.compressFolder).not.toHaveBeenCalled();
+  });
+
+  it('conceals a model outside the active user/library scope', async () => {
+    vi.mocked(modelService.requireOwnedModel).mockRejectedValue(
+      notFound('Model not found: model-1'),
+    );
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/models/model-1/folders/compress',
+      payload: { path: 'parts' },
+    });
+
+    expect(response.statusCode).toBe(404);
+    expect(response.json()).toMatchObject({
+      data: null,
+      meta: null,
+      errors: [{ code: 'NOT_FOUND' }],
+    });
+    expect(modelFolderArchiveService.compressFolder).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/routes/models.ts
+++ b/apps/backend/src/routes/models.ts
@@ -16,6 +16,7 @@ import type {
   UpdateModelFolderRequest,
   DeleteModelFolderRequest,
   SplitModelFolderRequest,
+  CompressModelFolderRequest,
   ExtractImportSessionArchiveRequest,
   CompleteMultipartUploadRequest,
 } from '@alexandria/shared';
@@ -23,6 +24,7 @@ import {
   createModelFolderSchema,
   deleteModelFolderSchema,
   splitModelFolderSchema,
+  compressModelFolderSchema,
   importConfigSchema,
   modelSearchParamsSchema,
   mergeModelsSchema,
@@ -50,6 +52,7 @@ import { presenterService } from '../services/presenter.service.js';
 import { storageService } from '../services/storage.service.js';
 import { uploadService } from '../services/upload.service.js';
 import { createModelArchive } from '../services/model-download.service.js';
+import { modelFolderArchiveService } from '../services/model-folder-archive.service.js';
 import { notFound, validationError } from '../utils/errors.js';
 
 export async function modelRoutes(app: FastifyInstance): Promise<void> {
@@ -693,6 +696,19 @@ export async function modelRoutes(app: FastifyInstance): Promise<void> {
         request.libraryId!,
       );
 
+      return reply.status(201).send({ data: result, meta: null, errors: null });
+    },
+  );
+
+  // POST /:id/folders/compress — create a sibling 7z archive without deleting the folder
+  app.post(
+    '/:id/folders/compress',
+    { preHandler: [requireAuth, requireLibrary, validate(compressModelFolderSchema)] },
+    async (request, reply) => {
+      const { id } = request.params as { id: string };
+      const body = request.body as CompressModelFolderRequest;
+      await modelService.requireOwnedModel(id, request.user!.id, request.libraryId!);
+      const result = await modelFolderArchiveService.compressFolder(id, body.path);
       return reply.status(201).send({ data: result, meta: null, errors: null });
     },
   );

--- a/apps/backend/src/services/file-processing.service.test.ts
+++ b/apps/backend/src/services/file-processing.service.test.ts
@@ -1129,3 +1129,41 @@ describe('7-Zip extraction preflight', () => {
     extract7z.mockRestore();
   });
 });
+
+describe('7-Zip archive creation', () => {
+  it('creates an LZMA2 archive from the source directory contents', async () => {
+    const fixtureDir = path.join(tmpDir, 'create-7z');
+    const sourceDir = path.join(fixtureDir, 'source');
+    const archivePath = path.join(fixtureDir, 'parts.7z');
+    await fsPromises.mkdir(path.join(sourceDir, 'nested'), { recursive: true });
+    await fsPromises.writeFile(path.join(sourceDir, 'body.stl'), 'solid body');
+    await fsPromises.writeFile(path.join(sourceDir, 'nested', 'notes.txt'), 'print slowly');
+
+    await service.create7zArchive(sourceDir, archivePath);
+
+    const { stdout } = await execFileAsync(path7z, ['l', '-slt', archivePath]);
+    expect(stdout).toContain('Method = LZMA2');
+    expect(stdout).toContain('Path = body.stl');
+    expect(stdout).toContain('Path = nested/notes.txt');
+    expect(stdout).not.toContain('Path = source/body.stl');
+
+    const extractDir = path.join(fixtureDir, 'extracted');
+    await execFileAsync(path7z, ['x', '-y', `-o${extractDir}`, archivePath]);
+    await expect(fsPromises.readFile(path.join(extractDir, 'body.stl'), 'utf8'))
+      .resolves.toBe('solid body');
+    await expect(fsPromises.readFile(path.join(extractDir, 'nested', 'notes.txt'), 'utf8'))
+      .resolves.toBe('print slowly');
+  });
+
+  it('creates a valid archive for an empty source directory', async () => {
+    const fixtureDir = path.join(tmpDir, 'create-empty-7z');
+    const sourceDir = path.join(fixtureDir, 'source');
+    const archivePath = path.join(fixtureDir, 'empty.7z');
+    await fsPromises.mkdir(sourceDir, { recursive: true });
+
+    await service.create7zArchive(sourceDir, archivePath);
+
+    expect((await fsPromises.stat(archivePath)).size).toBeGreaterThan(0);
+    await expect(execFileAsync(path7z, ['t', archivePath])).resolves.toBeDefined();
+  });
+});

--- a/apps/backend/src/services/file-processing.service.ts
+++ b/apps/backend/src/services/file-processing.service.ts
@@ -1,8 +1,10 @@
 import crypto from 'node:crypto';
+import { execFile } from 'node:child_process';
 import fs from 'node:fs';
 import fsPromises from 'node:fs/promises';
 import path from 'node:path';
 import { pipeline } from 'node:stream/promises';
+import { promisify } from 'node:util';
 import yauzl from 'yauzl';
 import * as tar from 'tar';
 import { createExtractorFromFile } from 'node-unrar-js';
@@ -25,6 +27,7 @@ import { createLogger } from '../utils/logger.js';
 import { uploadConcurrencyFor, type IStorageService } from './storage.service.js';
 
 const logger = createLogger('FileProcessingService');
+const execFileAsync = promisify(execFile);
 
 const STORAGE_PROGRESS_MIN_BYTES = 1024 * 1024;
 const STORAGE_PROGRESS_MAX_INTERVAL_MS = 250;
@@ -333,6 +336,38 @@ export interface DiscoveredModel {
 }
 
 export class FileProcessingService {
+  /** Create a 7z archive whose root contains sourceDir's children, not sourceDir itself. */
+  async create7zArchive(sourceDir: string, archivePath: string): Promise<void> {
+    await fsPromises.mkdir(path.dirname(archivePath), { recursive: true });
+    await execFileAsync(
+      path7z,
+      ['a', '-t7z', '-m0=LZMA2', '-mx=5', '-bb0', '-bd', '-y', archivePath, '.'],
+      { cwd: sourceDir },
+    );
+
+    // 7-Zip exits successfully without writing an archive for a completely
+    // empty directory. Seed and remove one entry so empty model folders still
+    // produce a valid, empty 7z container.
+    try {
+      await fsPromises.access(archivePath);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+      const placeholder = `.alexandria-empty-${crypto.randomUUID()}`;
+      const placeholderPath = path.join(sourceDir, placeholder);
+      await fsPromises.writeFile(placeholderPath, '');
+      try {
+        await execFileAsync(
+          path7z,
+          ['a', '-t7z', '-m0=LZMA2', '-mx=5', '-bb0', '-bd', '-y', archivePath, placeholder],
+          { cwd: sourceDir },
+        );
+        await execFileAsync(path7z, ['d', '-bb0', '-bd', '-y', archivePath, placeholder]);
+      } finally {
+        await fsPromises.rm(placeholderPath, { force: true });
+      }
+    }
+  }
+
   validateMultipartArchives(
     files: MultipartArchiveFile[],
     mode: MultipartArchiveMode,

--- a/apps/backend/src/services/model-folder-archive.service.test.ts
+++ b/apps/backend/src/services/model-folder-archive.service.test.ts
@@ -1,0 +1,284 @@
+import fsPromises from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { Readable } from 'node:stream';
+import { buffer } from 'node:stream/consumers';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { path7z } from '7zip-bin-full';
+import { FileProcessingService } from './file-processing.service.js';
+import { ModelFolderArchiveService } from './model-folder-archive.service.js';
+import type { ModelService } from './model.service.js';
+import type {
+  IStorageService,
+  StorageData,
+  StoreResult,
+} from './storage.service.js';
+
+const execFileAsync = promisify(execFile);
+let tmpDir: string;
+
+beforeAll(async () => {
+  tmpDir = await fsPromises.mkdtemp(path.join(os.tmpdir(), 'alex-folder-archive-test-'));
+});
+
+afterAll(async () => {
+  await fsPromises.rm(tmpDir, { recursive: true, force: true });
+});
+
+function memoryStorage(initial: Record<string, string>): {
+  storage: IStorageService;
+  objects: Map<string, Buffer>;
+} {
+  const objects: Map<string, Buffer> = new Map(
+    Object.entries(initial).map(([key, value]) => [key, Buffer.from(value)]),
+  );
+  const storage: IStorageService = {
+    kind: 's3',
+    async store(key: string, data: StorageData): Promise<StoreResult> {
+      objects.set(key, Buffer.isBuffer(data) ? data : await buffer(data));
+      return {};
+    },
+    async retrieve(key: string): Promise<Buffer> {
+      const value = objects.get(key);
+      if (!value) throw new Error(`Missing object: ${key}`);
+      return value;
+    },
+    async retrieveStream(key: string): Promise<Readable> {
+      return Readable.from(await this.retrieve(key));
+    },
+    async copy(source: string, destination: string): Promise<void> {
+      objects.set(destination, await this.retrieve(source));
+    },
+    async delete(key: string): Promise<void> {
+      objects.delete(key);
+    },
+    async exists(key: string): Promise<boolean> {
+      return objects.has(key);
+    },
+  };
+  return { storage, objects };
+}
+
+function modelService(options: {
+  files?: Array<{ relativePath: string; storagePath: string }>;
+  folders?: Array<{ path: string }>;
+  persist?: ReturnType<typeof vi.fn>;
+} = {}): ModelService {
+  return {
+    normalizeFolderPath: vi.fn((value: string) => {
+      if (value.length > 1000 || value.split('/').some((segment) => segment.length > 255)) {
+        throw new Error('Path exceeds model path limits');
+      }
+      return value;
+    }),
+    getModelFiles: vi.fn().mockResolvedValue(options.files ?? []),
+    getModelFolders: vi.fn().mockResolvedValue(options.folders ?? []),
+    createModelFileAndRecalculateStats:
+      options.persist ?? vi.fn().mockResolvedValue({ id: 'archive-file-1' }),
+  } as unknown as ModelService;
+}
+
+describe('ModelFolderArchiveService', () => {
+  it('streams a folder through storage and persists a non-destructive sibling archive', async () => {
+    const { storage, objects } = memoryStorage({
+      'models/model-1/parts/body.stl': 'solid body',
+      'models/model-1/parts/docs/readme.txt': 'print slowly',
+    });
+    const persist = vi.fn().mockResolvedValue({ id: 'archive-file-1' });
+    const models = modelService({
+      files: [
+        { relativePath: 'parts/body.stl', storagePath: 'models/model-1/parts/body.stl' },
+        { relativePath: 'parts/docs/readme.txt', storagePath: 'models/model-1/parts/docs/readme.txt' },
+      ],
+      folders: [{ path: 'parts' }, { path: 'parts/empty' }],
+      persist,
+    });
+    const service = new ModelFolderArchiveService(
+      models,
+      storage,
+      new FileProcessingService(),
+    );
+
+    const result = await service.compressFolder('model-1', 'parts');
+
+    expect(result).toMatchObject({
+      archiveFileId: 'archive-file-1',
+      archivePath: 'parts.7z',
+    });
+    expect(result.sizeBytes).toBeGreaterThan(0);
+    expect(objects.get('models/model-1/parts/body.stl')?.toString()).toBe('solid body');
+    expect(objects.get('models/model-1/parts/docs/readme.txt')?.toString()).toBe('print slowly');
+    expect(persist).toHaveBeenCalledWith(
+      'model-1',
+      expect.objectContaining({
+        filename: 'parts.7z',
+        relativePath: 'parts.7z',
+        fileType: 'other',
+        mimeType: 'application/x-7z-compressed',
+        sizeBytes: result.sizeBytes,
+        storagePath: 'models/model-1/parts.7z',
+        hash: expect.stringMatching(/^[a-f0-9]{64}$/),
+      }),
+    );
+
+    const archiveFixture = path.join(tmpDir, 'stored-parts.7z');
+    await fsPromises.writeFile(archiveFixture, objects.get('models/model-1/parts.7z')!);
+    const { stdout } = await execFileAsync(path7z, ['l', '-slt', archiveFixture]);
+    expect(stdout).toContain('Method = LZMA2');
+    expect(stdout).toContain('Path = body.stl');
+    expect(stdout).toContain('Path = docs/readme.txt');
+    expect(stdout).toContain('Path = empty');
+    expect(stdout).not.toContain('Path = parts/body.stl');
+  });
+
+  it('rejects an occupied sibling path before reading or writing storage', async () => {
+    const { storage } = memoryStorage({});
+    const create7zArchive = vi.fn();
+    const service = new ModelFolderArchiveService(
+      modelService({
+        files: [
+          { relativePath: 'parts/body.stl', storagePath: 'models/model-1/parts/body.stl' },
+          { relativePath: 'parts.7z', storagePath: 'models/model-1/parts.7z' },
+        ],
+        folders: [{ path: 'parts' }],
+      }),
+      storage,
+      { create7zArchive } as unknown as FileProcessingService,
+    );
+
+    await expect(service.compressFolder('model-1', 'parts')).rejects.toMatchObject({
+      code: 'CONFLICT',
+      statusCode: 409,
+    });
+    expect(create7zArchive).not.toHaveBeenCalled();
+  });
+
+  it('serializes concurrent compression of the same folder', async () => {
+    const { storage } = memoryStorage({
+      'models/model-1/parts/body.stl': 'solid body',
+    });
+    const actualFileProcessing = new FileProcessingService();
+    let signalStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      signalStarted = resolve;
+    });
+    let releaseCreation!: () => void;
+    const creationGate = new Promise<void>((resolve) => {
+      releaseCreation = resolve;
+    });
+    const create7zArchive = vi.fn(async (sourceDir: string, archivePath: string) => {
+      signalStarted();
+      await creationGate;
+      await actualFileProcessing.create7zArchive(sourceDir, archivePath);
+    });
+    const service = new ModelFolderArchiveService(
+      modelService({
+        files: [
+          { relativePath: 'parts/body.stl', storagePath: 'models/model-1/parts/body.stl' },
+        ],
+        folders: [{ path: 'parts' }],
+      }),
+      storage,
+      { create7zArchive } as unknown as FileProcessingService,
+    );
+
+    const first = service.compressFolder('model-1', 'parts');
+    await started;
+    const second = service.compressFolder('model-1', 'parts');
+    await Promise.resolve();
+    expect(create7zArchive).toHaveBeenCalledTimes(1);
+
+    releaseCreation();
+    await expect(first).resolves.toMatchObject({ archivePath: 'parts.7z' });
+    await expect(second).rejects.toMatchObject({ code: 'CONFLICT', statusCode: 409 });
+    expect(create7zArchive).toHaveBeenCalledTimes(1);
+  });
+
+  it('limits compression work across different folders', async () => {
+    const { storage } = memoryStorage({
+      'models/model-1/parts-a/body.stl': 'solid a',
+      'models/model-1/parts-b/body.stl': 'solid b',
+    });
+    const actualFileProcessing = new FileProcessingService();
+    let releaseFirst!: () => void;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const create7zArchive = vi.fn(async (sourceDir: string, archivePath: string) => {
+      if (create7zArchive.mock.calls.length === 1) await firstGate;
+      await actualFileProcessing.create7zArchive(sourceDir, archivePath);
+    });
+    const service = new ModelFolderArchiveService(
+      modelService({
+        files: [
+          { relativePath: 'parts-a/body.stl', storagePath: 'models/model-1/parts-a/body.stl' },
+          { relativePath: 'parts-b/body.stl', storagePath: 'models/model-1/parts-b/body.stl' },
+        ],
+        folders: [{ path: 'parts-a' }, { path: 'parts-b' }],
+      }),
+      storage,
+      { create7zArchive } as unknown as FileProcessingService,
+    );
+
+    const first = service.compressFolder('model-1', 'parts-a');
+    const second = service.compressFolder('model-1', 'parts-b');
+    await vi.waitFor(() => expect(create7zArchive).toHaveBeenCalledTimes(1));
+
+    releaseFirst();
+    await expect(Promise.all([first, second])).resolves.toHaveLength(2);
+    expect(create7zArchive).toHaveBeenCalledTimes(2);
+  });
+
+  it('removes the stored archive when database persistence fails', async () => {
+    const { storage, objects } = memoryStorage({
+      'models/model-1/parts/body.stl': 'solid body',
+    });
+    const service = new ModelFolderArchiveService(
+      modelService({
+        files: [
+          { relativePath: 'parts/body.stl', storagePath: 'models/model-1/parts/body.stl' },
+        ],
+        folders: [{ path: 'parts' }],
+        persist: vi.fn().mockRejectedValue(new Error('database unavailable')),
+      }),
+      storage,
+      new FileProcessingService(),
+    );
+
+    await expect(service.compressFolder('model-1', 'parts'))
+      .rejects.toThrow('database unavailable');
+    expect(objects.has('models/model-1/parts.7z')).toBe(false);
+    expect(objects.get('models/model-1/parts/body.stl')?.toString()).toBe('solid body');
+  });
+
+  it('rejects a missing folder', async () => {
+    const { storage } = memoryStorage({});
+    const service = new ModelFolderArchiveService(
+      modelService(),
+      storage,
+      new FileProcessingService(),
+    );
+
+    await expect(service.compressFolder('model-1', 'missing')).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+      statusCode: 404,
+    });
+  });
+
+  it('validates the derived archive path before reading model contents', async () => {
+    const { storage } = memoryStorage({});
+    const models = modelService();
+    const service = new ModelFolderArchiveService(
+      models,
+      storage,
+      new FileProcessingService(),
+    );
+
+    await expect(service.compressFolder('model-1', 'x'.repeat(253)))
+      .rejects.toThrow('Path exceeds model path limits');
+    expect(models.getModelFiles).not.toHaveBeenCalled();
+    expect(models.getModelFolders).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/services/model-folder-archive.service.ts
+++ b/apps/backend/src/services/model-folder-archive.service.ts
@@ -1,0 +1,200 @@
+import fs from 'node:fs';
+import fsPromises from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { pipeline } from 'node:stream/promises';
+import type { CompressFolderResponse } from '@alexandria/shared';
+import { conflict, notFound } from '../utils/errors.js';
+import { createLogger } from '../utils/logger.js';
+import { FileProcessingService, fileProcessingService } from './file-processing.service.js';
+import { ModelService, modelService } from './model.service.js';
+import {
+  type IStorageService,
+  storageService,
+  storeVerified,
+} from './storage.service.js';
+
+const logger = createLogger('ModelFolderArchiveService');
+
+export class ModelFolderArchiveService {
+  private readonly activeCompressions = new Map<string, Promise<void>>();
+  private activeCompressionCount = 0;
+  private readonly compressionWaiters: Array<() => void> = [];
+
+  constructor(
+    private readonly models: ModelService = modelService,
+    private readonly storage: IStorageService = storageService,
+    private readonly fileProcessing: FileProcessingService = fileProcessingService,
+    private readonly maxConcurrentCompressions = 1,
+  ) {}
+
+  async compressFolder(modelId: string, requestedPath: string): Promise<CompressFolderResponse> {
+    const folderPath = this.models.normalizeFolderPath(requestedPath);
+    const archivePath = this.models.normalizeFolderPath(`${folderPath}.7z`);
+    const operationKey = `${modelId}:${archivePath}`;
+    const previous = this.activeCompressions.get(operationKey) ?? Promise.resolve();
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const tail = previous.then(() => gate);
+    this.activeCompressions.set(operationKey, tail);
+
+    await previous;
+    const releaseCompressionPermit = await this.acquireCompressionPermit();
+    try {
+      return await this.compressFolderLocked(modelId, folderPath, archivePath);
+    } finally {
+      releaseCompressionPermit();
+      release();
+      if (this.activeCompressions.get(operationKey) === tail) {
+        this.activeCompressions.delete(operationKey);
+      }
+    }
+  }
+
+  private async compressFolderLocked(
+    modelId: string,
+    folderPath: string,
+    archivePath: string,
+  ): Promise<CompressFolderResponse> {
+    const prefix = `${folderPath}/`;
+    const [files, folders] = await Promise.all([
+      this.models.getModelFiles(modelId),
+      this.models.getModelFolders(modelId),
+    ]);
+
+    const sourceFiles = files.filter((file) => file.relativePath.startsWith(prefix));
+    const sourceFolders = folders.filter(
+      (folder) => folder.path === folderPath || folder.path.startsWith(prefix),
+    );
+    if (sourceFiles.length === 0 && sourceFolders.length === 0) {
+      throw notFound(`Folder not found: ${folderPath}`);
+    }
+
+    const archivePrefix = `${archivePath}/`;
+    if (
+      files.some(
+        (file) => file.relativePath === archivePath || file.relativePath.startsWith(archivePrefix),
+      ) ||
+      folders.some(
+        (folder) => folder.path === archivePath || folder.path.startsWith(archivePrefix),
+      )
+    ) {
+      throw conflict(`A file or folder already exists at ${archivePath}`);
+    }
+
+    const destinationStoragePath = `models/${modelId}/${archivePath}`;
+    if (await this.storage.exists(destinationStoragePath)) {
+      throw conflict(`A storage object already exists at ${archivePath}`);
+    }
+
+    const tempRoot = await fsPromises.mkdtemp(
+      path.join(os.tmpdir(), 'alexandria-folder-archive-'),
+    );
+    const stageRoot = path.join(tempRoot, 'contents');
+    const tempArchivePath = path.join(tempRoot, 'archive.7z');
+    let storageWriteAttempted = false;
+    let archivePersisted = false;
+
+    try {
+      await fsPromises.mkdir(stageRoot, { recursive: true });
+
+      for (const folder of sourceFolders) {
+        if (folder.path === folderPath) continue;
+        await fsPromises.mkdir(this.stagePath(stageRoot, folder.path.slice(prefix.length)), {
+          recursive: true,
+        });
+      }
+
+      for (const file of sourceFiles) {
+        const stagedPath = this.stagePath(stageRoot, file.relativePath.slice(prefix.length));
+        await fsPromises.mkdir(path.dirname(stagedPath), { recursive: true });
+        await pipeline(
+          await this.storage.retrieveStream(file.storagePath),
+          fs.createWriteStream(stagedPath),
+        );
+      }
+
+      await this.fileProcessing.create7zArchive(stageRoot, tempArchivePath);
+      const expectedSize = (await fsPromises.stat(tempArchivePath)).size;
+      storageWriteAttempted = true;
+      const stored = await storeVerified(
+        this.storage,
+        destinationStoragePath,
+        () => fs.createReadStream(tempArchivePath),
+        { expectedSize },
+      );
+
+      const created = await this.models.createModelFileAndRecalculateStats(modelId, {
+        filename: path.posix.basename(archivePath),
+        relativePath: archivePath,
+        fileType: 'other',
+        mimeType: 'application/x-7z-compressed',
+        sizeBytes: stored.sizeBytes,
+        storagePath: destinationStoragePath,
+        hash: stored.sha256,
+      });
+      archivePersisted = true;
+
+      logger.info(
+        { modelId, folderPath, archivePath, sizeBytes: stored.sizeBytes },
+        'Compressed model folder',
+      );
+      return {
+        archiveFileId: created.id,
+        archivePath,
+        sizeBytes: stored.sizeBytes,
+      };
+    } catch (error) {
+      if (storageWriteAttempted && !archivePersisted) {
+        await this.storage.delete(destinationStoragePath).catch((cleanupError) => {
+          logger.warn(
+            { modelId, archivePath, error: String(cleanupError) },
+            'Failed to remove incomplete folder archive from storage',
+          );
+        });
+      }
+      throw error;
+    } finally {
+      await fsPromises.rm(tempRoot, { recursive: true, force: true }).catch((cleanupError) => {
+        logger.warn(
+          { modelId, folderPath, tempRoot, error: String(cleanupError) },
+          'Failed to remove folder archive staging directory',
+        );
+      });
+    }
+  }
+
+  private stagePath(stageRoot: string, relativePath: string): string {
+    const destination = path.resolve(stageRoot, ...relativePath.split('/'));
+    const root = path.resolve(stageRoot);
+    if (!destination.startsWith(`${root}${path.sep}`)) {
+      throw conflict('Folder contents contain an unsafe path');
+    }
+    return destination;
+  }
+
+  private acquireCompressionPermit(): Promise<() => void> {
+    return new Promise((resolve) => {
+      const start = () => {
+        this.activeCompressionCount += 1;
+        let released = false;
+        resolve(() => {
+          if (released) return;
+          released = true;
+          this.activeCompressionCount -= 1;
+          this.compressionWaiters.shift()?.();
+        });
+      };
+
+      if (this.activeCompressionCount < this.maxConcurrentCompressions) {
+        start();
+      } else {
+        this.compressionWaiters.push(start);
+      }
+    });
+  }
+}
+
+export const modelFolderArchiveService = new ModelFolderArchiveService();

--- a/apps/backend/src/services/model.service.ts
+++ b/apps/backend/src/services/model.service.ts
@@ -66,7 +66,7 @@ export interface UpdateModelStatusData {
 }
 
 export class ModelService {
-  private normalizeFolderPath(input: string, field = 'path', allowRoot = false): string {
+  normalizeFolderPath(input: string, field = 'path', allowRoot = false): string {
     const raw = input.replace(/\\/g, '/').trim().replace(/^\/+|\/+$/g, '');
     if (!raw) {
       if (allowRoot) return '';
@@ -174,10 +174,11 @@ export class ModelService {
   async createModelFiles(
     modelId: string,
     files: CreateModelFileData[],
+    executor: DatabaseExecutor = db,
   ): Promise<Array<{ id: string; fileType: string }>> {
     if (files.length === 0) return [];
 
-    const rows = await db
+    const rows = await executor
       .insert(modelFiles)
       .values(
         files.map((f) => ({
@@ -263,6 +264,17 @@ export class ModelService {
         updatedAt: new Date(),
       })
       .where(eq(models.id, modelId));
+  }
+
+  async createModelFileAndRecalculateStats(
+    modelId: string,
+    file: CreateModelFileData,
+  ): Promise<{ id: string }> {
+    return db.transaction(async (tx) => {
+      const [created] = await this.createModelFiles(modelId, [file], tx);
+      await this.recalculateModelStats(modelId, tx);
+      return { id: created.id };
+    });
   }
 
   async getModelById(id: string, executor: DatabaseExecutor = db): Promise<Model> {

--- a/apps/frontend/src/api/models.test.ts
+++ b/apps/frontend/src/api/models.test.ts
@@ -11,7 +11,12 @@ vi.mock('./client', () => ({
 }));
 
 import { del, post, postForLibrary, putRaw } from './client';
-import { scanMultipartUpload, scanUpload, splitModelFolder } from './models';
+import {
+  compressModelFolder,
+  scanMultipartUpload,
+  scanUpload,
+  splitModelFolder,
+} from './models';
 
 const envelope = <T,>(data: T) => ({ data, meta: null, errors: null });
 
@@ -31,6 +36,21 @@ describe('splitModelFolder', () => {
       path: 'variants/large',
       name: 'Large Variant',
     });
+  });
+});
+
+describe('compressModelFolder', () => {
+  it('should post the folder path and return the created archive details', async () => {
+    const response = {
+      archiveFileId: 'archive-1',
+      archivePath: 'parts.7z',
+      sizeBytes: 2048,
+    };
+    vi.mocked(post).mockResolvedValue(envelope(response));
+
+    await expect(compressModelFolder('model-1', 'parts')).resolves.toEqual(response);
+
+    expect(post).toHaveBeenCalledWith('/models/model-1/folders/compress', { path: 'parts' });
   });
 });
 

--- a/apps/frontend/src/api/models.ts
+++ b/apps/frontend/src/api/models.ts
@@ -19,6 +19,7 @@ import type {
   ExtractArchiveResponse,
   SplitModelFolderRequest,
   SplitModelFolderResponse,
+  CompressFolderResponse,
 } from '@alexandria/shared';
 import { get, post, postForLibrary, patch, del, putRaw, postForm } from './client';
 import { buildQueryString } from '../lib/query';
@@ -115,6 +116,14 @@ export async function splitModelFolder(
   data: SplitModelFolderRequest,
 ): Promise<SplitModelFolderResponse> {
   const response = await post<SplitModelFolderResponse>(`/models/${id}/folders/split`, data);
+  return response.data;
+}
+
+export async function compressModelFolder(
+  id: string,
+  path: string,
+): Promise<CompressFolderResponse> {
+  const response = await post<CompressFolderResponse>(`/models/${id}/folders/compress`, { path });
   return response.data;
 }
 

--- a/apps/frontend/src/components/models/FileTree.test.tsx
+++ b/apps/frontend/src/components/models/FileTree.test.tsx
@@ -172,6 +172,19 @@ describe('FileTree', () => {
     expect(screen.getByRole('button', { name: 'Create folder' })).toBeDisabled();
   });
 
+  it('offers non-destructive 7z compression from a folder action menu', () => {
+    const onCompressFolder = vi.fn();
+    const confirm = vi.spyOn(window, 'confirm');
+    render(<FileTree tree={TREE} modelId="m1" onCompressFolder={onCompressFolder} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Actions for folder parts' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Compress to 7z' }));
+
+    expect(onCompressFolder).toHaveBeenCalledWith('parts', 'parts');
+    expect(confirm).not.toHaveBeenCalled();
+    confirm.mockRestore();
+  });
+
   it('keeps the move dialog open with a busy indicator until the move completes', async () => {
     const move = deferredPromise();
     const onMoveFolder = vi.fn(() => move.promise);

--- a/apps/frontend/src/components/models/FileTree.tsx
+++ b/apps/frontend/src/components/models/FileTree.tsx
@@ -15,6 +15,7 @@ import {
   SquareCheck,
   Trash2,
   PackageOpen,
+  Archive,
   Loader2,
   Scissors,
 } from 'lucide-react';
@@ -66,6 +67,7 @@ interface FileNodeProps {
   onExtractArchive?: (fileId: string, name: string) => void;
   onRenameFolder?: (path: string, name: string) => void;
   onMoveFolder?: (path: string, parentPath: string) => Promise<void>;
+  onCompressFolder?: (path: string, name: string) => void;
   onDeleteFolder?: (path: string, name: string) => void;
   onSplitFolder?: (path: string, name: string) => void;
   selectionMode: boolean;
@@ -340,6 +342,7 @@ function FileNode({
   onExtractArchive,
   onRenameFolder,
   onMoveFolder,
+  onCompressFolder,
   onDeleteFolder,
   onSplitFolder,
   selectionMode,
@@ -427,6 +430,10 @@ function FileNode({
                 <Scissors className="mr-2 h-3.5 w-3.5" />
                 Split into new model…
               </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => onCompressFolder?.(nodePath, node.name)}>
+                <Archive className="mr-2 h-3.5 w-3.5" />
+                Compress to 7z
+              </DropdownMenuItem>
               <DropdownMenuSeparator />
               <DropdownMenuItem
                 className="text-destructive hover:text-destructive"
@@ -465,6 +472,7 @@ function FileNode({
                 onExtractArchive={onExtractArchive}
                 onRenameFolder={onRenameFolder}
                 onMoveFolder={onMoveFolder}
+                onCompressFolder={onCompressFolder}
                 onDeleteFolder={onDeleteFolder}
                 onSplitFolder={onSplitFolder}
                 selectionMode={selectionMode}
@@ -709,6 +717,7 @@ interface FileTreeProps {
   onDeleteFiles?: (fileIds: string[]) => void;
   onRenameFolder?: (path: string, name: string) => void;
   onMoveFolder?: (path: string, parentPath: string) => Promise<void>;
+  onCompressFolder?: (path: string, name: string) => void;
   onDeleteFolder?: (path: string, name: string) => void;
   onSplitFolder?: (path: string, name: string) => void;
 }
@@ -731,6 +740,7 @@ export function FileTree({
   onDeleteFiles,
   onRenameFolder,
   onMoveFolder,
+  onCompressFolder,
   onDeleteFolder,
   onSplitFolder,
 }: FileTreeProps) {
@@ -1016,6 +1026,7 @@ export function FileTree({
               onExtractArchive={onExtractArchive}
               onRenameFolder={onRenameFolder}
               onMoveFolder={onMoveFolder}
+              onCompressFolder={onCompressFolder}
               onDeleteFolder={onDeleteFolder}
               onSplitFolder={onSplitFolder}
               selectionMode={selectionMode}

--- a/apps/frontend/src/components/models/ModelDetailPanel.tsx
+++ b/apps/frontend/src/components/models/ModelDetailPanel.tsx
@@ -32,6 +32,7 @@ interface ModelDetailPanelProps {
   onDeleteFiles?: (fileIds: string[]) => void;
   onRenameFolder?: (path: string, name: string) => void;
   onMoveFolder?: (path: string, parentPath: string) => Promise<void>;
+  onCompressFolder?: (path: string, name: string) => void;
   onDeleteFolder?: (path: string, name: string) => void;
   onSplitFolder?: (path: string, name: string) => void;
   allCollections: CollectionDetail[];
@@ -64,6 +65,7 @@ export function ModelDetailPanel({
   onDeleteFiles,
   onRenameFolder,
   onMoveFolder,
+  onCompressFolder,
   onDeleteFolder,
   onSplitFolder,
   allCollections,
@@ -128,6 +130,7 @@ export function ModelDetailPanel({
           onDeleteFiles={onDeleteFiles}
           onRenameFolder={onRenameFolder}
           onMoveFolder={onMoveFolder}
+          onCompressFolder={onCompressFolder}
           onDeleteFolder={onDeleteFolder}
           onSplitFolder={onSplitFolder}
         />

--- a/apps/frontend/src/pages/ModelDetailPage.test.tsx
+++ b/apps/frontend/src/pages/ModelDetailPage.test.tsx
@@ -1,7 +1,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
-import type { ModelDetail } from '@alexandria/shared';
+import type { CompressFolderResponse, ModelDetail } from '@alexandria/shared';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ModelDetailPage } from './ModelDetailPage';
 
@@ -19,6 +19,7 @@ vi.mock('../api/collections', () => ({
 }));
 
 vi.mock('../api/models', () => ({
+  compressModelFolder: vi.fn(),
   createModelFolder: vi.fn(),
   deleteModelFile: vi.fn(),
   deleteModelFolder: vi.fn(),
@@ -57,10 +58,20 @@ interface DetailPanelTestProps {
   collectionAddPending: boolean;
   onAddToCollections: (collectionIds: string[]) => Promise<void>;
   onSplitFolder: (path: string, name: string) => void;
+  fileActionsDisabled?: boolean;
+  fileActionStatus?: string;
+  onCompressFolder?: (path: string, name: string) => void;
 }
 
 vi.mock('../components/models/ModelDetailPanel', () => ({
-  ModelDetailPanel: ({ collectionAddPending, onAddToCollections, onSplitFolder }: DetailPanelTestProps) => (
+  ModelDetailPanel: ({
+    collectionAddPending,
+    onAddToCollections,
+    fileActionsDisabled,
+    fileActionStatus,
+    onCompressFolder,
+    onSplitFolder,
+  }: DetailPanelTestProps) => (
     <>
       <button
         type="button"
@@ -74,12 +85,24 @@ vi.mock('../components/models/ModelDetailPanel', () => ({
       <button type="button" onClick={() => onSplitFolder('variants/large', 'large')}>
         Split folder
       </button>
+      <button
+        type="button"
+        disabled={fileActionsDisabled}
+        onClick={() => onCompressFolder?.('parts', 'parts')}
+      >
+        {fileActionStatus ?? 'Compress folder'}
+      </button>
     </>
   ),
 }));
 
 import { addModelsToCollection, getCollections } from '../api/collections';
-import { getModel, getModelFiles, splitModelFolder } from '../api/models';
+import {
+  compressModelFolder,
+  getModel,
+  getModelFiles,
+  splitModelFolder,
+} from '../api/models';
 
 const model: ModelDetail = {
   id: 'model-1',
@@ -124,7 +147,7 @@ function renderPage(queryClient: QueryClient) {
   );
 }
 
-describe('ModelDetailPage collection membership', () => {
+describe('ModelDetailPage mutations', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(getModel).mockResolvedValue(model);
@@ -223,6 +246,41 @@ describe('ModelDetailPage collection membership', () => {
       ['model-files', 'model-1'],
       ['models'],
       ['search'],
+    ]) {
+      expect(invalidateQueries).toHaveBeenCalledWith({ queryKey });
+    }
+  });
+
+  it('should show compression progress, refresh model data, and name the created archive', async () => {
+    const compression = deferred<CompressFolderResponse>();
+    vi.mocked(compressModelFolder).mockReturnValue(compression.promise);
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries');
+    renderPage(queryClient);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Compress folder' }));
+
+    await waitFor(() => {
+      expect(compressModelFolder).toHaveBeenCalledWith('model-1', 'parts');
+      expect(screen.getByRole('button', { name: 'Compressing folder…' })).toBeDisabled();
+    });
+    expect(mocks.toast).not.toHaveBeenCalled();
+
+    compression.resolve({
+      archiveFileId: 'archive-1',
+      archivePath: 'parts.7z',
+      sizeBytes: 2048,
+    });
+
+    await waitFor(() => {
+      expect(mocks.toast).toHaveBeenCalledWith({ title: 'Created parts.7z' });
+    });
+    for (const queryKey of [
+      ['model', 'model-1'],
+      ['model-files', 'model-1'],
+      ['models'],
     ]) {
       expect(invalidateQueries).toHaveBeenCalledWith({ queryKey });
     }

--- a/apps/frontend/src/pages/ModelDetailPage.tsx
+++ b/apps/frontend/src/pages/ModelDetailPage.tsx
@@ -5,6 +5,7 @@ import { ChevronLeft, AlertTriangle, Download, GitMerge, Loader2, Upload, X } fr
 import type { ModelCard, ModelDetail, SplitModelFolderRequest } from '@alexandria/shared';
 import { addModelsToCollection, getCollections } from '../api/collections';
 import {
+  compressModelFolder,
   createModelFolder,
   deleteModelFile,
   deleteModelFolder,
@@ -53,6 +54,7 @@ type FileAction =
   | { type: 'delete-files'; fileIds: string[] }
   | { type: 'rename-folder'; path: string; name: string }
   | { type: 'move-folder'; path: string; parentPath: string }
+  | { type: 'compress-folder'; path: string; name: string }
   | { type: 'delete-folder'; path: string; name: string };
 
 function fileActionStatus(action: FileAction | undefined): string | undefined {
@@ -67,6 +69,7 @@ function fileActionStatus(action: FileAction | undefined): string | undefined {
     case 'delete-files': return `Deleting ${action.fileIds.length} files…`;
     case 'rename-folder': return 'Renaming folder…';
     case 'move-folder': return 'Moving folder…';
+    case 'compress-folder': return 'Compressing folder…';
     case 'delete-folder': return 'Deleting folder…';
   }
 }
@@ -196,6 +199,10 @@ export function ModelDetailPage() {
         case 'move-folder':
           await updateModelFolder(id, { path: action.path, parentPath: action.parentPath });
           return 'Folder moved';
+        case 'compress-folder': {
+          const result = await compressModelFolder(id, action.path);
+          return `Created ${result.archivePath}`;
+        }
         case 'delete-folder':
           await deleteModelFolder(id, action.path);
           return 'Folder deleted';
@@ -390,6 +397,7 @@ export function ModelDetailPage() {
               onDeleteFiles={(fileIds) => fileMutation.mutate({ type: 'delete-files', fileIds })}
               onRenameFolder={(path, name) => fileMutation.mutate({ type: 'rename-folder', path, name })}
               onMoveFolder={(path, parentPath) => runFileAction({ type: 'move-folder', path, parentPath })}
+              onCompressFolder={(path, name) => fileMutation.mutate({ type: 'compress-folder', path, name })}
               onDeleteFolder={(path, name) => fileMutation.mutate({ type: 'delete-folder', path, name })}
               onSplitFolder={(path, name) => setSplitFolderTarget({ path, name })}
               allCollections={collectionsQuery.data ?? []}

--- a/docs/API.md
+++ b/docs/API.md
@@ -1328,6 +1328,42 @@ The endpoint returns `400 VALIDATION_ERROR` when the source is not ready, the na
 
 ---
 
+### POST /models/:id/folders/compress
+
+Create a 7z archive from one folder in a model. The archive uses LZMA2 compression and is stored beside the source folder as `<folder-name>.7z`. Archive entries are relative to the selected folder, so extracting the new archive through Alexandria recreates the folder contents without an extra duplicate top-level directory. The operation is non-destructive: the source folder and its files remain unchanged.
+
+**Auth required:** Yes. The model must belong to the authenticated user and active library.
+
+**Path parameter:** `id` — model UUID
+
+**Request body:**
+
+```json
+{
+  "path": "extras/parts"
+}
+```
+
+`path` must identify an existing folder and is limited to 1,000 characters. The derived archive path must also satisfy Alexandria's path limits, so the source path can be at most 997 characters and its final segment at most 252 characters to leave room for `.7z`. A missing folder returns `404 NOT_FOUND`. If the `extras/parts.7z` sibling namespace or its underlying storage key is already occupied, the request returns `409 CONFLICT`; the operation does not replace an existing managed path.
+
+**Response (201):**
+
+```json
+{
+  "data": {
+    "archiveFileId": "uuid",
+    "archivePath": "extras/parts.7z",
+    "sizeBytes": 1048576
+  },
+  "meta": null,
+  "errors": null
+}
+```
+
+The backend streams the selected files from managed storage into a temporary directory, preserving explicit empty descendant folders, creates the archive with the bundled 7-Zip binary, stores and verifies it through the configured local or S3 storage backend, persists it as a model file with MIME type `application/x-7z-compressed`, and updates the model's file and byte totals in one database transaction. Temporary data is always removed. A failure before database persistence triggers best-effort cleanup of any newly stored archive object.
+
+---
+
 ### GET /models/:id/download
 
 Download all files belonging to a model as a ZIP archive. The archive is assembled and streamed from managed storage; the original directory structure is preserved and the full archive is never buffered in server memory.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -8,7 +8,7 @@ This document is the source of truth for Alexandria's architecture. Every struct
 
 Alexandria is a self-hosted personal library for 3D printing model collections. It manages the upload, processing, organization, browsing, and search of 3D printing model files. The primary deployment target is Docker Compose.
 
-The system follows a monorepo structure with a React frontend, a Fastify backend, and a shared types package. The backend is organized around focused services with clear ownership boundaries. All file processing happens asynchronously via a job queue.
+The system follows a monorepo structure with a React frontend, a Fastify backend, and a shared types package. The backend is organized around focused services with clear ownership boundaries. Upload and import pipelines run asynchronously through job queues; explicit file-tree actions such as extracting a stored archive or compressing a folder run synchronously within their authenticated request.
 
 ### Core Principles
 
@@ -66,6 +66,7 @@ The `runSeed` function is also exported for use as a standalone CLI script (`npm
 │  │ Routes   │→│PresenterSvc  │←│ Services            │   │
 │  │ (thin)   │  │(response     │  │                    │   │
 │  │          │  │ assembly)    │  │ ModelService        │   │
+│  │          │  │              │  │ ModelFolderArchive  │   │
 │  └─────────┘  └──────────────┘  │ MetadataService     │   │
 │                                  │ CollectionService   │   │
 │  requireAuth ──→ requireLibrary  │ SearchService       │   │
@@ -190,7 +191,7 @@ This index makes the enforcement race-safe: the database rejects a second `is_de
 
 Routes that apply `requireLibrary` (as of P5):
 
-- `GET /models`, `GET /models/:id`, `GET /models/:id/files`, `GET /models/:id/status`
+- `GET /models`, `GET /models/:id`, `GET /models/:id/files`, `GET /models/:id/status`, `POST /models/:id/folders/compress`
 - `GET /collections`, `POST /collections`, `GET /collections/:id`, `GET /collections/:id/models`
 - `GET /metadata/fields/:slug/values`
 - `POST /models/upload`, `POST /models/upload/:uploadId/complete`, `POST /models/upload/multipart/complete`, `POST /models/import`
@@ -267,11 +268,11 @@ Three entry paths:
 
 ### FileProcessingService
 
-**Owns:** Archive extraction, folder directory walking, file type classification, basic metadata extraction from file contents and names.
+**Owns:** Archive extraction and creation, folder directory walking, file type classification, basic metadata extraction from file contents and names.
 
 **Does not own:** File storage, thumbnail generation, database record persistence.
 
-**Behavior:** Given an archive file (zip, rar, 7z, tar.gz, tgz), an explicit multipart archive group, or a directory path, produces a structured manifest describing what was found: files with their relative paths, classified types, sizes, and any metadata extractable from filenames or structure. In `combine` mode every source must be an independent complete archive with a plain filename. Each archive is extracted beneath a folder derived from that filename, empty or dot-only folder names are rejected, folder collisions are resolved case-insensitively with `-2`, `-3`, and later suffixes, and the resolved folder must remain a strict descendant of the extraction root. In `split` mode the service validates either a contiguous classic `.z01` … `.z99` set plus one terminal `.zip`, a contiguous numbered `.zip.001` … `.zip.999` set, or a modern contiguous `<base>.partN.rar` set starting at part 1. Every set must use one case-insensitive base name; RAR members additionally require a safe base and consistent part-number padding. The service copies normalized member names into a temporary colocation directory, invokes the full 7-Zip extractor on the ZIP or RAR entry member so it can resolve the remaining colocated volumes, then removes the temporary directory. Before 7-Zip-based extraction it requests technical metadata and rejects absolute, drive-qualified, UNC, or parent-traversal paths plus symbolic links, hard links, and reparse entries. Link detection covers dedicated fields and Unix link modes or reparse markers reported through `Mode` or `Attributes`; extraction-reported paths outside the destination are also rejected. This manifest is what IngestionService uses to create ModelFile records and route files to storage. During commit, `copyManifestToStorage` reports monotonic per-file and byte counters without making progress reporting a requirement for a successful storage write.
+**Behavior:** Given an archive file (zip, rar, 7z, tar.gz, tgz), an explicit multipart archive group, or a directory path, produces a structured manifest describing what was found: files with their relative paths, classified types, sizes, and any metadata extractable from filenames or structure. In `combine` mode every source must be an independent complete archive with a plain filename. Each archive is extracted beneath a folder derived from that filename, empty or dot-only folder names are rejected, folder collisions are resolved case-insensitively with `-2`, `-3`, and later suffixes, and the resolved folder must remain a strict descendant of the extraction root. In `split` mode the service validates either a contiguous classic `.z01` … `.z99` set plus one terminal `.zip`, a contiguous numbered `.zip.001` … `.zip.999` set, or a modern contiguous `<base>.partN.rar` set starting at part 1. Every set must use one case-insensitive base name; RAR members additionally require a safe base and consistent part-number padding. The service copies normalized member names into a temporary colocation directory, invokes the full 7-Zip extractor on the ZIP or RAR entry member so it can resolve the remaining colocated volumes, then removes the temporary directory. Before 7-Zip-based extraction it requests technical metadata and rejects absolute, drive-qualified, UNC, or parent-traversal paths plus symbolic links, hard links, and reparse entries. Link detection covers dedicated fields and Unix link modes or reparse markers reported through `Mode` or `Attributes`; extraction-reported paths outside the destination are also rejected. This manifest is what IngestionService uses to create ModelFile records and route files to storage. During commit, `copyManifestToStorage` reports monotonic per-file and byte counters without making progress reporting a requirement for a successful storage write. For folder compression, `create7zArchive` invokes the bundled 7-Zip binary with the 7z container and explicit LZMA2 method; it archives the staging directory's children so it does not introduce an extra top-level folder.
 
 Uses the **PatternParser** utility (located in `utils/pattern-parser.ts`) — a pure function that takes a user-defined hierarchy pattern string (e.g., `{Collection}/{metadata.Artist}/{model}`), validates it, and returns a structured representation. Validation rules: pattern must end with `{model}`, segments must be `{Collection}` or `{metadata.<fieldSlug>}`, and `{model}` cannot appear in the middle.
 
@@ -328,6 +329,16 @@ On startup, S3 mode performs `HeadBucket` validation before database migration a
 **Folder split behavior:** `splitModelFolder` accepts one folder from an owned, ready model in the active library. The folder must contain at least one file. Its files become the root contents of a new ready, `manual` model; descendant paths are rebased by removing the selected folder prefix, while persisted nested folders, including empty descendants, are preserved. Existing ModelFile IDs and thumbnail records remain attached to their files. If the source model's selected preview is among the moved files, its preview selection and crop values transfer to the new model and are cleared on the source. Both models' file count and total size are recalculated. The new model receives the requested name but no metadata values, collection memberships, description, or other source provenance; those source relationships and values remain on the source model.
 
 The service copies file and thumbnail objects to new model-scoped storage keys before opening the database transaction. In the transaction it locks and revalidates the owned source and its exact folder contents, creates the new model, reassigns file/folder rows, updates storage keys and preview references, and recalculates both models' statistics. A concurrent folder change produces a conflict and rolls back the database work. Any pre-commit copy or transaction failure triggers best-effort removal of every object whose copy completed successfully. After a successful commit, deletion of the old storage objects is best-effort; a cleanup failure cannot roll back the committed split.
+
+For a derived folder archive, `createModelFileAndRecalculateStats` inserts the `ModelFile` record and recalculates the model's file and byte totals in one database transaction.
+
+### ModelFolderArchiveService
+
+**Owns:** Orchestrating non-destructive compression of one model folder into a sibling 7z archive.
+
+**Does not own:** Model ownership or library authorization (the route and ModelService), archive encoding (FileProcessingService), blob storage (StorageService), or model-file persistence (ModelService).
+
+**Behavior:** Normalizes the requested and derived archive paths, serializes concurrent requests for the same model and folder, and admits at most one compression process at a time per backend instance. It resolves descendant files and explicit empty folders and rejects a missing folder. Before reading source objects, it rejects any file, folder namespace, or storage object already occupying `<folder-path>.7z`. It streams source objects through StorageService into an isolated temporary directory, delegates explicit LZMA2 archive creation to FileProcessingService, and stores and verifies the result through the configured storage backend. ModelService then records the archive as `application/x-7z-compressed` and updates model totals transactionally. The source folder is never changed. Failures before database persistence trigger best-effort deletion of the newly written archive object, and temporary data is always removed.
 
 ### MetadataService
 
@@ -569,7 +580,7 @@ The Model Detail page (`pages/ModelDetailPage.tsx`) was fully redesigned in P2. 
 
 `components/models/ModelDetailPanel.tsx` is the tabbed right panel. `components/models/PanelTabs.tsx` is the generic full-width segmented control it uses. `PanelTabs` is typed with a string union for tab values and accepts icon components typed as `React.ComponentType<{ className?: string }>` (see the gotcha note in the Conventions doc).
 
-The Collections tab lists the model's current manual-collection memberships and can add the model to one or more additional collections without removing existing memberships. The browse bulk-action bar makes the same distinction explicit: **Add to collection** preserves existing memberships, while **Move** replaces them.
+The Files tab exposes file and folder organization actions from each tree node. A folder's **Compress to 7z** action creates a sibling archive and refreshes the detail and file-tree queries after completion; the original folder remains available. The Collections tab lists the model's current manual-collection memberships and can add the model to one or more additional collections without removing existing memberships. The browse bulk-action bar makes the same distinction explicit: **Add to collection** preserves existing memberships, while **Move** replaces them.
 
 The detail page also owns a per-model `MergeModelsDialog`, which keeps the current model as the merge target and searches the library for sources. The browse bar's bulk merge (see Pivot Workspace → Bulk merge) inverts that: the sources are already chosen and the dialog asks which one to keep.
 
@@ -611,8 +622,9 @@ Because `ModelViewer3DScene` is lazy-loaded, Vite emits three.js as a separate a
 | Method | Route | Purpose | Service Chain | Library-scoped |
 |--------|-------|---------|---------------|---------------|
 | GET | /models | Browse/search with filters | SearchService → PresenterService | Yes |
-| GET | /models/:id | Model detail | ModelService → PresenterService | No (userId) |
-| GET | /models/:id/files | File tree | ModelService → PresenterService | No (userId) |
+| GET | /models/:id | Model detail | ModelService → PresenterService | Yes |
+| GET | /models/:id/files | File tree | ModelService → PresenterService | Yes |
+| POST | /models/:id/folders/compress | Create a non-destructive sibling 7z archive | ModelFolderArchiveService → ModelService + FileProcessingService + StorageService | Yes |
 | POST | /models/upload | Upload archive → scan (returns sessionId) | IngestionService → ImportSessionService → JobService | Yes |
 | POST | /models/upload/init | Initiate chunked upload session | UploadService | No |
 | POST | /models/upload/multipart/init | Initiate one chunked member of a multipart group | UploadService | No |
@@ -627,12 +639,12 @@ Because `ModelViewer3DScene` is lazy-loaded, Vite emits three.js as a separate a
 | POST | /models/import-sessions/:id/files | Append loose files to a staged model | IngestionService → FileProcessingService | Yes |
 | POST | /models/import-sessions/:id/commit | Commit session → create model | IngestionService → JobService | Yes |
 | DELETE | /models/import-sessions/:id | Discard session + staged files | IngestionService | No (userId) |
-| GET | /models/:id/status | Processing status | JobService | No (userId) |
+| GET | /models/:id/status | Processing status | ModelService | Yes |
 | PATCH | /models/:id | Update model | ModelService → PresenterService | No (userId) |
 | POST | /models/:id/folders/split | Move one folder's contents into a new model root | ModelService → StorageService | Yes |
 | DELETE | /models/:id | Delete model + files | ModelService → StorageService | No (userId) |
 
-"Library-scoped" means the route applies the `requireLibrary` preHandler and scopes its read or write to `request.libraryId`. Routes marked `No (userId)` enforce ownership but do not use the active library. The folder-split route enforces both ownership and active-library scope because it creates another model in that library.
+"Library-scoped" means the route applies the `requireLibrary` preHandler and scopes its read or write to `request.libraryId`. Routes marked `No (userId)` enforce ownership but do not use the active library. Read/detail model routes and the folder-compression mutation enforce active-library scope; the folder-split route does the same because it creates another model in that library. The top-level `PATCH` and `DELETE` model mutations remain owned by `userId` only.
 
 **Collections**
 | Method | Route | Purpose | Service Chain | Library-scoped |

--- a/docs/STORAGE.md
+++ b/docs/STORAGE.md
@@ -4,6 +4,14 @@ Alexandria stores model files and thumbnails through one storage interface. The 
 
 Objects should be private. Alexandria's authenticated `/files/...` endpoints look up the logical key and stream bytes through the backend, so browsers never need bucket credentials or direct object access.
 
+## Derived folder archives
+
+`POST /models/:id/folders/compress` creates a new 7z archive from a folder already stored in a model. It is a non-destructive operation: the source folder and every file below it remain in place, while the new archive is stored beside the folder under the logical key `models/<model-id>/<folder-path>.7z`. Alexandria refuses the operation when that sibling path is already occupied by a file or folder; the action does not replace an existing managed path.
+
+Compression is storage-backend independent. The backend streams the selected files through `StorageService` into a temporary workspace, recreates explicit empty descendant folders, invokes 7-Zip with explicit LZMA2 compression, and stores and verifies the resulting archive through `StorageService`. It does not assume that model files have local filesystem paths, so the same path works with local and S3-compatible storage. Archive entries are relative to the selected folder rather than to the model root. To bound temporary-disk and CPU pressure, each backend process runs at most one folder-compression operation at a time.
+
+After the object is stored, Alexandria creates its `ModelFile` row and updates the model's file count and total size. If persistence fails, it makes a best-effort attempt to remove the newly stored object. Temporary files are removed whether the operation succeeds or fails.
+
 ## Configuration
 
 | Variable | Default | Required | Purpose |

--- a/docs/TYPES.md
+++ b/docs/TYPES.md
@@ -498,6 +498,17 @@ interface FileTreeNode {
   id?: string;               // present for files only (ModelFile.id)
   children?: FileTreeNode[]; // present for directories only
 }
+
+interface CompressModelFolderRequest {
+  path: string; // relative path of the folder within the model; 1–1,000 characters
+}
+
+// POST /models/:id/folders/compress
+interface CompressFolderResponse {
+  archiveFileId: string;
+  archivePath: string; // sibling path, for example parts.7z or extras/parts.7z
+  sizeBytes: number;
+}
 ```
 
 ### Metadata Response Types

--- a/docs/knowledge-base.md
+++ b/docs/knowledge-base.md
@@ -18,7 +18,7 @@ Several decisions were made during the architecture phase and are treated as set
 
 **Collections are not metadata.** Collections are organizational (where you put a model), not descriptive (what a model is). This is why Artist is a metadata field and Collections are a separate entity. A model can belong to multiple collections.
 
-**Managed storage only.** After upload or import, Alexandria owns all files in its storage root. No runtime external file references. When importing an existing library folder, you choose a strategy: hardlink (zero additional disk usage on the same filesystem), copy, or move. Once imported, StorageService is the sole authority.
+**Managed storage only.** After upload or import, Alexandria owns all files in its storage root. No runtime external file references. When importing an existing library folder, you choose a strategy: hardlink (zero additional disk usage on the same filesystem), copy, or move. Once imported, StorageService is the sole authority. Derived files follow the same rule: a model folder can be compressed to a sibling 7z archive without deleting or changing the source folder, whether storage is local or S3-compatible.
 
 **Server-side response assembly.** PresenterService on the backend assembles all API response payloads into ready-to-render shapes before sending them. The frontend does not reshape or join data — it receives what it needs to display. This keeps frontend complexity low and makes response format changes a single-location concern.
 
@@ -38,13 +38,14 @@ The backend is organized around focused services. Each service owns a coherent s
 
 - **IngestionService** — orchestrates the upload and import pipelines; creates model records and enqueues processing jobs
 - **FileProcessingService** — extracts archives and supported split archives, temporarily colocates split members and starts extraction from the set's entry member, rejects unsafe paths and link-like entries before 7-Zip extraction, combines explicitly grouped complete archives under collision-safe folders, walks import directories, classifies files by type, and computes SHA-256 hashes
+- **ModelFolderArchiveService** — creates a verified sibling 7z archive from a model folder without changing the source folder, across local or S3-compatible storage
 - **StorageService** — manages backend-independent logical keys through local-filesystem or S3-compatible providers
 - **ThumbnailService** — generates WebP thumbnails at grid and detail sizes using sharp
 - **UploadService** — manages chunked upload sessions in memory, bounds accepted chunk bytes to the declared file size, supports explicit abort and cleanup, and assembles single files or multipart groups for ingestion
 - **ImportSessionService** — owns staged scan, persisted review drafts, and commit sessions
 - **ImportStrategyService** — moves folder imports into managed storage using hardlink, copy, or move strategies
 - **JobService** — manages BullMQ queues and job lifecycle
-- **ModelService** — CRUD for Model and ModelFile records
+- **ModelService** — CRUD for Model, ModelFile, and ModelFolder records
 - **ModelDownloadService** — streams model downloads from managed storage
 - **MetadataService** — field definitions and metadata values, with internal routing for optimized field types (tags)
 - **SearchService** — all query execution: full-text search, metadata filtering, sorting, cursor pagination
@@ -75,6 +76,6 @@ The auto-seed uses `admin@alexandria.local` as the default email, but Docker Com
 
 ## Current Status
 
-Phases 1 through 8 are complete. The full feature set described above — ingestion pipeline, metadata system, folder import, full-text search, collections, PresenterService API polish, the React frontend, the in-browser STL viewer, and the preview-first assistant — is implemented and reviewed. Deployments can use either the bundled Postgres container or hosted PostgreSQL. Chunked uploads support files up to 5 GB with 10 MB chunks and automatic retry. The upload page also has a dedicated Multi-part archive tab for combining 2–100 independent complete archives or uploading one complete supported split archive, including a modern `<base>.partN.rar` set, into a single review session and model. The assistant can now read collections and metadata knowledge, act on current single or multi-model page targets, stage uniform metadata or collection operations across as many as 500 server-resolved models, and stage metadata for pre-commit uploads without committing them.
+Phases 1 through 8 are complete. The full feature set described above — ingestion pipeline, metadata system, folder import, full-text search, collections, PresenterService API polish, the React frontend, the in-browser STL viewer, and the preview-first assistant — is implemented and reviewed. A model's file tree supports in-place organization and non-destructive folder-to-7z compression. Deployments can use either the bundled Postgres container or hosted PostgreSQL. Chunked uploads support files up to 5 GB with 10 MB chunks and automatic retry. The upload page also has a dedicated Multi-part archive tab for combining 2–100 independent complete archives or uploading one complete supported split archive, including a modern `<base>.partN.rar` set, into a single review session and model. The assistant can now read collections and metadata knowledge, act on current single or multi-model page targets, stage uniform metadata or collection operations across as many as 500 server-resolved models, and stage metadata for pre-commit uploads without committing them.
 
 Planned but not yet implemented: multi-user support and print job tracking.

--- a/packages/shared/src/types/model.ts
+++ b/packages/shared/src/types/model.ts
@@ -127,6 +127,16 @@ export interface SplitModelFolderResponse {
   movedFileCount: number;
 }
 
+export interface CompressModelFolderRequest {
+  path: string;
+}
+
+export interface CompressFolderResponse {
+  archiveFileId: string;
+  archivePath: string;
+  sizeBytes: number;
+}
+
 export interface ExtractArchiveResponse {
   addedFileCount: number;
   destinationPath: string;

--- a/packages/shared/src/validation/model.ts
+++ b/packages/shared/src/validation/model.ts
@@ -55,3 +55,7 @@ export const splitModelFolderSchema = z.object({
   path: relativePathSchema,
   name: z.string().trim().min(1).max(255),
 });
+
+export const compressModelFolderSchema = z.object({
+  path: relativePathSchema,
+});


### PR DESCRIPTION
## Summary
- add a non-destructive folder action that creates a sibling `.7z` archive using LZMA2
- stage, verify, and persist archives across local and S3-compatible storage with cleanup, conflict handling, and bounded concurrency
- add the API contract, frontend action/progress feedback, documentation, and backend/frontend coverage

## Verification
- `npm test -- --output-logs=errors-only`
- `npm run build`
- `npm run lint`