### PR TITLE
feat: add duplicate scanner tool

### DIFF
--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -15,6 +15,7 @@ import { libraryRoutes } from './routes/libraries.js';
 import { fileRoutes } from './routes/files.js';
 import { searchRoutes } from './routes/search.js';
 import { aiRoutes } from './routes/ai.js';
+import { toolsRoutes } from './routes/tools.js';
 import { startIngestionWorker } from './workers/ingestion.worker.js';
 
 export async function buildApp(): Promise<ReturnType<typeof Fastify>> {
@@ -73,6 +74,7 @@ export async function buildApp(): Promise<ReturnType<typeof Fastify>> {
   await app.register(fileRoutes, { prefix: '/files' });
   await app.register(searchRoutes, { prefix: '/search' });
   await app.register(aiRoutes, { prefix: '/ai' });
+  await app.register(toolsRoutes, { prefix: '/tools' });
 
   // Start background workers
   startIngestionWorker();

--- a/apps/backend/src/routes/tools.integration.test.ts
+++ b/apps/backend/src/routes/tools.integration.test.ts
@@ -1,0 +1,337 @@
+/**
+ * Integration coverage for GET /tools/duplicates.
+ *
+ * These tests exercise the complete Fastify/auth/library/service/database path.
+ * Every library contains models with the same file-hash multiset so successful
+ * scans also prove that duplicate groups cannot cross a library or tenant
+ * boundary.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import { eq, inArray } from 'drizzle-orm';
+import { buildApp } from '../app.js';
+import { db } from '../db/index.js';
+import { libraries, modelFiles, models, users } from '../db/schema/index.js';
+
+const OWNER_EMAIL = 'tools-duplicates-route-owner@example.com';
+const OTHER_TENANT_EMAIL = 'tools-duplicates-route-tenant@example.com';
+const PASSWORD = 'password123';
+const SHARED_HASHES = ['1'.repeat(64), '2'.repeat(64)];
+
+let app: FastifyInstance;
+let sessionCookie: string;
+let ownerDefaultLibraryId: string;
+let ownerSecondLibraryId: string;
+let otherTenantLibraryId: string;
+let defaultModelIds: string[];
+let secondLibraryModelIds: string[];
+let otherTenantModelIds: string[];
+
+async function cleanupFixtures(): Promise<void> {
+  const fixtureUsers = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(inArray(users.email, [OWNER_EMAIL, OTHER_TENANT_EMAIL]));
+
+  const userIds = fixtureUsers.map((user) => user.id);
+  if (userIds.length === 0) return;
+
+  // Model-file rows cascade from models. Remove the remaining rows in FK order.
+  await db.delete(models).where(inArray(models.userId, userIds));
+  await db.delete(libraries).where(inArray(libraries.userId, userIds));
+  await db.delete(users).where(inArray(users.id, userIds));
+}
+
+async function login(email: string): Promise<string> {
+  const response = await app.inject({
+    method: 'POST',
+    url: '/auth/login',
+    payload: { email, password: PASSWORD },
+  });
+  if (response.statusCode !== 200) {
+    throw new Error(`Fixture login failed with ${response.statusCode}: ${response.body}`);
+  }
+
+  const setCookie = response.headers['set-cookie'];
+  const cookie = Array.isArray(setCookie) ? setCookie[0] : setCookie;
+  if (!cookie) throw new Error('Fixture login did not return a session cookie');
+  return cookie.split(';')[0];
+}
+
+async function createDuplicatePair(options: {
+  label: string;
+  runToken: string;
+  userId: string;
+  libraryId: string;
+  createdAt: [Date, Date];
+  totalSizeBytes: [number, number];
+}): Promise<string[]> {
+  const insertedModels = await db
+    .insert(models)
+    .values([0, 1].map((index) => ({
+      name: `${options.label} ${index + 1}`,
+      slug: `${options.runToken}-${options.label.toLowerCase().replaceAll(' ', '-')}-${index + 1}`,
+      userId: options.userId,
+      libraryId: options.libraryId,
+      sourceType: 'manual',
+      status: 'ready',
+      originalFilename: `${options.label.toLowerCase().replaceAll(' ', '-')}-${index + 1}.zip`,
+      totalSizeBytes: options.totalSizeBytes[index],
+      fileCount: SHARED_HASHES.length,
+      createdAt: options.createdAt[index],
+      updatedAt: options.createdAt[index],
+    })))
+    .returning({ id: models.id });
+
+  for (const [modelIndex, model] of insertedModels.entries()) {
+    await db.insert(modelFiles).values(SHARED_HASHES.map((hash, fileIndex) => ({
+      modelId: model.id,
+      filename: `part-${fileIndex + 1}-${modelIndex + 1}.stl`,
+      relativePath: `parts/part-${fileIndex + 1}-${modelIndex + 1}.stl`,
+      fileType: 'stl',
+      mimeType: 'model/stl',
+      sizeBytes: 50 + fileIndex,
+      storagePath: `models/${model.id}/part-${fileIndex + 1}.stl`,
+      hash,
+    })));
+  }
+
+  return insertedModels.map((model) => model.id);
+}
+
+function scanDuplicates(libraryId?: string) {
+  const headers: Record<string, string> = { cookie: sessionCookie };
+  if (libraryId) headers['x-library-id'] = libraryId;
+  return app.inject({ method: 'GET', url: '/tools/duplicates', headers });
+}
+
+beforeAll(async () => {
+  await cleanupFixtures();
+
+  app = await buildApp();
+  await app.ready();
+
+  const runToken = `tools-duplicates-${Date.now()}-${process.pid}`;
+  const authService = (
+    app as FastifyInstance & {
+      authService: import('../services/auth.service.js').AuthService;
+    }
+  ).authService;
+
+  await authService.createUser(OWNER_EMAIL, PASSWORD, 'Duplicate Tools Owner');
+  await authService.createUser(OTHER_TENANT_EMAIL, PASSWORD, 'Duplicate Tools Tenant');
+
+  const [owner] = await db.select({ id: users.id }).from(users).where(eq(users.email, OWNER_EMAIL));
+  const [otherTenant] = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(eq(users.email, OTHER_TENANT_EMAIL));
+
+  const [defaultLibrary] = await db
+    .insert(libraries)
+    .values({
+      name: 'Duplicate Tools Default',
+      slug: `${runToken}-default-library`,
+      userId: owner.id,
+      isDefault: true,
+    })
+    .returning({ id: libraries.id });
+  ownerDefaultLibraryId = defaultLibrary.id;
+
+  const [secondLibrary] = await db
+    .insert(libraries)
+    .values({
+      name: 'Duplicate Tools Second',
+      slug: `${runToken}-second-library`,
+      userId: owner.id,
+      isDefault: false,
+    })
+    .returning({ id: libraries.id });
+  ownerSecondLibraryId = secondLibrary.id;
+
+  const [tenantLibrary] = await db
+    .insert(libraries)
+    .values({
+      name: 'Duplicate Tools Other Tenant',
+      slug: `${runToken}-tenant-library`,
+      userId: otherTenant.id,
+      isDefault: true,
+    })
+    .returning({ id: libraries.id });
+  otherTenantLibraryId = tenantLibrary.id;
+
+  defaultModelIds = await createDuplicatePair({
+    label: 'Default Pair',
+    runToken,
+    userId: owner.id,
+    libraryId: ownerDefaultLibraryId,
+    createdAt: [new Date('2026-01-01T00:00:00.000Z'), new Date('2026-01-02T00:00:00.000Z')],
+    totalSizeBytes: [100, 200],
+  });
+
+  const [processingModel] = await db
+    .insert(models)
+    .values({
+      name: 'Processing Duplicate',
+      slug: `${runToken}-processing-duplicate`,
+      userId: owner.id,
+      libraryId: ownerDefaultLibraryId,
+      sourceType: 'manual',
+      status: 'processing',
+      totalSizeBytes: 100,
+      fileCount: SHARED_HASHES.length,
+    })
+    .returning({ id: models.id });
+  await db.insert(modelFiles).values(SHARED_HASHES.map((hash, index) => ({
+    modelId: processingModel.id,
+    filename: `processing-${index}.stl`,
+    relativePath: `processing-${index}.stl`,
+    fileType: 'stl',
+    mimeType: 'model/stl',
+    sizeBytes: 50 + index,
+    storagePath: `models/${processingModel.id}/processing-${index}.stl`,
+    hash,
+  })));
+  await db.insert(models).values({
+    name: 'Empty Ready Model',
+    slug: `${runToken}-empty-ready-model`,
+    userId: owner.id,
+    libraryId: ownerDefaultLibraryId,
+    sourceType: 'manual',
+    status: 'ready',
+    totalSizeBytes: 0,
+    fileCount: 0,
+  });
+
+  secondLibraryModelIds = await createDuplicatePair({
+    label: 'Second Pair',
+    runToken,
+    userId: owner.id,
+    libraryId: ownerSecondLibraryId,
+    createdAt: [new Date('2026-02-01T00:00:00.000Z'), new Date('2026-02-02T00:00:00.000Z')],
+    totalSizeBytes: [300, 400],
+  });
+  otherTenantModelIds = await createDuplicatePair({
+    label: 'Tenant Pair',
+    runToken,
+    userId: otherTenant.id,
+    libraryId: otherTenantLibraryId,
+    createdAt: [new Date('2026-03-01T00:00:00.000Z'), new Date('2026-03-02T00:00:00.000Z')],
+    totalSizeBytes: [500, 600],
+  });
+
+  sessionCookie = await login(OWNER_EMAIL);
+});
+
+afterAll(async () => {
+  await cleanupFixtures();
+  await app?.close();
+});
+
+describe('GET /tools/duplicates integration', () => {
+  it('should return a standard 401 envelope when the session cookie is absent', async () => {
+    const response = await app.inject({ method: 'GET', url: '/tools/duplicates' });
+
+    expect(response.statusCode).toBe(401);
+    expect(response.json()).toEqual({
+      data: null,
+      meta: null,
+      errors: [
+        {
+          code: 'UNAUTHORIZED',
+          field: null,
+          message: 'Authentication required',
+        },
+      ],
+    });
+  });
+
+  it('should scan the default library when X-Library-Id is absent', async () => {
+    const response = await scanDuplicates();
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+    expect(body).toEqual({
+      data: {
+        scannedModelCount: 2,
+        redundantModelCount: 1,
+        reclaimableBytes: 200,
+        groups: [
+          {
+            fingerprint: expect.stringMatching(/^[a-f0-9]{64}$/),
+            fileCount: 2,
+            totalSizeBytes: 100,
+            reclaimableBytes: 200,
+            models: [
+              {
+                id: defaultModelIds[0],
+                name: 'Default Pair 1',
+                originalFilename: 'default-pair-1.zip',
+                createdAt: '2026-01-01T00:00:00.000Z',
+              },
+              {
+                id: defaultModelIds[1],
+                name: 'Default Pair 2',
+                originalFilename: 'default-pair-2.zip',
+                createdAt: '2026-01-02T00:00:00.000Z',
+              },
+            ],
+          },
+        ],
+      },
+      meta: null,
+      errors: null,
+    });
+
+    const returnedIds = body.data.groups.flatMap(
+      (group: { models: Array<{ id: string }> }) => group.models.map((model) => model.id),
+    );
+    expect(returnedIds).not.toContain(secondLibraryModelIds[0]);
+    expect(returnedIds).not.toContain(otherTenantModelIds[0]);
+  });
+
+  it('should scan only an explicitly selected owned library', async () => {
+    const response = await scanDuplicates(ownerSecondLibraryId);
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+    expect(body.meta).toBeNull();
+    expect(body.errors).toBeNull();
+    expect(body.data).toMatchObject({
+      scannedModelCount: 2,
+      redundantModelCount: 1,
+      reclaimableBytes: 400,
+      groups: [
+        {
+          fileCount: 2,
+          totalSizeBytes: 300,
+          reclaimableBytes: 400,
+        },
+      ],
+    });
+    expect(body.data.groups[0].models.map((model: { id: string }) => model.id))
+      .toEqual(secondLibraryModelIds);
+    expect(body.data.groups[0].models.map((model: { id: string }) => model.id))
+      .not.toContain(defaultModelIds[0]);
+    expect(body.data.groups[0].models.map((model: { id: string }) => model.id))
+      .not.toContain(otherTenantModelIds[0]);
+  });
+
+  it("should return 404 when X-Library-Id references another user's library", async () => {
+    const response = await scanDuplicates(otherTenantLibraryId);
+
+    expect(response.statusCode).toBe(404);
+    expect(response.json()).toEqual({
+      data: null,
+      meta: null,
+      errors: [
+        {
+          code: 'NOT_FOUND',
+          field: null,
+          message: 'Library not found',
+        },
+      ],
+    });
+  });
+});

--- a/apps/backend/src/routes/tools.test.ts
+++ b/apps/backend/src/routes/tools.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import Fastify, { type FastifyInstance } from 'fastify';
+
+const USER_ID = '11111111-1111-4111-8111-111111111111';
+const LIBRARY_ID = '22222222-2222-4222-8222-222222222222';
+
+const mocks = vi.hoisted(() => ({
+  requireAuth: vi.fn(async (request: { user?: unknown }) => {
+    request.user = { id: USER_ID };
+  }),
+  requireLibrary: vi.fn(async (request: { libraryId?: string }) => {
+    request.libraryId = LIBRARY_ID;
+  }),
+  scanDuplicates: vi.fn(),
+  buildDuplicateScanResult: vi.fn(),
+}));
+
+vi.mock('../middleware/auth.js', () => ({ requireAuth: mocks.requireAuth }));
+vi.mock('../middleware/library.js', () => ({ requireLibrary: mocks.requireLibrary }));
+vi.mock('../services/duplicate-scanner.service.js', () => ({
+  duplicateScannerService: { scanDuplicates: mocks.scanDuplicates },
+}));
+vi.mock('../services/presenter.service.js', () => ({
+  presenterService: { buildDuplicateScanResult: mocks.buildDuplicateScanResult },
+}));
+
+import { toolsRoutes } from './tools.js';
+
+describe('Tools routes', () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mocks.scanDuplicates.mockResolvedValue({
+      scannedModelCount: 2,
+      groups: [],
+    });
+    mocks.buildDuplicateScanResult.mockReturnValue({
+      scannedModelCount: 2,
+      redundantModelCount: 1,
+      reclaimableBytes: 1024,
+      groups: [],
+    });
+    app = Fastify();
+    await app.register(toolsRoutes, { prefix: '/tools' });
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('requires authentication and the active library before scanning', async () => {
+    const response = await app.inject({ method: 'GET', url: '/tools/duplicates' });
+
+    expect(response.statusCode).toBe(200);
+    expect(mocks.requireAuth).toHaveBeenCalledOnce();
+    expect(mocks.requireLibrary).toHaveBeenCalledOnce();
+    expect(mocks.requireAuth.mock.invocationCallOrder[0])
+      .toBeLessThan(mocks.requireLibrary.mock.invocationCallOrder[0]);
+    expect(mocks.scanDuplicates).toHaveBeenCalledWith(LIBRARY_ID);
+    expect(mocks.buildDuplicateScanResult).toHaveBeenCalledWith({
+      scannedModelCount: 2,
+      groups: [],
+    });
+  });
+
+  it('returns duplicate scan results in the standard envelope', async () => {
+    const response = await app.inject({ method: 'GET', url: '/tools/duplicates' });
+
+    expect(response.json()).toEqual({
+      data: {
+        scannedModelCount: 2,
+        redundantModelCount: 1,
+        reclaimableBytes: 1024,
+        groups: [],
+      },
+      meta: null,
+      errors: null,
+    });
+  });
+});

--- a/apps/backend/src/routes/tools.ts
+++ b/apps/backend/src/routes/tools.ts
@@ -1,0 +1,17 @@
+import type { FastifyInstance } from 'fastify';
+import { requireAuth } from '../middleware/auth.js';
+import { requireLibrary } from '../middleware/library.js';
+import { duplicateScannerService } from '../services/duplicate-scanner.service.js';
+import { presenterService } from '../services/presenter.service.js';
+
+export async function toolsRoutes(app: FastifyInstance): Promise<void> {
+  app.get(
+    '/duplicates',
+    { preHandler: [requireAuth, requireLibrary] },
+    async (request, reply) => {
+      const scan = await duplicateScannerService.scanDuplicates(request.libraryId!);
+      const result = presenterService.buildDuplicateScanResult(scan);
+      return reply.status(200).send({ data: result, meta: null, errors: null });
+    },
+  );
+}

--- a/apps/backend/src/services/duplicate-scanner.service.test.ts
+++ b/apps/backend/src/services/duplicate-scanner.service.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it, vi } from 'vitest';
+import { DuplicateScannerService } from './duplicate-scanner.service.js';
+
+interface CandidateRow {
+  id: string;
+  name: string;
+  originalFilename: string | null;
+  totalSizeBytes: number;
+  createdAt: Date;
+  hashes: string[];
+}
+
+function databaseReturning(rows: CandidateRow[]) {
+  const query = {
+    from: vi.fn(),
+    innerJoin: vi.fn(),
+    where: vi.fn(),
+    groupBy: vi.fn(),
+    orderBy: vi.fn(),
+  };
+  query.from.mockReturnValue(query);
+  query.innerJoin.mockReturnValue(query);
+  query.where.mockReturnValue(query);
+  query.groupBy.mockReturnValue(query);
+  query.orderBy.mockResolvedValue(rows);
+
+  return {
+    database: { select: vi.fn().mockReturnValue(query) },
+    query,
+  };
+}
+
+function row(
+  id: string,
+  hashes: string[],
+  options: {
+    name?: string;
+    originalFilename?: string | null;
+    totalSizeBytes?: number;
+    createdAt?: string;
+  } = {},
+): CandidateRow {
+  return {
+    id,
+    hashes,
+    name: options.name ?? id,
+    originalFilename: options.originalFilename ?? `${id}.zip`,
+    totalSizeBytes: options.totalSizeBytes ?? 100,
+    createdAt: new Date(options.createdAt ?? '2026-01-01T00:00:00.000Z'),
+  };
+}
+
+describe('DuplicateScannerService', () => {
+  it('matches only complete sorted hash multisets and preserves multiplicity', async () => {
+    const { database, query } = databaseReturning([
+      row('new-copy', ['hash-a', 'hash-b'], {
+        name: 'Renamed copy',
+        originalFilename: 'different-source.7z',
+        totalSizeBytes: 120,
+        createdAt: '2026-02-01T00:00:00.000Z',
+      }),
+      row('old-copy', ['hash-a', 'hash-b'], {
+        name: 'Original',
+        originalFilename: 'original.zip',
+        totalSizeBytes: 100,
+        createdAt: '2026-01-01T00:00:00.000Z',
+      }),
+      row('single-a', ['hash-a']),
+      row('repeated-a', ['hash-a', 'hash-a']),
+    ]);
+    const service = new DuplicateScannerService(database as never);
+
+    const result = await service.scanDuplicates('library-1');
+
+    expect(database.select).toHaveBeenCalledOnce();
+    expect(query.innerJoin).toHaveBeenCalledOnce();
+    expect(query.where).toHaveBeenCalledOnce();
+    expect(query.groupBy).toHaveBeenCalledOnce();
+    expect(result).toEqual({
+      scannedModelCount: 4,
+      groups: [
+        {
+          fingerprint: expect.stringMatching(/^[a-f0-9]{64}$/),
+          fileCount: 2,
+          models: [
+            {
+              id: 'old-copy',
+              name: 'Original',
+              originalFilename: 'original.zip',
+              totalSizeBytes: 100,
+              createdAt: new Date('2026-01-01T00:00:00.000Z'),
+            },
+            {
+              id: 'new-copy',
+              name: 'Renamed copy',
+              originalFilename: 'different-source.7z',
+              totalSizeBytes: 120,
+              createdAt: new Date('2026-02-01T00:00:00.000Z'),
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it('returns stable ordering for models and groups regardless of row order', async () => {
+    const rows = [
+      row('group-b-new', ['hash-z'], { createdAt: '2026-04-01T00:00:00.000Z' }),
+      row('group-a-new', ['hash-a'], { createdAt: '2026-03-01T00:00:00.000Z' }),
+      row('group-b-old', ['hash-z'], { createdAt: '2026-02-01T00:00:00.000Z' }),
+      row('group-a-old', ['hash-a'], { createdAt: '2026-01-01T00:00:00.000Z' }),
+    ];
+    const first = databaseReturning(rows);
+    const second = databaseReturning([...rows].reverse());
+
+    const firstResult = await new DuplicateScannerService(first.database as never)
+      .scanDuplicates('library-1');
+    const secondResult = await new DuplicateScannerService(second.database as never)
+      .scanDuplicates('library-1');
+
+    expect(firstResult).toEqual(secondResult);
+    expect(firstResult.groups.map((group) => group.models.map((model) => model.id))).toEqual([
+      ['group-a-old', 'group-a-new'],
+      ['group-b-old', 'group-b-new'],
+    ]);
+  });
+
+  it('coalesces concurrent scans for the same library', async () => {
+    const fixture = databaseReturning([row('only-model', ['hash-a'])]);
+    const service = new DuplicateScannerService(fixture.database as never);
+
+    const [first, second] = await Promise.all([
+      service.scanDuplicates('library-1'),
+      service.scanDuplicates('library-1'),
+    ]);
+
+    expect(first).toEqual(second);
+    expect(fixture.database.select).toHaveBeenCalledOnce();
+  });
+
+  it('does not scan or group models without files', async () => {
+    const { database } = databaseReturning([]);
+
+    await expect(new DuplicateScannerService(database as never).scanDuplicates('library-1'))
+      .resolves.toEqual({ scannedModelCount: 0, groups: [] });
+  });
+});

--- a/apps/backend/src/services/duplicate-scanner.service.ts
+++ b/apps/backend/src/services/duplicate-scanner.service.ts
@@ -1,0 +1,143 @@
+import { createHash } from 'node:crypto';
+import { and, asc, eq, sql } from 'drizzle-orm';
+import { db } from '../db/index.js';
+import type { DatabaseExecutor } from '../db/index.js';
+import { modelFiles, models } from '../db/schema/index.js';
+import { createLogger } from '../utils/logger.js';
+
+const logger = createLogger('DuplicateScannerService');
+
+export interface DuplicateScanCandidate {
+  id: string;
+  name: string;
+  originalFilename: string | null;
+  createdAt: Date;
+  totalSizeBytes: number;
+}
+
+export interface DuplicateScanGroup {
+  fingerprint: string;
+  fileCount: number;
+  models: DuplicateScanCandidate[];
+}
+
+export interface DuplicateScan {
+  scannedModelCount: number;
+  groups: DuplicateScanGroup[];
+}
+
+export interface IDuplicateScannerService {
+  scanDuplicates(libraryId: string): Promise<DuplicateScan>;
+}
+
+/**
+ * Finds exact model duplicates from their complete multisets of per-file
+ * SHA-256 hashes. File names and paths deliberately do not participate.
+ */
+export class DuplicateScannerService implements IDuplicateScannerService {
+  private readonly inFlightByLibrary = new Map<string, Promise<DuplicateScan>>();
+
+  constructor(private readonly database: DatabaseExecutor = db) {}
+
+  /** Coalesce concurrent requests for the same library onto one database scan. */
+  scanDuplicates(libraryId: string): Promise<DuplicateScan> {
+    const existing = this.inFlightByLibrary.get(libraryId);
+    if (existing) return existing;
+
+    const scan = this.runScan(libraryId);
+    this.inFlightByLibrary.set(libraryId, scan);
+    void scan
+      .finally(() => {
+        if (this.inFlightByLibrary.get(libraryId) === scan) {
+          this.inFlightByLibrary.delete(libraryId);
+        }
+      })
+      .catch(() => undefined);
+
+    return scan;
+  }
+
+  private async runScan(libraryId: string): Promise<DuplicateScan> {
+    // Aggregate in PostgreSQL so one row crosses the database boundary per
+    // eligible model rather than one repeated model row per stored file.
+    const rows = await this.database
+      .select({
+        id: models.id,
+        name: models.name,
+        originalFilename: models.originalFilename,
+        totalSizeBytes: models.totalSizeBytes,
+        createdAt: models.createdAt,
+        hashes: sql<string[]>`array_agg(${modelFiles.hash} order by ${modelFiles.hash}, ${modelFiles.id})`,
+      })
+      .from(models)
+      .innerJoin(modelFiles, eq(modelFiles.modelId, models.id))
+      .where(and(eq(models.libraryId, libraryId), eq(models.status, 'ready')))
+      .groupBy(models.id)
+      .orderBy(asc(models.createdAt), asc(models.id));
+
+    const groupsByHashMultiset = new Map<string, DuplicateScanGroup>();
+
+    for (const row of rows) {
+      // JSON supplies unambiguous element boundaries. Repeated hashes remain
+      // repeated, so multiplicity is part of the exact content identity.
+      const hashMultisetKey = JSON.stringify(row.hashes);
+      const existing = groupsByHashMultiset.get(hashMultisetKey);
+      const candidate: DuplicateScanCandidate = {
+        id: row.id,
+        name: row.name,
+        originalFilename: row.originalFilename,
+        createdAt: row.createdAt,
+        totalSizeBytes: row.totalSizeBytes,
+      };
+
+      if (existing) {
+        existing.models.push(candidate);
+      } else {
+        groupsByHashMultiset.set(hashMultisetKey, {
+          fingerprint: createHash('sha256').update(hashMultisetKey).digest('hex'),
+          fileCount: row.hashes.length,
+          models: [candidate],
+        });
+      }
+    }
+
+    const groups = [...groupsByHashMultiset.values()]
+      .filter((group) => group.models.length > 1)
+      .map((group) => ({ ...group, models: [...group.models].sort(compareCandidates) }))
+      .sort(compareGroups);
+
+    const result: DuplicateScan = { scannedModelCount: rows.length, groups };
+
+    logger.debug(
+      {
+        service: 'DuplicateScannerService',
+        libraryId,
+        scannedModelCount: result.scannedModelCount,
+        duplicateGroupCount: result.groups.length,
+      },
+      'Completed duplicate scan',
+    );
+
+    return result;
+  }
+}
+
+function compareCandidates(left: DuplicateScanCandidate, right: DuplicateScanCandidate): number {
+  return left.createdAt.getTime() - right.createdAt.getTime() || compareStrings(left.id, right.id);
+}
+
+function compareGroups(left: DuplicateScanGroup, right: DuplicateScanGroup): number {
+  const leftOldest = left.models[0];
+  const rightOldest = right.models[0];
+  return leftOldest.createdAt.getTime() - rightOldest.createdAt.getTime()
+    || compareStrings(leftOldest.id, rightOldest.id)
+    || compareStrings(left.fingerprint, right.fingerprint);
+}
+
+function compareStrings(left: string, right: string): number {
+  if (left < right) return -1;
+  if (left > right) return 1;
+  return 0;
+}
+
+export const duplicateScannerService = new DuplicateScannerService();

--- a/apps/backend/src/services/presenter.service.test.ts
+++ b/apps/backend/src/services/presenter.service.test.ts
@@ -599,3 +599,61 @@ describe('buildCollectionList', () => {
     }
   });
 });
