### PR TITLE
Add browsable metadata navigation

### DIFF
--- a/apps/frontend/src/components/icons/index.ts
+++ b/apps/frontend/src/components/icons/index.ts
@@ -8,6 +8,7 @@ export {
   User as ArtistIcon,
   Tag as TagIcon,
   Sparkles as SmartIcon,
+  ListFilter as MetadataIcon,
   LayoutGrid as GridViewIcon,
   List as ListViewIcon,
   Rows3 as GroupViewIcon,

--- a/apps/frontend/src/components/metadata/FieldDialog.tsx
+++ b/apps/frontend/src/components/metadata/FieldDialog.tsx
@@ -230,7 +230,7 @@ export function FieldDialog({ open, onOpenChange, field, onSuccess }: FieldDialo
                 className="rounded border-input"
               />
               <span className="text-sm">Browsable</span>
-              <span className="text-xs text-muted-foreground">(shown on model cards)</span>
+              <span className="text-xs text-muted-foreground">(appears in Browse by navigation)</span>
             </label>
           </div>
 

--- a/apps/frontend/src/components/models/ModelGroupView.test.tsx
+++ b/apps/frontend/src/components/models/ModelGroupView.test.tsx
@@ -70,6 +70,14 @@ const MODEL_NO_ARTIST = makeModel({
   metadata: [],
 });
 
+const MODEL_MULTI_MATERIAL = makeModel({
+  id: 'model-multi-material',
+  name: 'Mixed Material Part',
+  metadata: [
+    { fieldSlug: 'material', fieldName: 'Material', type: 'multi_enum', value: ['PLA', 'PETG'], displayValue: 'PLA, PETG' },
+  ],
+});
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -254,6 +262,39 @@ describe('ModelGroupView', () => {
       );
 
       expect(screen.getByRole('heading', { name: /collection/i })).toBeTruthy();
+    });
+  });
+
+  describe('axis=metadata:<slug>', () => {
+    it('groups by a metadata display value', () => {
+      render(
+        <ModelGroupView
+          models={[MODEL_MULTI_MATERIAL]}
+          axis="metadata:material"
+          activeAxisValue={DEFAULT_AXIS_VALUE}
+          metadataFieldName="Material"
+        />,
+        { wrapper }
+      );
+
+      expect(screen.getByRole('heading', { name: 'PLA, PETG' })).toBeTruthy();
+      expect(screen.getByText('Mixed Material Part')).toBeTruthy();
+    });
+
+    it('keeps an array-valued selection as one stored/display combination', () => {
+      render(
+        <ModelGroupView
+          models={[MODEL_MULTI_MATERIAL]}
+          axis="metadata:material"
+          activeAxisValue={DEFAULT_AXIS_VALUE}
+          metadataFieldName="Material"
+        />,
+        { wrapper }
+      );
+
+      expect(screen.getAllByRole('heading', { level: 2 })).toHaveLength(1);
+      expect(screen.queryByRole('heading', { name: 'PLA' })).toBeNull();
+      expect(screen.queryByRole('heading', { name: 'PETG' })).toBeNull();
     });
   });
 });

--- a/apps/frontend/src/components/models/ModelGroupView.tsx
+++ b/apps/frontend/src/components/models/ModelGroupView.tsx
@@ -1,5 +1,6 @@
 import type { ModelCard } from '@alexandria/shared';
 import { ModelCard as ModelCardComponent } from './ModelCard';
+import { getMetadataAxisSlug } from '../../hooks/use-model-filters';
 import type { PivotAxis } from '../../hooks/use-model-filters';
 import type { ActiveAxisValue } from '../../hooks/use-model-filters';
 
@@ -7,6 +8,7 @@ export interface ModelGroupViewProps {
   models: ModelCard[];
   axis: PivotAxis;
   activeAxisValue: ActiveAxisValue;
+  metadataFieldName?: string;
   selectable?: boolean;
   isSelected?: (id: string) => boolean;
   onToggleSelect?: (id: string) => void;
@@ -67,6 +69,43 @@ function groupByTags(models: ModelCard[]): ModelGroup[] {
   }
 
   return sortGroups(map);
+}
+
+/** Group each model by the complete stored/display value for a metadata field. */
+function groupByMetadata(
+  models: ModelCard[],
+  slug: string,
+  fieldName?: string,
+): ModelGroup[] {
+  const groups = new Map<string, ModelGroup>();
+  const resolvedFieldName = fieldName
+    ?? models.flatMap((model) => model.metadata).find((item) => item.fieldSlug === slug)?.fieldName
+    ?? slug;
+  const fallbackLabel = `No ${resolvedFieldName}`;
+
+  for (const model of models) {
+    const metadata = model.metadata.find((item) => item.fieldSlug === slug);
+    const hasValue = metadata
+      && (Array.isArray(metadata.value) ? metadata.value.length > 0 : metadata.value.length > 0);
+    const label = hasValue && metadata.displayValue ? metadata.displayValue : fallbackLabel;
+    // Array-valued metadata represents one stored selection combination here.
+    // Keep it paired with its display value instead of splitting it like Tags.
+    const key = hasValue
+      ? JSON.stringify([metadata.value, metadata.displayValue])
+      : '__missing__';
+    const group = groups.get(key) ?? { label, models: [] };
+    group.models.push(model);
+    groups.set(key, group);
+  }
+
+  const result = Array.from(groups.values());
+  result.sort((a, b) => {
+    if (a.label === fallbackLabel && b.label !== fallbackLabel) return 1;
+    if (a.label !== fallbackLabel && b.label === fallbackLabel) return -1;
+    if (b.models.length !== a.models.length) return b.models.length - a.models.length;
+    return a.label.localeCompare(b.label);
+  });
+  return result;
 }
 
 /** Sort groups: largest first, then alphabetically. "Untagged"/"Unknown artist" always last. */