+
+describe('buildDuplicateScanResult', () => {
+  it('formats duplicate candidates and computes removable-copy totals', () => {
+    const result = presenterService.buildDuplicateScanResult({
+      scannedModelCount: 3,
+      groups: [
+        {
+          fingerprint: 'fingerprint',
+          fileCount: 2,
+          models: [
+            {
+              id: 'old-copy',
+              name: 'Original',
+              originalFilename: 'original.zip',
+              createdAt: new Date('2026-01-01T00:00:00.000Z'),
+              totalSizeBytes: 100,
+            },
+            {
+              id: 'new-copy',
+              name: 'Copy',
+              originalFilename: 'copy.zip',
+              createdAt: new Date('2026-02-01T00:00:00.000Z'),
+              totalSizeBytes: 120,
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(result).toEqual({
+      scannedModelCount: 3,
+      redundantModelCount: 1,
+      reclaimableBytes: 120,
+      groups: [
+        {
+          fingerprint: 'fingerprint',
+          fileCount: 2,
+          totalSizeBytes: 100,
+          reclaimableBytes: 120,
+          models: [
+            {
+              id: 'old-copy',
+              name: 'Original',
+              originalFilename: 'original.zip',
+              createdAt: '2026-01-01T00:00:00.000Z',
+            },
+            {
+              id: 'new-copy',
+              name: 'Copy',
+              originalFilename: 'copy.zip',
+              createdAt: '2026-02-01T00:00:00.000Z',
+            },
+          ],
+        },
+      ],
+    });
+  });
+});

--- a/apps/backend/src/services/presenter.service.ts
+++ b/apps/backend/src/services/presenter.service.ts
@@ -12,6 +12,7 @@ import type {
   ImageFile,
   FileTreeNode,
   FileType,
+  DuplicateScanResult,
 } from '@alexandria/shared';
 import { db } from '../db/index.js';
 import {
@@ -29,6 +30,7 @@ import { metadataService } from './metadata.service.js';
 import { collectionService } from './collection.service.js';
 import { createLogger } from '../utils/logger.js';
 import { formatDisplayValue } from '../utils/format.js';
+import type { DuplicateScan } from './duplicate-scanner.service.js';
 
 const logger = createLogger('PresenterService');
 
@@ -42,6 +44,7 @@ export interface IPresenterService {
     rows: ModelRow[],
     modelIds: string[],
   ): Promise<ModelCard[]>;
+  buildDuplicateScanResult(scan: DuplicateScan): DuplicateScanResult;
   buildModelDetail(modelId: string): Promise<ModelDetail>;
   buildFileTree(files: ModelFileRow[], folders?: ModelFolderRow[]): FileTreeNode[];
   buildCollectionDetail(collectionId: string): Promise<CollectionDetail>;
@@ -83,6 +86,38 @@ export interface ModelFolderRow {
 // ---------------------------------------------------------------------------
 
 export class PresenterService implements IPresenterService {
+  // -----------------------------------------------------------------------
+  // buildDuplicateScanResult — exact duplicate report
+  // -----------------------------------------------------------------------
+
+  buildDuplicateScanResult(scan: DuplicateScan): DuplicateScanResult {
+    const groups = scan.groups.map((group) => {
+      const reclaimableBytes = group.models
+        .slice(1)
+        .reduce((sum, model) => sum + model.totalSizeBytes, 0);
+
+      return {
+        fingerprint: group.fingerprint,
+        fileCount: group.fileCount,
+        totalSizeBytes: group.models[0].totalSizeBytes,
+        reclaimableBytes,
+        models: group.models.map((model) => ({
+          id: model.id,
+          name: model.name,
+          originalFilename: model.originalFilename,
+          createdAt: model.createdAt.toISOString(),
+        })),
+      };
+    });
+
+    return {
+      scannedModelCount: scan.scannedModelCount,
+      redundantModelCount: groups.reduce((sum, group) => sum + group.models.length - 1, 0),
+      reclaimableBytes: groups.reduce((sum, group) => sum + group.reclaimableBytes, 0),
+      groups,
+    };
+  }
+
   // -----------------------------------------------------------------------
   // buildModelCard — single model
   // -----------------------------------------------------------------------

--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import { ModelDetailPage } from './pages/ModelDetailPage';
 import { CollectionsPage } from './pages/CollectionsPage';
 import { CollectionDetailPage } from './pages/CollectionDetailPage';
 import { SettingsPage } from './pages/SettingsPage';
+import { ToolsPage } from './pages/ToolsPage';
 import { UploadPage } from './pages/UploadPage';
 import { SearchPage } from './pages/SearchPage';
 import { SmartCollectionComposerPage } from './pages/SmartCollectionComposerPage';
@@ -66,6 +67,7 @@ export default function App() {
           <Route path="smart-collections/new" element={<SmartCollectionComposerPage />} />
           <Route path="smart-collections/:id/edit" element={<SmartCollectionComposerPage />} />
           <Route path="settings" element={<SettingsPage />} />
+          <Route path="tools" element={<ToolsPage />} />
           <Route path="search" element={<SearchPage />} />
         </Route>
       </Route>

--- a/apps/frontend/src/api/tools.ts
+++ b/apps/frontend/src/api/tools.ts
@@ -1,0 +1,7 @@
+import type { DuplicateScanResult } from '@alexandria/shared';
+import { get } from './client';
+
+export async function scanDuplicates(): Promise<DuplicateScanResult> {
+  const response = await get<DuplicateScanResult>('/tools/duplicates');
+  return response.data;
+}

--- a/apps/frontend/src/components/pivot/PivotRail.tsx
+++ b/apps/frontend/src/components/pivot/PivotRail.tsx
@@ -23,7 +23,7 @@ import { UserMenu } from './UserMenu';
  *   1. Library header — brand + interactive library switcher (P5 multi-library)
  *   2. AxisPicker — 2-col grid letting the user pick Collections / Artists / Tags
  *   3. AxisFacetBody — scrollable list for the active axis (flex-1)
- *   4. UserMenu — pinned footer with avatar, identity, theme toggle, Settings, Log out
+ *   4. UserMenu — pinned footer with avatar, identity, theme toggle, Tools, Settings, Log out
  */
 export function PivotRail() {
   const { axis } = useModelFilters();

--- a/apps/frontend/src/components/pivot/UserMenu.test.tsx
+++ b/apps/frontend/src/components/pivot/UserMenu.test.tsx
@@ -1,0 +1,35 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { UserMenu } from './UserMenu';
+
+const mockNavigate = vi.fn();
+
+vi.mock('react-router-dom', () => ({ useNavigate: () => mockNavigate }));
+vi.mock('../../hooks/use-auth', () => ({
+  useAuth: () => ({
+    user: {
+      id: 'user-1',
+      displayName: 'Alex Reader',
+      email: 'alex@example.com',
+      role: 'admin',
+    },
+    logout: vi.fn(),
+  }),
+}));
+vi.mock('../../hooks/use-libraries', () => ({
+  useLibraryPath: () => (path: string) => `/lib/library-1${path === '/' ? '' : path}`,
+}));
+vi.mock('../layout/ThemeToggle', () => ({ ThemeToggle: () => <button>Theme</button> }));
+
+describe('UserMenu', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('navigates to the active library tools page', () => {
+    render(<UserMenu />);
+
+    fireEvent.click(screen.getByRole('button', { name: /user menu/i }));
+    fireEvent.click(screen.getByRole('button', { name: 'Tools' }));
+
+    expect(mockNavigate).toHaveBeenCalledWith('/lib/library-1/tools');
+  });
+});

--- a/apps/frontend/src/components/pivot/UserMenu.tsx
+++ b/apps/frontend/src/components/pivot/UserMenu.tsx
@@ -1,4 +1,4 @@
-import { LogOut, MoreHorizontal, User } from 'lucide-react';
+import { LogOut, MoreHorizontal, User, Wrench } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../../hooks/use-auth';
 import { useLibraryPath } from '../../hooks/use-libraries';
@@ -24,7 +24,7 @@ function getInitials(displayName: string): string {
 
 /**
  * Rail-footer account control. Same behavior as Header's user menu (theme
- * toggle, identity, Settings nav, Log out) but styled for the dark rail.
+ * toggle, identity, Tools/Settings navigation, Log out) but styled for the dark rail.
  * Pinned at the bottom of PivotRail.
  */
 export function UserMenu() {
@@ -94,6 +94,10 @@ export function UserMenu() {
                 </div>
               </DropdownMenuLabel>
               <DropdownMenuSeparator />
+              <DropdownMenuItem onClick={() => navigate(libPath('/tools'))}>
+                <Wrench className="mr-2 h-4 w-4" />
+                Tools
+              </DropdownMenuItem>
               <DropdownMenuItem onClick={() => navigate(libPath('/settings'))}>
                 <User className="mr-2 h-4 w-4" />
                 Settings

--- a/apps/frontend/src/pages/ToolsPage.test.tsx
+++ b/apps/frontend/src/pages/ToolsPage.test.tsx
@@ -1,0 +1,100 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { scanDuplicates } from '../api/tools';
+import { ToolsPage } from './ToolsPage';
+
+vi.mock('../api/tools', () => ({ scanDuplicates: vi.fn() }));
+
+const mockScanDuplicates = vi.mocked(scanDuplicates);
+
+function makeWrapper() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={client}>
+        <MemoryRouter initialEntries={['/tools']}>{children}</MemoryRouter>
+      </QueryClientProvider>
+    );
+  };
+}
+
+describe('ToolsPage', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('waits for the user to start a duplicate scan', () => {
+    render(<ToolsPage />, { wrapper: makeWrapper() });
+
+    expect(screen.getByRole('heading', { name: 'Tools' })).toBeTruthy();
+    expect(screen.getByText(/no scan has been run yet/i)).toBeTruthy();
+    expect(mockScanDuplicates).not.toHaveBeenCalled();
+  });
+
+  it('shows matching models returned by the scanner', async () => {
+    mockScanDuplicates.mockResolvedValue({
+      scannedModelCount: 3,
+      redundantModelCount: 1,
+      reclaimableBytes: 2048,
+      groups: [
+        {
+          fingerprint: 'same-files',
+          fileCount: 2,
+          totalSizeBytes: 2048,
+          reclaimableBytes: 2048,
+          models: [
+            { id: 'model-1', name: 'Dragon original', originalFilename: 'dragon.zip', createdAt: '2025-01-01T00:00:00.000Z' },
+            { id: 'model-2', name: 'Dragon copy', originalFilename: 'copy.zip', createdAt: '2025-02-01T00:00:00.000Z' },
+          ],
+        },
+      ],
+    });
+
+    render(<ToolsPage />, { wrapper: makeWrapper() });
+    fireEvent.click(screen.getByRole('button', { name: /scan library/i }));
+
+    await waitFor(() => expect(screen.getByText('Dragon original')).toBeTruthy());
+    expect(screen.getByText('Dragon copy')).toBeTruthy();
+    expect(screen.getByText('Oldest copy')).toBeTruthy();
+    expect(screen.getAllByText(/2\.0 KB/).length).toBeGreaterThan(0);
+  });
+
+  it('announces scan progress and completion', async () => {
+    let finishScan!: (value: Awaited<ReturnType<typeof scanDuplicates>>) => void;
+    mockScanDuplicates.mockReturnValue(new Promise((resolve) => { finishScan = resolve; }));
+
+    render(<ToolsPage />, { wrapper: makeWrapper() });
+    fireEvent.click(screen.getByRole('button', { name: /scan library/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('status').textContent).toMatch(/scanning library/i);
+    });
+    expect(screen.getByText('Scanning library…')).toBeTruthy();
+
+    finishScan({
+      scannedModelCount: 2,
+      redundantModelCount: 0,
+      reclaimableBytes: 0,
+      groups: [],
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('status').textContent).toMatch(/scan complete/i);
+    });
+  });
+
+  it('shows a clear result when no duplicates are found', async () => {
+    mockScanDuplicates.mockResolvedValue({
+      scannedModelCount: 4,
+      redundantModelCount: 0,
+      reclaimableBytes: 0,
+      groups: [],
+    });
+
+    render(<ToolsPage />, { wrapper: makeWrapper() });
+    fireEvent.click(screen.getByRole('button', { name: /scan library/i }));
+
+    await waitFor(() => expect(screen.getByText(/no duplicate models found/i)).toBeTruthy());
+    expect(screen.getByText(/compared 4 ready models with files/i)).toBeTruthy();
+  });
+});

--- a/apps/frontend/src/pages/ToolsPage.tsx
+++ b/apps/frontend/src/pages/ToolsPage.tsx
@@ -1,0 +1,210 @@
+import { useQuery } from '@tanstack/react-query';
+import {
+  ArrowLeft,
+  CheckCircle2,
+  Copy,
+  FileSearch,
+  Loader2,
+  RefreshCw,
+  Wrench,
+} from 'lucide-react';
+import { Link } from 'react-router-dom';
+import type { DuplicateModel, DuplicateScanResult } from '@alexandria/shared';
+import { scanDuplicates } from '../api/tools';
+import { Badge } from '../components/ui/badge';
+import { Button } from '../components/ui/button';
+import { useLibraryPath } from '../hooks/use-libraries';
+import { formatDate, formatFileSize } from '../lib/format';
+
+export function ToolsPage() {
+  const libPath = useLibraryPath();
+  const scan = useQuery({
+    queryKey: ['tools', 'duplicate-scan'],
+    queryFn: scanDuplicates,
+    enabled: false,
+    retry: false,
+  });
+
+  return (
+    <div className="flex max-w-5xl flex-col gap-8 p-6">
+      <header className="flex flex-col gap-3">
+        <Link
+          to={libPath('/')}
+          className="inline-flex w-fit items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+        >
+          <ArrowLeft className="h-3.5 w-3.5" />
+          Back to Library
+        </Link>
+        <div className="flex items-start gap-3">
+          <div className="rounded-lg bg-primary/10 p-2 text-primary">
+            <Wrench className="h-5 w-5" />
+          </div>
+          <div>
+            <h1 className="text-2xl font-bold text-foreground">Tools</h1>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Inspect and maintain the models in this library.
+            </p>
+          </div>
+        </div>
+      </header>
+
+      <section className="overflow-hidden rounded-xl border bg-card">
+        <div className="flex flex-col gap-4 border-b p-5 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-start gap-3">
+            <div className="rounded-lg bg-muted p-2 text-foreground">
+              <FileSearch className="h-5 w-5" />
+            </div>
+            <div>
+              <h2 className="font-semibold text-foreground">Duplicate scanner</h2>
+              <p className="mt-1 max-w-2xl text-sm text-muted-foreground">
+                Find ready models with identical file contents. File names and folder layout do
+                not affect matching.
+              </p>
+            </div>
+          </div>
+          <Button onClick={() => void scan.refetch()} disabled={scan.isFetching}>
+            {scan.isFetching ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : scan.data ? (
+              <RefreshCw className="mr-2 h-4 w-4" />
+            ) : (
+              <FileSearch className="mr-2 h-4 w-4" />
+            )}
+            {scan.isFetching ? 'Scanning…' : scan.data ? 'Scan again' : 'Scan library'}
+          </Button>
+        </div>
+
+        <div className="p-5">
+          <p role="status" aria-live="polite" className="sr-only">
+            {scan.isFetching
+              ? 'Scanning library for duplicate models.'
+              : scan.data
+                ? `Scan complete. Found ${scan.data.groups.length} duplicate groups and ${scan.data.redundantModelCount} redundant copies.`
+                : ''}
+          </p>
+          {scan.isFetching && !scan.data ? (
+            <div className="flex flex-col items-center justify-center gap-3 py-12 text-center">
+              <Loader2 className="h-8 w-8 animate-spin text-primary" />
+              <div>
+                <p className="text-sm font-medium text-foreground">Scanning library…</p>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  Comparing the complete file contents of each eligible model.
+                </p>
+              </div>
+            </div>
+          ) : scan.isError ? (
+            <div role="alert" className="rounded-lg border border-destructive/30 bg-destructive/5 p-4">
+              <p className="text-sm font-medium text-destructive">The duplicate scan failed.</p>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Try again. If the problem continues, check the server logs.
+              </p>
+            </div>
+          ) : scan.data ? (
+            <DuplicateResults result={scan.data} />
+          ) : (
+            <div className="flex flex-col items-center justify-center gap-3 py-12 text-center">
+              <Copy className="h-8 w-8 text-muted-foreground/60" />
+              <div>
+                <p className="text-sm font-medium text-foreground">No scan has been run yet</p>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  Run the scanner to compare every ready model that contains files.
+                </p>
+              </div>
+            </div>
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function DuplicateResults({ result }: { result: DuplicateScanResult }) {
+  if (result.groups.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-3 py-10 text-center">
+        <CheckCircle2 className="h-9 w-9 text-emerald-600" />
+        <div>
+          <p className="font-medium text-foreground">No duplicate models found</p>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Compared {result.scannedModelCount}{' '}
+            {result.scannedModelCount === 1 ? 'ready model with files' : 'ready models with files'}.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+        <ScanStat label="Models scanned" value={result.scannedModelCount.toLocaleString()} />
+        <ScanStat label="Duplicate groups" value={result.groups.length.toLocaleString()} />
+        <ScanStat label="Redundant copies" value={result.redundantModelCount.toLocaleString()} />
+        <ScanStat label="Potential savings" value={formatFileSize(result.reclaimableBytes)} />
+      </div>
+
+      <div className="flex flex-col gap-4">
+        {result.groups.map((group, index) => (
+          <div key={group.fingerprint} className="overflow-hidden rounded-lg border">
+            <div className="flex flex-col gap-1 border-b bg-muted/30 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <h3 className="text-sm font-semibold text-foreground">Duplicate set {index + 1}</h3>
+                <p className="text-xs text-muted-foreground">
+                  {group.fileCount} {group.fileCount === 1 ? 'file' : 'files'} per model ·{' '}
+                  {formatFileSize(group.totalSizeBytes)} each
+                </p>
+              </div>
+              <Badge variant="outline">
+                {group.models.length} identical models · {formatFileSize(group.reclaimableBytes)} reclaimable
+              </Badge>
+            </div>
+            <div className="divide-y">
+              {group.models.map((model, modelIndex) => (
+                <DuplicateModelRow key={model.id} model={model} suggestedKeep={modelIndex === 0} />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <p className="text-xs text-muted-foreground">
+        Results are informational. Review model metadata and collections before deleting a copy.
+      </p>
+    </div>
+  );
+}
+
+function ScanStat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-lg border bg-muted/20 p-3">
+      <p className="text-xs text-muted-foreground">{label}</p>
+      <p className="mt-1 text-lg font-semibold text-foreground">{value}</p>
+    </div>
+  );
+}
+
+function DuplicateModelRow({ model, suggestedKeep }: { model: DuplicateModel; suggestedKeep: boolean }) {
+  const libPath = useLibraryPath();
+
+  return (
+    <div className="flex flex-col gap-2 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
+      <div className="min-w-0">
+        <div className="flex items-center gap-2">
+          <Link
+            to={libPath(`/models/${model.id}`)}
+            className="truncate text-sm font-medium text-foreground hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            {model.name}
+          </Link>
+          {suggestedKeep && <Badge variant="secondary">Oldest copy</Badge>}
+        </div>
+        <p className="mt-0.5 truncate text-xs text-muted-foreground">
+          {model.originalFilename ?? 'No original filename'}
+        </p>
+      </div>
+      <span className="whitespace-nowrap text-xs text-muted-foreground">
+        Added {formatDate(model.createdAt)}
+      </span>
+    </div>
+  );
+}

--- a/docs/API.md
+++ b/docs/API.md
@@ -1468,6 +1468,60 @@ Values are validated against the resolved field definition before storage. Numbe
 
 ---
 
+## Tools
+
+Tools are library maintenance operations exposed from the library-scoped Tools page at `/lib/:id/tools`.
+
+### GET /tools/duplicates
+
+Scan the active library for exact duplicate model contents. The scan is read-only and synchronous; it reports candidates but does not merge, delete, or otherwise modify models or files.
+
+**Auth required:** Yes. The route applies `requireAuth` followed by `requireLibrary`.
+
+**Library scope:** Required. `X-Library-Id` selects the active owned library; when the header is absent, the user's default library is used. An unknown or un-owned library returns `404 NOT_FOUND`.
+
+Only `ready` models with at least one file are scanned. Two models are duplicates only when their complete sorted multisets of per-file SHA-256 hashes match. Sorting makes file order irrelevant, while treating the hashes as a multiset preserves multiplicity: a model containing two copies of a file does not match a model containing one copy. Filenames and relative paths do not participate in matching.
+
+**Response (200):**
+
+```json
+{
+  "data": {
+    "scannedModelCount": 3,
+    "redundantModelCount": 1,
+    "reclaimableBytes": 8388608,
+    "groups": [
+      {
+        "fingerprint": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "fileCount": 4,
+        "totalSizeBytes": 8388608,
+        "reclaimableBytes": 8388608,
+        "models": [
+          {
+            "id": "uuid",
+            "name": "Dragon Bust",
+            "originalFilename": "dragon-bust.zip",
+            "createdAt": "2026-01-15T10:30:00.000Z"
+          },
+          {
+            "id": "uuid",
+            "name": "Dragon Bust Copy",
+            "originalFilename": "renamed-copy.zip",
+            "createdAt": "2026-02-01T12:00:00.000Z"
+          }
+        ]
+      }
+    ]
+  },
+  "meta": null,
+  "errors": null
+}
+```
+
+`data` is a `DuplicateScanResult`; each member of `groups` is a `DuplicateGroup`, whose `models` are `DuplicateModel` values. The fingerprint is the SHA-256 digest of the encoded sorted file-hash multiset and should be treated as an opaque group identifier. Models within a group are oldest-first, with UUID as the equal-timestamp tie-breaker; groups are likewise ordered by their oldest model. `scannedModelCount` counts eligible models whether or not they belong to a duplicate group. `redundantModelCount` counts duplicate copies beyond the oldest model in each group. Group and scan `reclaimableBytes` sum the stored sizes of those later copies; `totalSizeBytes` is the oldest model's stored total. These values are estimates only—the decision and any deletion remain manual.
+
+---
+
 ## Libraries
 
 Manage the libraries a user owns. These endpoints manage the library scope itself, so they are **not** scoped by the `X-Library-Id` header — they operate on the authenticated user's full set of libraries, identified by the URL `:id`. See [Library scoping](#library-scoping-multi-library).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -55,6 +55,7 @@ The `runSeed` function is also exported for use as a standalone CLI script (`npm
 │   ModelDetailPage: ModelBreadcrumb + ModelHero +         │
 │     ModelDetailPanel (Info/Collections/Files tabs)       │
 │     + SplitFolderDialog for file-tree folder extraction  │
+│   ToolsPage: library maintenance tools + duplicate scan  │
 │   ModelViewer3DModal → lazy ModelViewer3DScene (three.js)│
 │   lib/model-files.ts: STL path helpers (pure)           │
 └──────────────────────┬──────────────────────────────────┘
@@ -70,7 +71,8 @@ The `runSeed` function is also exported for use as a standalone CLI script (`npm
 │  └─────────┘  └──────────────┘  │ MetadataService     │   │
 │                                  │ CollectionService   │   │
 │  requireAuth ──→ requireLibrary  │ SearchService       │   │
-│  (injects request.libraryId)     │ AuthService         │   │
+│  (injects request.libraryId)     │ DuplicateScannerSvc │   │
+│                                  │ AuthService         │   │
 │                                  │ LibraryService      │   │
 │  ┌──────────────┐               └───────────────────┘   │
 │  │IngestionSvc  │──────────────→(services above)         │
@@ -197,6 +199,7 @@ Routes that apply `requireLibrary` (as of P5):
 - `POST /models/upload`, `POST /models/upload/:uploadId/complete`, `POST /models/upload/multipart/complete`, `POST /models/import`
 - `GET /models/import-sessions`, `POST /models/import-sessions/:id/commit`
 - `GET /search`
+- `GET /tools/duplicates`
 - All `/smart-collections` routes
 - All `/bulk/*` routes
 - `POST /ai/chat`, `POST /ai/proposals/:id/apply`
@@ -346,6 +349,14 @@ On startup, S3 mode performs `HeadBucket` validation before database migration a
 
 **Abstraction:** The search implementation is behind an interface. Postgres FTS is the MVP implementation. A future MeiliSearch or Typesense implementation can be swapped in without changing any callers.
 
+### DuplicateScannerService
+
+**Owns:** Read-only detection and reporting of exact duplicate models within one authenticated user's active library.
+
+**Does not own:** File hashing, model deletion, model merging, or any other mutation.
+
+**Behavior:** `scanDuplicates(libraryId)` considers only `ready` models that have at least one file. The route supplies the ownership-checked `request.libraryId` produced by `requireLibrary`. PostgreSQL aggregates the ordered file-hash multiset into one row per model before results cross the database boundary, and concurrent requests for the same library share one in-flight scan. Sorting makes file order irrelevant while preserving repeated hashes, so a model containing the same file twice does not match one containing it once. Filenames and relative paths do not participate in matching. Only identities shared by at least two models are returned. PresenterService formats timestamps and assembles per-group and aggregate counts and reclaimable-byte estimates. The operation is report-only and never changes models or files.
+
 ### ModelService
 
 **Owns:** Model, ModelFile, and ModelFolder CRUD. Creating, reading, updating, and deleting Model records; managing file and persisted-folder relationships; and coordinating structural operations such as model merge and splitting one folder into a new model.
@@ -469,6 +480,7 @@ Provider base URLs are user-configured and contacted from the backend, so they a
 - `buildCollectionDetail(collection)` → collection with children and model count
 - `buildCollectionList(userId, params)` → all collections for a user, with optional depth expansion
 - `buildMetadataFieldList(fields)` → field definitions with value counts
+- `buildDuplicateScanResult(scan)` → duplicate groups, summary counts, and reclaimable-byte estimates
 
 ---
 
@@ -485,7 +497,7 @@ The application shell (`AppShell`) is a full-height flex row:
 │  PivotRail   │             <Outlet>                      │
 │  (272 px,    │  PivotPage → PivotMain                   │
 │   fixed)     │  ModelDetailPage, CollectionDetailPage,   │
-│              │  UploadPage, SettingsPage                 │
+│              │  UploadPage, SettingsPage, ToolsPage      │
 └──────────────┴──────────────────────────────────────────┘
 ```
 
@@ -495,10 +507,10 @@ The application shell (`AppShell`) is a full-height flex row:
 
 The rail contains, top to bottom:
 
-1. **Library header** — brand mark plus a library-name badge. The badge includes a chevron-down but is non-interactive (`aria-disabled`, `tabIndex=-1`): multi-library switching is a P5 stub.
+1. **Library header** — brand mark plus the active library switcher. Selecting another owned library navigates to that library's `/lib/:id` workspace; the switcher also links to the All-Libraries home.
 2. **AxisPicker** — a 2-column button grid for selecting the active axis. Collections, Artists, Tags, and Smart Collections are always present; every metadata field marked `isBrowsable` is also exposed as an axis (Artist and Tags reuse their dedicated axes instead of appearing twice).
 3. **AxisFacetBody** — a scrollable list for the active axis. Shows the collections tree, smart collections, or the values and model counts for the selected metadata dimension, each pulling from the appropriate backend endpoint.
-4. **UserMenu** — pinned footer with user avatar, display name, theme toggle, Settings link, and Log out.
+4. **UserMenu** — pinned footer with user avatar, display name, theme toggle, library-relative Tools and Settings links, and Log out. Tools navigates to `/lib/:id/tools` for the active library.
 
 ### Axes
 
@@ -568,9 +580,9 @@ On success the dialog drops its own `merge-selection` lookups and the detail-pag
 
 ### Navigation
 
-Routes unchanged from P0: `/models/:id`, `/collections`, `/collections/:id`, `/upload`, `/settings`. The standalone `/collections` nav link was removed from the left rail (collections are now an axis, not a separate page), but the route itself still exists for direct navigation and is used by collection-detail links.
+Authenticated workspace routes are rooted at `/lib/:id`. They include the library pivot at `/lib/:id`, model and collection detail routes, upload and search, smart-collection composition, `/lib/:id/settings`, and `/lib/:id/tools`. The UserMenu exposes Tools beside Settings; the Tools page keeps navigation and API requests within the active library. `/` is the authenticated All-Libraries home.
 
-`/lib/:id` (multi-library routing) does not exist yet; deferred to P5.
+The standalone collections route remains available beneath the library workspace for direct navigation and collection-detail links, although collections are primarily browsed as a pivot axis rather than through a persistent rail link.
 
 ---
 
@@ -743,6 +755,11 @@ All provider routes apply `requireAuth` and enforce provider ownership in `AiPro
 | Method | Route | Purpose | Service Chain | Library-scoped |
 |--------|-------|---------|---------------|---------------|
 | GET | /search | Cross-entity search (models, collections, artists, tags) | SearchService | Yes |
+
+**Tools**
+| Method | Route | Purpose | Service Chain | Library-scoped |
+|--------|-------|---------|---------------|---------------|
+| GET | /tools/duplicates | Report ready models with identical complete file-hash multisets | DuplicateScannerService → PresenterService | Yes |
 
 **Bulk Operations**
 | Method | Route | Purpose | Service Chain | Library-scoped |

--- a/docs/TYPES.md
+++ b/docs/TYPES.md
@@ -511,6 +511,36 @@ interface CompressFolderResponse {
 }
 ```
 
+### Tools Response Types
+
+Defined in `packages/shared/src/types/tools.ts`. Returned by `GET /tools/duplicates`.
+
+```typescript
+interface DuplicateModel {
+  id: string;
+  name: string;
+  originalFilename: string | null;
+  createdAt: string;
+}
+
+interface DuplicateGroup {
+  fingerprint: string;       // SHA-256 of the encoded complete sorted hash multiset
+  fileCount: number;         // files in each model; repeated file hashes count separately
+  totalSizeBytes: number;    // stored size of the oldest model in the group
+  reclaimableBytes: number;  // summed sizes of every model after the oldest
+  models: DuplicateModel[];  // oldest first; UUID breaks equal-timestamp ties
+}
+
+interface DuplicateScanResult {
+  scannedModelCount: number;   // ready, non-empty models considered
+  redundantModelCount: number; // duplicate copies beyond the oldest model in each group
+  reclaimableBytes: number;
+  groups: DuplicateGroup[];
+}
+```
+
+Duplicate identity uses the complete sorted multiset of per-file SHA-256 hashes. File order, filenames, and relative paths are ignored, but hash multiplicity is preserved. Models that are not `ready` or contain no files are excluded. Groups are ordered by their oldest model, using model UUID and then fingerprint as deterministic tie-breakers. These response types describe a report only; scanning does not delete, merge, or otherwise modify a model.
+
 ### Metadata Response Types
 
 ```typescript

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -8,3 +8,4 @@ export * from './upload.js';
 export * from './search.js';
 export * from './smart-collection.js';
 export * from './ai.js';
+export * from './tools.js';

--- a/packages/shared/src/types/tools.ts
+++ b/packages/shared/src/types/tools.ts
@@ -1,0 +1,21 @@
+export interface DuplicateModel {
+  id: string;
+  name: string;
+  originalFilename: string | null;
+  createdAt: string;
+}
+
+export interface DuplicateGroup {
+  fingerprint: string;
+  fileCount: number;
+  totalSizeBytes: number;
+  reclaimableBytes: number;
+  models: DuplicateModel[];
+}
+
+export interface DuplicateScanResult {
+  scannedModelCount: number;
+  redundantModelCount: number;
+  reclaimableBytes: number;
+  groups: DuplicateGroup[];
+}


### PR DESCRIPTION
## Summary

- add a library-scoped Tools page and expose it from the user context menu
- add the first tool: an exact duplicate scanner based on complete per-file SHA-256 hash multisets
- present grouped matches, suggested oldest copy, and potential storage savings without deleting or merging automatically

## Implementation

- add `GET /tools/duplicates` behind authentication and active-library resolution
- aggregate hashes per model in PostgreSQL and coalesce concurrent scans for the same library
- assemble the shared response contract through PresenterService
- add explicit loading, error, empty, result, and accessible live-status states in the frontend
- document the endpoint, types, service boundary, and navigation

## Validation

- `npm test` — 915 backend tests and 359 frontend tests passed
- `npm run build`
- `npm run lint`
- reviewer pass completed with no remaining findings in scope