@@ -162,6 +201,7 @@ export function ModelGroupView({
   models,
   axis,
   activeAxisValue,
+  metadataFieldName,
   selectable,
   isSelected,
   onToggleSelect,
@@ -172,6 +212,8 @@ export function ModelGroupView({
     groups = groupByArtist(models);
   } else if (axis === 'tags') {
     groups = groupByTags(models);
+  } else if (getMetadataAxisSlug(axis)) {
+    groups = groupByMetadata(models, getMetadataAxisSlug(axis)!, metadataFieldName);
   } else {
     // axis === 'collections'
     // Per-collection grouping is impossible client-side: ModelCard has no

--- a/apps/frontend/src/components/pivot/AxisFacetBody.test.tsx
+++ b/apps/frontend/src/components/pivot/AxisFacetBody.test.tsx
@@ -15,6 +15,7 @@ vi.mock('../../api/collections', () => ({
 }));
 
 vi.mock('../../api/metadata', () => ({
+  getFields: vi.fn(),
   getFieldValues: vi.fn(),
 }));
 
@@ -33,11 +34,12 @@ vi.mock('../../hooks/use-auth', () => ({
 }));
 
 import { getCollections } from '../../api/collections';
-import { getFieldValues } from '../../api/metadata';
+import { getFields, getFieldValues } from '../../api/metadata';
 import { listLibraries } from '../../api/libraries';
 
 const mockGetCollections = vi.mocked(getCollections);
 const mockGetFieldValues = vi.mocked(getFieldValues);
+const mockGetFields = vi.mocked(getFields);
 const mockListLibraries = vi.mocked(listLibraries);
 
 function LocationProbe() {
@@ -57,6 +59,11 @@ const TAGS: MetadataFieldValue[] = [
 const ARTISTS: MetadataFieldValue[] = [
   { value: 'Prusa', modelCount: 22 },
   { value: 'Bambu', modelCount: 11 },
+];
+
+const METADATA_FIELDS = [
+  { id: 'field-1', name: 'Scale', slug: 'scale', type: 'enum' as const, isDefault: false, isFilterable: true, isBrowsable: true, config: null, sortOrder: 1 },
+  { id: 'field-2', name: 'Private Notes', slug: 'private-notes', type: 'text' as const, isDefault: false, isFilterable: false, isBrowsable: false, config: null, sortOrder: 2 },
 ];
 
 const COLLECTION: CollectionDetail = {
@@ -124,6 +131,10 @@ function makeLibraryWrapper(initialUrl = '/lib/library-1') {
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
+beforeEach(() => {
+  mockGetFields.mockResolvedValue(METADATA_FIELDS);
+});
+
 describe('AxisFacetBody — tags axis', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -259,6 +270,53 @@ describe('AxisFacetBody — artists axis', () => {
     await waitFor(() => {
       expect(screen.getByText(/no artists found/i)).toBeTruthy();
     });
+  });
+});
+
+describe('AxisFacetBody — metadata axis', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetFieldValues.mockResolvedValue([
+      { value: '1:12', modelCount: 8 },
+      { value: '1:24', modelCount: 3 },
+    ]);
+  });
+
+  it('fetches and renders values and counts for the axis field', async () => {
+    render(<AxisFacetBody axis="metadata:scale" />, { wrapper: makeWrapper() });
+
+    expect(await screen.findByText('1:12')).toBeTruthy();
+    expect(screen.getByText('8')).toBeTruthy();
+    expect(mockGetFieldValues).toHaveBeenCalledWith('scale');
+  });
+
+  it('toggles the field value through its meta_<slug> URL filter', async () => {
+    render(<AxisFacetBody axis="metadata:scale" />, {
+      wrapper: makeWrapper('/?axis=metadata%3Ascale'),
+    });
+    const value = await screen.findByRole('button', { name: /1:12/i });
+    fireEvent.click(value);
+
+    await waitFor(() => expect(screen.getByTestId('location')).toHaveTextContent(
+      '/?axis=metadata%3Ascale&meta_scale=1%3A12'
+    ));
+    fireEvent.click(value);
+    await waitFor(() => expect(screen.getByTestId('location')).toHaveTextContent(
+      '/?axis=metadata%3Ascale'
+    ));
+  });
+
+  it.each([
+    ['unknown', 'metadata:unknown'],
+    ['non-browsable', 'metadata:private-notes'],
+    ['reserved tags', 'metadata:tags'],
+  ] as const)('does not fetch facet values for a %s metadata axis', async (_case, axis) => {
+    render(<AxisFacetBody axis={axis} />, { wrapper: makeWrapper() });
+
+    if (axis !== 'metadata:tags') {
+      await waitFor(() => expect(mockGetFields).toHaveBeenCalled());
+    }
+    expect(mockGetFieldValues).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/frontend/src/components/pivot/AxisFacetBody.tsx
+++ b/apps/frontend/src/components/pivot/AxisFacetBody.tsx
@@ -2,13 +2,13 @@ import { useQuery } from '@tanstack/react-query';
 import { Link } from 'react-router-dom';
 import { Plus } from 'lucide-react';
 import { getCollections } from '../../api/collections';
-import { getFieldValues } from '../../api/metadata';
+import { getFields, getFieldValues } from '../../api/metadata';
 import { getSmartCollections } from '../../api/smart-collections';
-import { useModelFilters } from '../../hooks/use-model-filters';
+import { getMetadataAxisSlug, useModelFilters } from '../../hooks/use-model-filters';
 import { useLibraryPath } from '../../hooks/use-libraries';
 import type { PivotAxis } from '../../hooks/use-model-filters';
 import { CollectionTree } from '../collections/CollectionTree';
-import { ArtistIcon, TagIcon, SmartIcon } from '../icons';
+import { ArtistIcon, TagIcon, SmartIcon, MetadataIcon } from '../icons';
 import { FacetItem } from './FacetItem';
 
 interface AxisFacetBodyProps {
@@ -125,6 +125,39 @@ function TagsAxis() {
   );
 }
 
+function MetadataAxis({ slug }: { slug: string }) {
+  const { filters, setMetaFilter } = useModelFilters();
+  const { data, isLoading } = useQuery({
+    queryKey: ['field-values', slug],
+    queryFn: () => getFieldValues(slug),
+  });
+
+  if (isLoading) return <LoadingRows />;
+
+  if (!data || data.length === 0) {
+    return (
+      <p className="px-3 py-4 text-xs text-[var(--ax-rail-fg-muted)]">No values found.</p>
+    );
+  }
+
+  const activeValue = filters.metadataFilters[slug];
+
+  return (
+    <div className="flex flex-col gap-px px-1">
+      {data.map((item) => (
+        <FacetItem
+          key={item.value}
+          icon={MetadataIcon}
+          label={item.value}
+          count={item.modelCount}
+          active={activeValue === item.value}
+          onClick={() => setMetaFilter(slug, activeValue === item.value ? undefined : item.value)}
+        />
+      ))}
+    </div>
+  );
+}
+
 function SmartAxis() {
   const { smartCollectionId, setSmartCollectionId } = useModelFilters();
   const libPath = useLibraryPath();
@@ -170,12 +203,24 @@ function SmartAxis() {
  * to update URL-driven filter state.
  */
 export function AxisFacetBody({ axis }: AxisFacetBodyProps) {
+  const metadataSlug = getMetadataAxisSlug(axis);
+  const { data: metadataFields, isLoading: isLoadingFields } = useQuery({
+    queryKey: ['metadata-fields'],
+    queryFn: getFields,
+    enabled: !!metadataSlug,
+  });
+  const metadataFieldIsBrowsable = metadataSlug
+    ? metadataFields?.some((field) => field.slug === metadataSlug && field.isBrowsable) ?? false
+    : false;
+
   return (
     <div className="flex-1 overflow-y-auto ax-scroll min-h-0">
       {axis === 'collections' && <CollectionsAxis />}
       {axis === 'artists' && <ArtistsAxis />}
       {axis === 'tags' && <TagsAxis />}
       {axis === 'smart' && <SmartAxis />}
+      {metadataSlug && isLoadingFields && <LoadingRows />}
+      {metadataSlug && metadataFieldIsBrowsable && <MetadataAxis slug={metadataSlug} />}
     </div>
   );
 }

--- a/apps/frontend/src/components/pivot/AxisPicker.test.tsx
+++ b/apps/frontend/src/components/pivot/AxisPicker.test.tsx
@@ -1,25 +1,67 @@
-import { describe, it, expect } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
-import { MemoryRouter, useLocation } from 'react-router-dom';
+import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter, useLocation, useNavigate } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { MetadataFieldDetail } from '@alexandria/shared';
 import { AxisPicker } from './AxisPicker';
+
+vi.mock('../../api/metadata', () => ({ getFields: vi.fn() }));
+
+import { getFields } from '../../api/metadata';
+
+const mockGetFields = vi.mocked(getFields);
+const FIELDS: MetadataFieldDetail[] = [
+  { id: '1', name: 'Artist', slug: 'artist', type: 'text', isDefault: true, isFilterable: true, isBrowsable: true, config: null, sortOrder: 0 },
+  { id: '2', name: 'Scale', slug: 'scale', type: 'enum', isDefault: false, isFilterable: true, isBrowsable: true, config: null, sortOrder: 1 },
+  { id: '3', name: 'Private Notes', slug: 'private-notes', type: 'text', isDefault: false, isFilterable: false, isBrowsable: false, config: null, sortOrder: 2 },
+  { id: '4', name: 'Material', slug: 'material', type: 'text', isDefault: false, isFilterable: true, isBrowsable: true, config: null, sortOrder: 3 },
+  { id: '5', name: 'Generated Field', slug: '-abcd', type: 'text', isDefault: false, isFilterable: true, isBrowsable: true, config: null, sortOrder: 4 },
+];
 
 function LocationProbe() {
   const location = useLocation();
   return <output data-testid="location">{location.pathname}{location.search}</output>;
 }
 
+function BackButton() {
+  const navigate = useNavigate();
+  return <button type="button" onClick={() => navigate(-1)}>Back</button>;
+}
+
 function makeWrapper(initialUrl = '/') {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return function Wrapper({ children }: { children: React.ReactNode }) {
     return (
-      <MemoryRouter initialEntries={[initialUrl]}>
-        {children}
-        <LocationProbe />
-      </MemoryRouter>
+      <QueryClientProvider client={client}>
+        <MemoryRouter initialEntries={[initialUrl]}>
+          {children}
+          <LocationProbe />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+  };
+}
+
+function makeHistoryWrapper(initialEntries: string[]) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={client}>
+        <MemoryRouter initialEntries={initialEntries} initialIndex={initialEntries.length - 1}>
+          {children}
+          <LocationProbe />
+          <BackButton />
+        </MemoryRouter>
+      </QueryClientProvider>
     );
   };
 }
 
 describe('AxisPicker', () => {
+  beforeEach(() => {
+    mockGetFields.mockResolvedValue(FIELDS);
+  });
+
   it('renders all three axis buttons', () => {
     render(<AxisPicker />, { wrapper: makeWrapper() });
 
@@ -89,5 +131,87 @@ describe('AxisPicker', () => {
     expect(screen.getByTestId('location')).toHaveTextContent(
       '/?collectionId=col-1&axis=tags'
     );
+  });
+
+  it('renders browsable metadata fields in returned order without duplicating built-ins', async () => {
+    render(<AxisPicker />, { wrapper: makeWrapper() });
+
+    const scale = await screen.findByRole('button', { name: 'Scale' });
+    const material = screen.getByRole('button', { name: 'Material' });
+    expect(scale.compareDocumentPosition(material) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Private Notes' })).toBeNull();
+    expect(screen.getAllByRole('button', { name: 'Artists' })).toHaveLength(1);
+  });
+
+  it('selects a metadata axis using metadata:<slug> URL encoding', async () => {
+    render(<AxisPicker />, { wrapper: makeWrapper() });
+    fireEvent.click(await screen.findByRole('button', { name: 'Scale' }));
+
+    expect(screen.getByTestId('location')).toHaveTextContent('/?axis=metadata%3Ascale');
+    expect(screen.getByRole('button', { name: 'Scale' }).getAttribute('aria-pressed')).toBe('true');
+  });
+
+  it('allows a returned browsable field with a leading-hyphen slug', async () => {
+    render(<AxisPicker />, { wrapper: makeWrapper('/?axis=metadata%3A-abcd') });
+
+    const field = await screen.findByRole('button', { name: 'Generated Field' });
+    expect(field.getAttribute('aria-pressed')).toBe('true');
+    expect(screen.getByTestId('location').textContent).toBe('/?axis=metadata%3A-abcd');
+  });
+
+  it.each([
+    ['unknown', 'metadata%3Aunknown'],
+    ['non-browsable', 'metadata%3Aprivate-notes'],
+    ['reserved tags', 'metadata%3Atags'],
+  ])('normalizes a %s metadata axis back to collections', async (_case, encodedAxis) => {
+    render(<AxisPicker />, { wrapper: makeWrapper(`/?axis=${encodedAxis}`) });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('location').textContent).toBe('/');
+      expect(screen.getByRole('button', { name: 'Collections' }).getAttribute('aria-pressed')).toBe('true');
+    });
+  });
+
+  it('replaces an invalid browse axis so Back does not revisit cleanup', async () => {
+    render(<AxisPicker />, {
+      wrapper: makeHistoryWrapper(['/previous', '/?axis=metadata%3Aunknown&q=keep']),
+    });
+
+    await waitFor(() => expect(screen.getByTestId('location').textContent).toBe('/?q=keep'));
+    fireEvent.click(screen.getByRole('button', { name: 'Back' }));
+    await waitFor(() => expect(screen.getByTestId('location').textContent).toBe('/previous'));
+  });
+
+  it('does not rewrite an invalid dynamic axis on a non-browse pathname', async () => {
+    render(<AxisPicker />, {
+      wrapper: makeWrapper('/models/model-1?axis=metadata%3Aunknown&q=keep'),
+    });
+
+    await screen.findByRole('button', { name: 'Scale' });
+    expect(screen.getByTestId('location').textContent).toBe(
+      '/models/model-1?axis=metadata%3Aunknown&q=keep'
+    );
+  });
+
+  it('bounds and scrolls the options region when many fields are browsable', async () => {
+    mockGetFields.mockResolvedValue(
+      Array.from({ length: 30 }, (_, index): MetadataFieldDetail => ({
+        id: `field-${index}`,
+        name: `Field ${index}`,
+        slug: `field-${index}`,
+        type: 'text',
+        isDefault: false,
+        isFilterable: true,
+        isBrowsable: true,
+        config: null,
+        sortOrder: index,
+      }))
+    );
+    render(<AxisPicker />, { wrapper: makeWrapper() });
+
+    expect(await screen.findByRole('button', { name: 'Field 29' })).toBeTruthy();
+    const options = screen.getByRole('group', { name: 'Browse axes' });
+    expect(options.className).toContain('max-h-48');
+    expect(options.className).toContain('overflow-y-auto');
   });
 });

--- a/apps/frontend/src/components/pivot/AxisPicker.tsx
+++ b/apps/frontend/src/components/pivot/AxisPicker.tsx
@@ -1,6 +1,16 @@
+import { useEffect } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { useLocation, useSearchParams } from 'react-router-dom';
 import { cn } from '../../lib/utils';
-import { useModelFilters, type PivotAxis } from '../../hooks/use-model-filters';
-import { CollectionsIcon, ArtistIcon, TagIcon, SmartIcon } from '../icons';
+import { getFields } from '../../api/metadata';
+import { useLibraryPath } from '../../hooks/use-libraries';
+import {
+  getMetadataAxisSlug,
+  isValidMetadataAxisSlug,
+  useModelFilters,
+  type PivotAxis,
+} from '../../hooks/use-model-filters';
+import { CollectionsIcon, ArtistIcon, TagIcon, SmartIcon, MetadataIcon } from '../icons';
 
 interface AxisOption {
   id: PivotAxis;
@@ -8,7 +18,7 @@ interface AxisOption {
   icon: React.ComponentType<{ className?: string }>;
 }
 
-const AXIS_OPTIONS: AxisOption[] = [
+const BUILT_IN_AXIS_OPTIONS: AxisOption[] = [
   { id: 'collections', label: 'Collections', icon: CollectionsIcon },
   { id: 'artists', label: 'Artists', icon: ArtistIcon },
   { id: 'tags', label: 'Tags', icon: TagIcon },
@@ -21,6 +31,40 @@ const AXIS_OPTIONS: AxisOption[] = [
  */
 export function AxisPicker() {
   const { axis, setAxis } = useModelFilters();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const location = useLocation();
+  const libPath = useLibraryPath();
+  const browsePath = libPath('/');
+  const { data: fieldsData, isSuccess } = useQuery({
+    queryKey: ['metadata-fields'],
+    queryFn: getFields,
+  });
+  const fields = fieldsData ?? [];
+  const metadataAxes: AxisOption[] = fields
+    .filter((field) => field.isBrowsable && isValidMetadataAxisSlug(field.slug))
+    .map((field) => ({
+      id: `metadata:${field.slug}`,
+      label: field.name,
+      icon: MetadataIcon,
+    }));
+  const axisOptions = [...BUILT_IN_AXIS_OPTIONS, ...metadataAxes];
+
+  useEffect(() => {
+    if (!isSuccess || location.pathname !== browsePath) return;
+    const rawAxis = searchParams.get('axis');
+    if (!rawAxis?.startsWith('metadata:')) return;
+    const slug = getMetadataAxisSlug(rawAxis as PivotAxis);
+    const fieldIsBrowsable = slug
+      ? fields.some((field) => field.slug === slug && field.isBrowsable)
+      : false;
+    if (!fieldIsBrowsable) {
+      setSearchParams((previous) => {
+        const next = new URLSearchParams(previous);
+        next.delete('axis');
+        return next;
+      }, { replace: true });
+    }
+  }, [browsePath, fields, isSuccess, location.pathname, searchParams, setSearchParams]);
 
   return (
     <div className="px-3 py-2">
@@ -31,14 +75,16 @@ export function AxisPicker() {
         Browse by
       </p>
       <div
-        className="grid gap-1 rounded-lg p-1"
+        role="group"
+        aria-label="Browse axes"
+        className="grid max-h-48 gap-1 overflow-y-auto rounded-lg p-1 ax-scroll"
         style={{
           gridTemplateColumns: '1fr 1fr',
           background: 'var(--ax-rail-elev)',
           border: '1px solid var(--ax-rail-border)',
         }}
       >
-        {AXIS_OPTIONS.map(({ id, label, icon: Icon }) => {
+        {axisOptions.map(({ id, label, icon: Icon }) => {
           const isActive = axis === id;
           return (
             <button

--- a/apps/frontend/src/components/pivot/Breadcrumb.test.tsx
+++ b/apps/frontend/src/components/pivot/Breadcrumb.test.tsx
@@ -8,6 +8,7 @@ const EMPTY_AXIS_VALUE: ActiveAxisValue = {
   artist: undefined,
   tags: [],
   smartCollectionId: undefined,
+  metadata: undefined,
 };
 
 describe('Breadcrumb', () => {
@@ -63,6 +64,19 @@ describe('Breadcrumb', () => {
     render(<Breadcrumb axis="tags" activeAxisValue={value} />);
 
     expect(screen.getByText('dragon, fantasy')).toBeTruthy();
+  });
+
+  it('renders a metadata field name and selected value', () => {
+    render(
+      <Breadcrumb
+        axis="metadata:scale"
+        activeAxisValue={{ ...EMPTY_AXIS_VALUE, metadata: { slug: 'scale', value: '1:12' } }}
+        metadataFieldName="Scale"
+      />
+    );
+
+    expect(screen.getByText('Scale')).toBeTruthy();
+    expect(screen.getByText('1:12')).toBeTruthy();
   });
 
   it('does not render a value crumb when nothing is selected', () => {

--- a/apps/frontend/src/components/pivot/Breadcrumb.tsx
+++ b/apps/frontend/src/components/pivot/Breadcrumb.tsx
@@ -1,25 +1,28 @@
-import type { PivotAxis, ActiveAxisValue } from '../../hooks/use-model-filters';
+import { getMetadataAxisSlug } from '../../hooks/use-model-filters';
+import type { PivotAxis, ActiveAxisValue, BuiltInPivotAxis } from '../../hooks/use-model-filters';
 import {
   CollectionsIcon,
   ArtistIcon,
   TagIcon,
   SmartIcon,
+  MetadataIcon,
   ChevronRightIcon,
 } from '../icons';
 
 interface BreadcrumbProps {
   axis: PivotAxis;
   activeAxisValue: ActiveAxisValue;
+  metadataFieldName?: string;
 }
 
-const AXIS_LABELS: Record<PivotAxis, string> = {
+const AXIS_LABELS: Record<BuiltInPivotAxis, string> = {
   collections: 'Collections',
   artists: 'Artists',
   tags: 'Tags',
   smart: 'Smart Collections',
 };
 
-const AXIS_ICONS: Record<PivotAxis, React.ReactNode> = {
+const AXIS_ICONS: Record<BuiltInPivotAxis, React.ReactNode> = {
   collections: <CollectionsIcon className="h-3.5 w-3.5" />,
   artists: <ArtistIcon className="h-3.5 w-3.5" />,
   tags: <TagIcon className="h-3.5 w-3.5" />,
@@ -34,9 +37,12 @@ const AXIS_ICONS: Record<PivotAxis, React.ReactNode> = {
  * Accepts axis and activeAxisValue as props so it's easily testable
  * without needing router/URL context.
  */
-export function Breadcrumb({ axis, activeAxisValue }: BreadcrumbProps) {
-  const axisLabel = AXIS_LABELS[axis];
-  const axisIcon = AXIS_ICONS[axis];
+export function Breadcrumb({ axis, activeAxisValue, metadataFieldName }: BreadcrumbProps) {
+  const metadataSlug = getMetadataAxisSlug(axis);
+  const axisLabel = metadataSlug ? metadataFieldName ?? metadataSlug : AXIS_LABELS[axis as BuiltInPivotAxis];
+  const axisIcon = metadataSlug
+    ? <MetadataIcon className="h-3.5 w-3.5" />
+    : AXIS_ICONS[axis as BuiltInPivotAxis];
 
   // Derive the current value label from the active axis value
   let valueLabel: string | null = null;
@@ -48,6 +54,8 @@ export function Breadcrumb({ axis, activeAxisValue }: BreadcrumbProps) {
     valueLabel = activeAxisValue.artist;
   } else if (axis === 'tags' && activeAxisValue.tags.length > 0) {
     valueLabel = activeAxisValue.tags.join(', ');
+  } else if (metadataSlug && activeAxisValue.metadata?.value) {
+    valueLabel = activeAxisValue.metadata.value;
   }
 
   const crumbs: Array<{ label: string; icon?: React.ReactNode }> = [

--- a/apps/frontend/src/components/pivot/PivotMain.test.tsx
+++ b/apps/frontend/src/components/pivot/PivotMain.test.tsx
@@ -42,13 +42,20 @@ vi.mock('../../api/models', () => ({
   getModels: vi.fn(),
 }));
 
+vi.mock('../../api/metadata', () => ({
+  getFields: vi.fn(),
+  getFieldValues: vi.fn(),
+}));
+
 vi.mock('../../hooks/use-assistant-context', () => ({
   useAssistantTarget: vi.fn(),
 }));
 
 import { getModels } from '../../api/models';
+import { getFields } from '../../api/metadata';
 import { useAssistantTarget } from '../../hooks/use-assistant-context';
 const mockGetModels = vi.mocked(getModels);
+const mockGetFields = vi.mocked(getFields);
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -119,6 +126,9 @@ describe('PivotMain', () => {
     localStorage.clear();
     stubIntersectionObserver();
     mockGetModels.mockResolvedValue(MODELS_RESPONSE);
+    mockGetFields.mockResolvedValue([
+      { id: 'field-1', name: 'Scale', slug: 'scale', type: 'enum', isDefault: false, isFilterable: true, isBrowsable: true, config: null, sortOrder: 1 },
+    ]);
   });
 
   it('renders the search input', () => {
@@ -178,6 +188,16 @@ describe('PivotMain', () => {
     render(<PivotMain />, { wrapper: makeWrapper('/?axis=artists') });
 
     expect(screen.getByText('Artists')).toBeTruthy();
+  });
+
+  it('shows the metadata field name and active value in its context', async () => {
+    render(<PivotMain />, {
+      wrapper: makeWrapper('/?axis=metadata%3Ascale&meta_scale=1%3A12'),
+    });
+
+    expect(await screen.findByText('Scale')).toBeTruthy();
+    expect(screen.getByText('1:12')).toBeTruthy();
+    expect(screen.getByRole('heading', { name: 'Scale: 1:12' })).toBeTruthy();
   });
 
   it('renders the ViewSwitch with all three buttons', () => {

--- a/apps/frontend/src/components/pivot/PivotMain.tsx
+++ b/apps/frontend/src/components/pivot/PivotMain.tsx
@@ -6,6 +6,7 @@ import { useModelFilters } from '../../hooks/use-model-filters';
 import { useLibraryPath } from '../../hooks/use-libraries';
 import { useModelResults } from '../../hooks/use-model-results';
 import { getSmartCollections, getSmartCollectionModels } from '../../api/smart-collections';
+import { getFields } from '../../api/metadata';
 import { useDisplayPreferences } from '../../hooks/use-display-preferences';
 import { useBulkSelection } from '../../hooks/use-bulk-selection';
 import { useAssistantTarget } from '../../hooks/use-assistant-context';
@@ -24,17 +25,19 @@ import {
   ArtistIcon,
   TagIcon,
   SmartIcon,
+  MetadataIcon,
 } from '../icons';
-import type { PivotAxis } from '../../hooks/use-model-filters';
+import { getMetadataAxisSlug } from '../../hooks/use-model-filters';
+import type { BuiltInPivotAxis, PivotAxis } from '../../hooks/use-model-filters';
 
-const AXIS_ICONS: Record<PivotAxis, React.ComponentType<{ className?: string }>> = {
+const AXIS_ICONS: Record<BuiltInPivotAxis, React.ComponentType<{ className?: string }>> = {
   collections: CollectionsIcon,
   artists: ArtistIcon,
   tags: TagIcon,
   smart: SmartIcon,
 };
 
-const AXIS_LABELS: Record<PivotAxis, string> = {
+const AXIS_LABELS: Record<BuiltInPivotAxis, string> = {
   collections: 'Collections',
   artists: 'Artists',
   tags: 'Tags',
@@ -44,8 +47,16 @@ const AXIS_LABELS: Record<PivotAxis, string> = {
 /** Derive a human-readable context title from the active axis + selection. */
 function deriveContextTitle(
   axis: PivotAxis,
-  activeAxisValue: ReturnType<typeof useModelFilters>['activeAxisValue']
+  activeAxisValue: ReturnType<typeof useModelFilters>['activeAxisValue'],
+  metadataFieldName?: string,
 ): string {
+  const metadataSlug = getMetadataAxisSlug(axis);
+  if (metadataSlug) {
+    const fieldName = metadataFieldName ?? metadataSlug;
+    return activeAxisValue.metadata?.value
+      ? `${fieldName}: ${activeAxisValue.metadata.value}`
+      : `All ${fieldName}`;
+  }
   if (axis === 'collections') {
     return activeAxisValue.collectionId ? 'Collection' : 'All Collections';
   }
@@ -57,7 +68,7 @@ function deriveContextTitle(
       ? activeAxisValue.tags.join(', ')
       : 'All Tags';
   }
-  return AXIS_LABELS[axis];
+  return AXIS_LABELS[axis as BuiltInPivotAxis];
 }
 
 /**
@@ -77,6 +88,13 @@ export function PivotMain() {
   const { filters, toApiParams, setQ, axis, activeAxisValue, hasActiveFilters, smartCollectionId } =
     useModelFilters();
   const { view, showThumbnails } = useDisplayPreferences();
+  const metadataSlug = getMetadataAxisSlug(axis);
+  const { data: metadataFields = [] } = useQuery({
+    queryKey: ['metadata-fields'],
+    queryFn: getFields,
+    enabled: !!metadataSlug,
+  });
+  const activeMetadataField = metadataFields.find((field) => field.slug === metadataSlug);
 
   const [bulkMode, setBulkMode] = useState(false);
   const { selected, toggle, selectAll, clear, isSelected, count } = useBulkSelection();
@@ -126,18 +144,21 @@ export function PivotMain() {
     setBulkMode(false);
   }
 
-  const AxisIcon = AXIS_ICONS[axis];
+  const AxisIcon = metadataSlug ? MetadataIcon : AXIS_ICONS[axis as BuiltInPivotAxis];
   const contextTitle = isSmart
     ? activeSmart?.name ?? 'Smart Collections'
-    : deriveContextTitle(axis, activeAxisValue);
+    : deriveContextTitle(axis, activeAxisValue, activeMetadataField?.name);
 
   // Axis icon badge background per axis
-  const AXIS_BG: Record<PivotAxis, string> = {
+  const AXIS_BG: Record<BuiltInPivotAxis, string> = {
     collections: 'linear-gradient(135deg, var(--ax-amber), var(--ax-amber-deep, #b45309))',
     artists: 'linear-gradient(135deg, var(--ax-teal, #0d9488), #0f766e)',
     tags: 'linear-gradient(135deg, var(--ax-teal, #0d9488), #0f766e)',
     smart: 'linear-gradient(135deg, var(--ax-violet, #7c3aed), #6d28d9)',
   };
+  const axisBackground = metadataSlug
+    ? 'linear-gradient(135deg, var(--ax-teal, #0d9488), #0f766e)'
+    : AXIS_BG[axis as BuiltInPivotAxis];
 
   return (
     <div className="relative flex flex-col h-full min-h-0" style={{ background: 'var(--ax-bg)', color: 'var(--ax-fg)' }}>
@@ -151,7 +172,11 @@ export function PivotMain() {
       >
         {/* Left: breadcrumb */}
         <div className="flex-1 min-w-0">
-          <Breadcrumb axis={axis} activeAxisValue={activeAxisValue} />
+          <Breadcrumb
+            axis={axis}
+            activeAxisValue={activeAxisValue}
+            metadataFieldName={activeMetadataField?.name}
+          />
         </div>
 
         {/* Right: search + upload */}
@@ -217,7 +242,7 @@ export function PivotMain() {
             style={{
               width: 56,
               height: 56,
-              background: AXIS_BG[axis],
+              background: axisBackground,
               boxShadow: 'var(--ax-shadow-md)',
               color: 'white',
             }}
@@ -353,6 +378,7 @@ export function PivotMain() {
                 models={models}
                 axis={axis}
                 activeAxisValue={activeAxisValue}
+                metadataFieldName={activeMetadataField?.name}
                 selectable={bulkMode}
                 isSelected={isSelected}
                 onToggleSelect={toggle}

--- a/apps/frontend/src/components/pivot/PivotRail.test.tsx
+++ b/apps/frontend/src/components/pivot/PivotRail.test.tsx
@@ -27,6 +27,7 @@ vi.mock('../../api/collections', () => ({
 }));
 
 vi.mock('../../api/metadata', () => ({
+  getFields: vi.fn(),
   getFieldValues: vi.fn(),
 }));
 
@@ -63,11 +64,12 @@ vi.mock('react-router-dom', async (importOriginal) => {
 });
 
 import { getCollections } from '../../api/collections';
-import { getFieldValues } from '../../api/metadata';
+import { getFields, getFieldValues } from '../../api/metadata';
 import { useAuth } from '../../hooks/use-auth';
 
 const mockGetCollections = vi.mocked(getCollections);
 const mockGetFieldValues = vi.mocked(getFieldValues);
+const mockGetFields = vi.mocked(getFields);
 const mockUseAuth = vi.mocked(useAuth);
 
 // ---------------------------------------------------------------------------
@@ -106,6 +108,7 @@ describe('PivotRail', () => {
     vi.clearAllMocks();
     mockGetCollections.mockResolvedValue({ data: [], meta: null, errors: null });
     mockGetFieldValues.mockResolvedValue([]);
+    mockGetFields.mockResolvedValue([]);
     mockUseAuth.mockReturnValue({
       user: FAKE_USER,
       isLoading: false,

--- a/apps/frontend/src/hooks/use-model-filters.test.tsx
+++ b/apps/frontend/src/hooks/use-model-filters.test.tsx
@@ -39,6 +39,44 @@ describe('useModelFilters — axis (pivot UI state)', () => {
     expect(result.current.axis).toBe('collections');
   });
 
+  it('parses a metadata-prefixed axis from the URL', () => {
+    const { result } = renderHook(() => useModelFilters(), {
+      wrapper: makeWrapper(['/?axis=metadata%3Ascale&meta_scale=1%3A12']),
+    });
+
+    expect(result.current.axis).toBe('metadata:scale');
+    expect(result.current.activeAxisValue.metadata).toEqual({ slug: 'scale', value: '1:12' });
+  });
+
+  it('falls back to collections for an empty metadata axis slug', () => {
+    const { result } = renderHook(() => useModelFilters(), {
+      wrapper: makeWrapper(['/?axis=metadata%3A']),
+    });
+    expect(result.current.axis).toBe('collections');
+  });
+
+  it.each(['artist', 'tags'])('reserves metadata:%s for its built-in axis', (slug) => {
+    const { result } = renderHook(() => useModelFilters(), {
+      wrapper: makeWrapper([`/?axis=metadata%3A${slug}`]),
+    });
+    expect(result.current.axis).toBe('collections');
+    expect(result.current.activeAxisValue.metadata).toBeUndefined();
+  });
+
+  it('rejects an overlong metadata axis slug', () => {
+    const { result } = renderHook(() => useModelFilters(), {
+      wrapper: makeWrapper([`/?axis=${encodeURIComponent(`metadata:${'x'.repeat(256)}`)}`]),
+    });
+    expect(result.current.axis).toBe('collections');
+  });
+
+  it('accepts a nonempty backend-generated leading-hyphen slug', () => {
+    const { result } = renderHook(() => useModelFilters(), {
+      wrapper: makeWrapper(['/?axis=metadata%3A-abcd']),
+    });
+    expect(result.current.axis).toBe('metadata:-abcd');
+  });
+
   it('setAxis("tags") adds ?axis=tags while preserving other params', () => {
     const { result } = renderHook(() => useModelFilters(), {
       wrapper: makeWrapper(['/?q=vase&sort=name']),

--- a/apps/frontend/src/hooks/use-model-filters.ts
+++ b/apps/frontend/src/hooks/use-model-filters.ts
@@ -13,10 +13,35 @@ export interface ModelFilters {
   metadataFilters: Record<string, string>;
 }
 
-export type PivotAxis = 'collections' | 'artists' | 'tags' | 'smart';
+export type BuiltInPivotAxis = 'collections' | 'artists' | 'tags' | 'smart';
+export type MetadataPivotAxis = `metadata:${string}`;
+export type PivotAxis = BuiltInPivotAxis | MetadataPivotAxis;
 
-const VALID_AXES: PivotAxis[] = ['collections', 'artists', 'tags', 'smart'];
-const DEFAULT_AXIS: PivotAxis = 'collections';
+const VALID_AXES: BuiltInPivotAxis[] = ['collections', 'artists', 'tags', 'smart'];
+const DEFAULT_AXIS: BuiltInPivotAxis = 'collections';
+const RESERVED_METADATA_AXIS_SLUGS = new Set(['artist', 'tags']);
+
+export function isValidMetadataAxisSlug(slug: string): boolean {
+  return slug.length > 0
+    && slug.length <= 255
+    && !RESERVED_METADATA_AXIS_SLUGS.has(slug);
+}
+
+export function getMetadataAxisSlug(axis: PivotAxis): string | undefined {
+  if (!axis.startsWith('metadata:')) return undefined;
+  const slug = axis.slice('metadata:'.length);
+  return isValidMetadataAxisSlug(slug) ? slug : undefined;
+}
+
+function parsePivotAxis(rawAxis: string | null): PivotAxis {
+  if (rawAxis && VALID_AXES.includes(rawAxis as BuiltInPivotAxis)) {
+    return rawAxis as BuiltInPivotAxis;
+  }
+  if (rawAxis?.startsWith('metadata:') && getMetadataAxisSlug(rawAxis as MetadataPivotAxis)) {
+    return rawAxis as MetadataPivotAxis;
+  }
+  return DEFAULT_AXIS;
+}
 
 /**
  * The currently-selected value for the active pivot axis:
@@ -30,6 +55,7 @@ export interface ActiveAxisValue {
   artist: string | undefined;
   tags: string[];
   smartCollectionId: string | undefined;
+  metadata?: { slug: string; value: string | undefined };
 }
 
 function parseMetaFilters(params: URLSearchParams): Record<string, string> {
@@ -79,11 +105,8 @@ export function useModelFilters() {
   };
 
   // axis is pure UI — NOT in ModelFilters, NOT in toApiParams, NOT in the query key
-  const rawAxis = searchParams.get('axis');
-  const axis: PivotAxis =
-    rawAxis !== null && VALID_AXES.includes(rawAxis as PivotAxis)
-      ? (rawAxis as PivotAxis)
-      : DEFAULT_AXIS;
+  const axis = parsePivotAxis(searchParams.get('axis'));
+  const metadataAxisSlug = getMetadataAxisSlug(axis);
 
   // smartCollectionId is pure UI selection (which smart collection to view) —
   // like axis, it is NOT a model filter and not in toApiParams/the query key.
@@ -95,6 +118,9 @@ export function useModelFilters() {
     artist: axis === 'artists' ? filters.metadataFilters['artist'] : undefined,
     tags: axis === 'tags' ? filters.tags : [],
     smartCollectionId: axis === 'smart' ? smartCollectionId : undefined,
+    metadata: metadataAxisSlug
+      ? { slug: metadataAxisSlug, value: filters.metadataFilters[metadataAxisSlug] }
+      : undefined,
   };
 
   const toApiParams = useCallback(

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -494,23 +494,27 @@ The application shell (`AppShell`) is a full-height flex row:
 The rail contains, top to bottom:
 
 1. **Library header** — brand mark plus a library-name badge. The badge includes a chevron-down but is non-interactive (`aria-disabled`, `tabIndex=-1`): multi-library switching is a P5 stub.
-2. **AxisPicker** — a 2-column button grid for selecting the active axis (Collections, Artists, Tags).
-3. **AxisFacetBody** — a scrollable list for the active axis. Shows collections tree, artist values, or tag values, each pulling from the appropriate backend endpoint.
+2. **AxisPicker** — a 2-column button grid for selecting the active axis. Collections, Artists, Tags, and Smart Collections are always present; every metadata field marked `isBrowsable` is also exposed as an axis (Artist and Tags reuse their dedicated axes instead of appearing twice).
+3. **AxisFacetBody** — a scrollable list for the active axis. Shows the collections tree, smart collections, or the values and model counts for the selected metadata dimension, each pulling from the appropriate backend endpoint.
 4. **UserMenu** — pinned footer with user avatar, display name, theme toggle, Settings link, and Log out.
 
 ### Axes
 
-The "axis" is the currently-selected browse dimension. It is stored in the URL as `?axis=` (e.g., `?axis=artists`). The default axis is `collections`, which is omitted from the URL for clean links.
+The "axis" is the currently-selected browse dimension. It is stored in the URL as `?axis=` (e.g., `?axis=artists`). Dynamic metadata axes use `metadata:<slug>` (for example, `?axis=metadata:source`). The default axis is `collections`, which is omitted from the URL for clean links.
 
 The axis is **pure UI state**. It is kept out of the React Query key and does not affect the API request made by `useModelResults`. Changing the axis reshapes the rail and the context header but does not refetch models unless the axis selection also changes the active filter (e.g., selecting a collection updates `?collectionId=`).
 
-The three axes and what they do in the rail:
+The fixed and dynamic axes behave as follows:
 
 | Axis | Rail body | Active filter set |
 |------|-----------|-------------------|
 | `collections` | Collections tree | `collectionId` query param |
 | `artists` | Artist values + model counts | `meta_artist` query param |
 | `tags` | Tag values + model counts | `tags` query param |
+| `smart` | Saved smart collections | `smartCollectionId` UI selection; the selected collection supplies the model query |
+| `metadata:<slug>` | Values + model counts for a browsable metadata field | `meta_<slug>` query param |
+
+The picker derives dynamic axes from `GET /metadata/fields`, preserving the endpoint's field-definition order (`sortOrder`, then creation time) and including only definitions with `isBrowsable: true`. The dedicated Artist and Tags axes remain responsible for those default fields because Tags uses its optimized storage and filter path. Other metadata axes use `GET /metadata/fields/:slug/values` and the existing generic metadata-filter contract.
 
 ### useModelFilters
 
@@ -548,7 +552,7 @@ Three view modes are available, selected via `ViewSwitch` and persisted in `loca
 
 The `showThumbnails` preference (also in `displayPrefs`) toggles thumbnail display in list and group views.
 
-**Group view limitation:** For `axis=collections`, per-collection grouping requires collection membership on `ModelCard`, which the API does not currently return. Group view renders a single group for the collections axis. For `artists` and `tags`, grouping runs client-side on loaded models; group counts reflect loaded models only and will grow as infinite scroll loads more pages.
+**Group view limitation:** For `axis=collections`, per-collection grouping requires collection membership on `ModelCard`, which the API does not currently return. Group view renders a single group for the collections axis. For `artists`, `tags`, and dynamic metadata axes, grouping runs client-side on loaded models; group counts reflect loaded models only and will grow as infinite scroll loads more pages. A dynamic metadata axis groups each model by the field's complete display value and puts models without a value in a `No <field name>` group.
 
 ### Bulk merge
 
@@ -791,7 +795,7 @@ Services throw typed errors or return domain data. Routes and middleware handle 
 The `requireLibrary` preHandler derives `libraryId` from the authenticated session and writes it to `request.libraryId`. No route accepts a `libraryId` value from the client. This ensures a user cannot access another user's library by supplying an arbitrary `libraryId` in the query string or request body.
 
 ### D14: Pivot axis is URL state, not query state
-The active pivot axis (`?axis=collections|artists|tags`) is stored in the URL so it survives navigation and is shareable, but it is excluded from the React Query key. The axis controls how the rail and context header look; it does not change the underlying API request. Only the filter values derived from an axis selection (e.g., `collectionId`, `meta_artist`) enter the query key and trigger refetches.
+The active pivot axis is stored in the URL so it survives navigation and is shareable, but it is excluded from the React Query key. Fixed axes use `?axis=collections|artists|tags|smart`; browsable metadata fields use `?axis=metadata:<slug>`. Artist and Tags remain reserved dedicated axes and are not duplicated as `metadata:artist` or `metadata:tags`. The axis by itself controls how the rail and context header look. Filter values derived from an axis selection (for example, `collectionId` or `meta_artist`) enter the model query key and trigger refetches; a selected smart collection instead supplies its own query and key.
 
 ### D15: three.js is isolated in a single lazy-loaded module
 `ModelViewer3DScene` is the only file in the frontend that imports `three`, `@react-three/fiber`, or `@react-three/drei`. All other code reaches it through `ModelViewer3DModal` via `React.lazy`, which causes Vite to emit three.js as a separate async chunk (~924 KB). The chunk is never fetched unless the 3D viewer is opened. This isolation is intentional: adding any static import of three anywhere else in the app would pull the entire bundle into the critical path. If the viewer grows to need additional three.js utilities, they must be added inside `ModelViewer3DScene` or co-located lazy modules — not imported at the app or component level.


### PR DESCRIPTION
## Summary

- adds dynamic Browse by axes for metadata fields marked browsable
- shows field values and counts, filters models, and carries metadata context through breadcrumbs, headings, and grouped views
- keeps Artist and Tags on their existing dedicated paths and safely handles stale axes
- updates architecture documentation

## Validation

- npm test
- npm run lint
- npm run build
- reviewer: no actionable findings