### PR TITLE
feat: scan library for duplicate files

### DIFF
--- a/apps/backend/src/routes/tools.integration.test.ts
+++ b/apps/backend/src/routes/tools.integration.test.ts
@@ -25,6 +25,7 @@ let ownerDefaultLibraryId: string;
 let ownerSecondLibraryId: string;
 let otherTenantLibraryId: string;
 let defaultModelIds: string[];
+let partialDuplicateModelId: string;
 let secondLibraryModelIds: string[];
 let otherTenantModelIds: string[];
 
@@ -94,6 +95,7 @@ async function createDuplicatePair(options: {
       sizeBytes: 50 + fileIndex,
       storagePath: `models/${model.id}/part-${fileIndex + 1}.stl`,
       hash,
+      createdAt: options.createdAt[modelIndex],
     })));
   }
 
@@ -169,6 +171,49 @@ beforeAll(async () => {
     createdAt: [new Date('2026-01-01T00:00:00.000Z'), new Date('2026-01-02T00:00:00.000Z')],
     totalSizeBytes: [100, 200],
   });
+
+  const partialDuplicateCreatedAt = new Date('2026-01-03T00:00:00.000Z');
+  const [partialDuplicateModel] = await db
+    .insert(models)
+    .values({
+      name: 'Partial File Match',
+      slug: `${runToken}-partial-file-match`,
+      userId: owner.id,
+      libraryId: ownerDefaultLibraryId,
+      sourceType: 'manual',
+      status: 'ready',
+      originalFilename: 'partial-file-match.zip',
+      totalSizeBytes: 121,
+      fileCount: 2,
+      createdAt: partialDuplicateCreatedAt,
+      updatedAt: partialDuplicateCreatedAt,
+    })
+    .returning({ id: models.id });
+  partialDuplicateModelId = partialDuplicateModel.id;
+  await db.insert(modelFiles).values([
+    {
+      modelId: partialDuplicateModelId,
+      filename: 'shared-part.stl',
+      relativePath: 'alternate/shared-part.stl',
+      fileType: 'stl',
+      mimeType: 'model/stl',
+      sizeBytes: 60,
+      storagePath: `models/${partialDuplicateModelId}/shared-part.stl`,
+      hash: SHARED_HASHES[0],
+      createdAt: partialDuplicateCreatedAt,
+    },
+    {
+      modelId: partialDuplicateModelId,
+      filename: 'unique-part.stl',
+      relativePath: 'unique-part.stl',
+      fileType: 'stl',
+      mimeType: 'model/stl',
+      sizeBytes: 61,
+      storagePath: `models/${partialDuplicateModelId}/unique-part.stl`,
+      hash: '3'.repeat(64),
+      createdAt: partialDuplicateCreatedAt,
+    },
+  ]);
 
   const [processingModel] = await db
     .insert(models)
@@ -254,9 +299,12 @@ describe('GET /tools/duplicates integration', () => {
     const body = response.json();
     expect(body).toEqual({
       data: {
-        scannedModelCount: 2,
+        scannedModelCount: 3,
+        scannedFileCount: 6,
         redundantModelCount: 1,
+        redundantFileCount: 3,
         reclaimableBytes: 200,
+        fileReclaimableBytes: 161,
         groups: [
           {
             fingerprint: expect.stringMatching(/^[a-f0-9]{64}$/),
@@ -279,6 +327,67 @@ describe('GET /tools/duplicates integration', () => {
             ],
           },
         ],
+        fileGroups: [
+          {
+            hash: SHARED_HASHES[0],
+            sizeBytes: 50,
+            reclaimableBytes: 110,
+            files: [
+              {
+                id: expect.any(String),
+                modelId: defaultModelIds[0],
+                modelName: 'Default Pair 1',
+                filename: 'part-1-1.stl',
+                relativePath: 'parts/part-1-1.stl',
+                sizeBytes: 50,
+                createdAt: '2026-01-01T00:00:00.000Z',
+              },
+              {
+                id: expect.any(String),
+                modelId: defaultModelIds[1],
+                modelName: 'Default Pair 2',
+                filename: 'part-1-2.stl',
+                relativePath: 'parts/part-1-2.stl',
+                sizeBytes: 50,
+                createdAt: '2026-01-02T00:00:00.000Z',
+              },
+              {
+                id: expect.any(String),
+                modelId: partialDuplicateModelId,
+                modelName: 'Partial File Match',
+                filename: 'shared-part.stl',
+                relativePath: 'alternate/shared-part.stl',
+                sizeBytes: 60,
+                createdAt: '2026-01-03T00:00:00.000Z',
+              },
+            ],
+          },
+          {
+            hash: SHARED_HASHES[1],
+            sizeBytes: 51,
+            reclaimableBytes: 51,
+            files: [
+              {
+                id: expect.any(String),
+                modelId: defaultModelIds[0],
+                modelName: 'Default Pair 1',
+                filename: 'part-2-1.stl',
+                relativePath: 'parts/part-2-1.stl',
+                sizeBytes: 51,
+                createdAt: '2026-01-01T00:00:00.000Z',
+              },
+              {
+                id: expect.any(String),
+                modelId: defaultModelIds[1],
+                modelName: 'Default Pair 2',
+                filename: 'part-2-2.stl',
+                relativePath: 'parts/part-2-2.stl',
+                sizeBytes: 51,
+                createdAt: '2026-01-02T00:00:00.000Z',
+              },
+            ],
+          },
+        ],
       },
       meta: null,
       errors: null,
@@ -289,6 +398,9 @@ describe('GET /tools/duplicates integration', () => {
     );
     expect(returnedIds).not.toContain(secondLibraryModelIds[0]);
     expect(returnedIds).not.toContain(otherTenantModelIds[0]);
+    expect(returnedIds).not.toContain(partialDuplicateModelId);
+    expect(body.data.fileGroups[0].files.map((file: { modelId: string }) => file.modelId))
+      .toContain(partialDuplicateModelId);
   });
 
   it('should scan only an explicitly selected owned library', async () => {

--- a/apps/backend/src/routes/tools.test.ts
+++ b/apps/backend/src/routes/tools.test.ts
@@ -33,13 +33,19 @@ describe('Tools routes', () => {
     vi.clearAllMocks();
     mocks.scanDuplicates.mockResolvedValue({
       scannedModelCount: 2,
+      scannedFileCount: 4,
       groups: [],
+      fileGroups: [],
     });
     mocks.buildDuplicateScanResult.mockReturnValue({
       scannedModelCount: 2,
+      scannedFileCount: 4,
       redundantModelCount: 1,
+      redundantFileCount: 2,
       reclaimableBytes: 1024,
+      fileReclaimableBytes: 512,
       groups: [],
+      fileGroups: [],
     });
     app = Fastify();
     await app.register(toolsRoutes, { prefix: '/tools' });
@@ -61,7 +67,9 @@ describe('Tools routes', () => {
     expect(mocks.scanDuplicates).toHaveBeenCalledWith(LIBRARY_ID);
     expect(mocks.buildDuplicateScanResult).toHaveBeenCalledWith({
       scannedModelCount: 2,
+      scannedFileCount: 4,
       groups: [],
+      fileGroups: [],
     });
   });
 
@@ -71,9 +79,13 @@ describe('Tools routes', () => {
     expect(response.json()).toEqual({
       data: {
         scannedModelCount: 2,
+        scannedFileCount: 4,
         redundantModelCount: 1,
+        redundantFileCount: 2,
         reclaimableBytes: 1024,
+        fileReclaimableBytes: 512,
         groups: [],
+        fileGroups: [],
       },
       meta: null,
       errors: null,

--- a/apps/backend/src/services/duplicate-scanner.service.test.ts
+++ b/apps/backend/src/services/duplicate-scanner.service.test.ts
@@ -1,7 +1,21 @@
 import { describe, expect, it, vi } from 'vitest';
 import { DuplicateScannerService } from './duplicate-scanner.service.js';
 
-interface CandidateRow {
+interface FileCandidateRow {
+  modelId: string;
+  modelName: string;
+  originalFilename: string | null;
+  modelTotalSizeBytes: number;
+  modelCreatedAt: Date;
+  fileId: string;
+  filename: string;
+  relativePath: string;
+  fileSizeBytes: number;
+  fileCreatedAt: Date;
+  hash: string;
+}
+
+interface ModelCandidateRow {
   id: string;
   name: string;
   originalFilename: string | null;
@@ -10,105 +24,164 @@ interface CandidateRow {
   hashes: string[];
 }
 
-function databaseReturning(rows: CandidateRow[]) {
-  const query = {
+function databaseReturning(rows: FileCandidateRow[]) {
+  const modelRows = [...rows.reduce((byModel, row) => {
+    const existing = byModel.get(row.modelId);
+    if (existing) existing.hashes.push(row.hash);
+    else byModel.set(row.modelId, {
+      id: row.modelId,
+      name: row.modelName,
+      originalFilename: row.originalFilename,
+      totalSizeBytes: row.modelTotalSizeBytes,
+      createdAt: row.modelCreatedAt,
+      hashes: [row.hash],
+    });
+    return byModel;
+  }, new Map<string, ModelCandidateRow>()).values()]
+    .map((model) => ({ ...model, hashes: model.hashes.sort() }));
+  const hashCounts = rows.reduce((counts, row) => {
+    counts.set(row.hash, (counts.get(row.hash) ?? 0) + 1);
+    return counts;
+  }, new Map<string, number>());
+  const duplicateFileRows = rows.filter((row) => (hashCounts.get(row.hash) ?? 0) > 1);
+
+  const modelQuery = {
     from: vi.fn(),
     innerJoin: vi.fn(),
     where: vi.fn(),
     groupBy: vi.fn(),
     orderBy: vi.fn(),
   };
-  query.from.mockReturnValue(query);
-  query.innerJoin.mockReturnValue(query);
-  query.where.mockReturnValue(query);
-  query.groupBy.mockReturnValue(query);
-  query.orderBy.mockResolvedValue(rows);
+  modelQuery.from.mockReturnValue(modelQuery);
+  modelQuery.innerJoin.mockReturnValue(modelQuery);
+  modelQuery.where.mockReturnValue(modelQuery);
+  modelQuery.groupBy.mockReturnValue(modelQuery);
+  modelQuery.orderBy.mockResolvedValue(modelRows);
+
+  const fileQuery = {
+    from: vi.fn(),
+    innerJoin: vi.fn(),
+    where: vi.fn(),
+    orderBy: vi.fn(),
+  };
+  fileQuery.from.mockReturnValue(fileQuery);
+  fileQuery.innerJoin.mockReturnValue(fileQuery);
+  fileQuery.where.mockReturnValue(fileQuery);
+  fileQuery.orderBy.mockResolvedValue(duplicateFileRows);
 
   return {
-    database: { select: vi.fn().mockReturnValue(query) },
-    query,
+    database: {
+      select: vi.fn()
+        .mockReturnValueOnce(modelQuery)
+        .mockReturnValueOnce(fileQuery),
+    },
+    modelQuery,
+    fileQuery,
   };
 }
 
-function row(
-  id: string,
-  hashes: string[],
+function fileRow(
+  modelId: string,
+  hash: string,
   options: {
-    name?: string;
+    fileId?: string;
+    modelName?: string;
     originalFilename?: string | null;
-    totalSizeBytes?: number;
-    createdAt?: string;
+    modelTotalSizeBytes?: number;
+    modelCreatedAt?: string;
+    filename?: string;
+    relativePath?: string;
+    fileSizeBytes?: number;
+    fileCreatedAt?: string;
   } = {},
-): CandidateRow {
+): FileCandidateRow {
+  const fileId = options.fileId ?? `${modelId}-${hash}`;
   return {
-    id,
-    hashes,
-    name: options.name ?? id,
-    originalFilename: options.originalFilename ?? `${id}.zip`,
-    totalSizeBytes: options.totalSizeBytes ?? 100,
-    createdAt: new Date(options.createdAt ?? '2026-01-01T00:00:00.000Z'),
+    modelId,
+    hash,
+    modelName: options.modelName ?? modelId,
+    originalFilename: options.originalFilename ?? `${modelId}.zip`,
+    modelTotalSizeBytes: options.modelTotalSizeBytes ?? 100,
+    modelCreatedAt: new Date(options.modelCreatedAt ?? '2026-01-01T00:00:00.000Z'),
+    fileId,
+    filename: options.filename ?? `${fileId}.stl`,
+    relativePath: options.relativePath ?? `parts/${fileId}.stl`,
+    fileSizeBytes: options.fileSizeBytes ?? 50,
+    fileCreatedAt: new Date(
+      options.fileCreatedAt ?? options.modelCreatedAt ?? '2026-01-01T01:00:00.000Z',
+    ),
   };
 }
 
 describe('DuplicateScannerService', () => {
-  it('matches only complete sorted hash multisets and preserves multiplicity', async () => {
-    const { database, query } = databaseReturning([
-      row('new-copy', ['hash-a', 'hash-b'], {
-        name: 'Renamed copy',
+  it('finds individual duplicate files and complete model hash multisets', async () => {
+    const { database, modelQuery, fileQuery } = databaseReturning([
+      fileRow('new-copy', 'hash-a', {
+        fileId: 'new-a',
+        modelName: 'Renamed copy',
         originalFilename: 'different-source.7z',
-        totalSizeBytes: 120,
-        createdAt: '2026-02-01T00:00:00.000Z',
+        modelTotalSizeBytes: 120,
+        modelCreatedAt: '2026-02-01T00:00:00.000Z',
       }),
-      row('old-copy', ['hash-a', 'hash-b'], {
-        name: 'Original',
-        originalFilename: 'original.zip',
-        totalSizeBytes: 100,
-        createdAt: '2026-01-01T00:00:00.000Z',
+      fileRow('new-copy', 'hash-b', {
+        fileId: 'new-b',
+        modelName: 'Renamed copy',
+        originalFilename: 'different-source.7z',
+        modelTotalSizeBytes: 120,
+        modelCreatedAt: '2026-02-01T00:00:00.000Z',
       }),
-      row('single-a', ['hash-a']),
-      row('repeated-a', ['hash-a', 'hash-a']),
+      fileRow('old-copy', 'hash-a', { fileId: 'old-a', modelName: 'Original' }),
+      fileRow('old-copy', 'hash-b', { fileId: 'old-b', modelName: 'Original' }),
+      fileRow('single-a', 'hash-a', { fileId: 'single-a' }),
+      fileRow('repeated-a', 'hash-a', { fileId: 'repeated-a-1' }),
+      fileRow('repeated-a', 'hash-a', { fileId: 'repeated-a-2' }),
     ]);
     const service = new DuplicateScannerService(database as never);
 
     const result = await service.scanDuplicates('library-1');
 
-    expect(database.select).toHaveBeenCalledOnce();
-    expect(query.innerJoin).toHaveBeenCalledOnce();
-    expect(query.where).toHaveBeenCalledOnce();
-    expect(query.groupBy).toHaveBeenCalledOnce();
-    expect(result).toEqual({
-      scannedModelCount: 4,
-      groups: [
-        {
-          fingerprint: expect.stringMatching(/^[a-f0-9]{64}$/),
-          fileCount: 2,
-          models: [
-            {
-              id: 'old-copy',
-              name: 'Original',
-              originalFilename: 'original.zip',
-              totalSizeBytes: 100,
-              createdAt: new Date('2026-01-01T00:00:00.000Z'),
-            },
-            {
-              id: 'new-copy',
-              name: 'Renamed copy',
-              originalFilename: 'different-source.7z',
-              totalSizeBytes: 120,
-              createdAt: new Date('2026-02-01T00:00:00.000Z'),
-            },
-          ],
-        },
-      ],
-    });
+    expect(database.select).toHaveBeenCalledTimes(2);
+    expect(modelQuery.groupBy).toHaveBeenCalledOnce();
+    expect(fileQuery.where).toHaveBeenCalledOnce();
+    expect(result.scannedModelCount).toBe(4);
+    expect(result.scannedFileCount).toBe(7);
+    expect(result.groups).toEqual([
+      {
+        fingerprint: expect.stringMatching(/^[a-f0-9]{64}$/),
+        fileCount: 2,
+        models: [
+          {
+            id: 'old-copy',
+            name: 'Original',
+            originalFilename: 'old-copy.zip',
+            totalSizeBytes: 100,
+            createdAt: new Date('2026-01-01T00:00:00.000Z'),
+          },
+          {
+            id: 'new-copy',
+            name: 'Renamed copy',
+            originalFilename: 'different-source.7z',
+            totalSizeBytes: 120,
+            createdAt: new Date('2026-02-01T00:00:00.000Z'),
+          },
+        ],
+      },
+    ]);
+    expect(result.fileGroups.map((group) => ({
+      hash: group.hash,
+      ids: group.files.map((file) => file.id),
+    }))).toEqual([
+      { hash: 'hash-a', ids: ['old-a', 'repeated-a-1', 'repeated-a-2', 'single-a', 'new-a'] },
+      { hash: 'hash-b', ids: ['old-b', 'new-b'] },
+    ]);
   });
 
-  it('returns stable ordering for models and groups regardless of row order', async () => {
+  it('returns stable ordering for models, files, and groups regardless of row order', async () => {
     const rows = [
-      row('group-b-new', ['hash-z'], { createdAt: '2026-04-01T00:00:00.000Z' }),
-      row('group-a-new', ['hash-a'], { createdAt: '2026-03-01T00:00:00.000Z' }),
-      row('group-b-old', ['hash-z'], { createdAt: '2026-02-01T00:00:00.000Z' }),
-      row('group-a-old', ['hash-a'], { createdAt: '2026-01-01T00:00:00.000Z' }),
+      fileRow('group-b-new', 'hash-z', { fileId: 'b-new', modelCreatedAt: '2026-04-01T00:00:00.000Z' }),
+      fileRow('group-a-new', 'hash-a', { fileId: 'a-new', modelCreatedAt: '2026-03-01T00:00:00.000Z' }),
+      fileRow('group-b-old', 'hash-z', { fileId: 'b-old', modelCreatedAt: '2026-02-01T00:00:00.000Z' }),
+      fileRow('group-a-old', 'hash-a', { fileId: 'a-old', modelCreatedAt: '2026-01-01T00:00:00.000Z' }),
     ];
     const first = databaseReturning(rows);
     const second = databaseReturning([...rows].reverse());
@@ -123,10 +196,14 @@ describe('DuplicateScannerService', () => {
       ['group-a-old', 'group-a-new'],
       ['group-b-old', 'group-b-new'],
     ]);
+    expect(firstResult.fileGroups.map((group) => group.files.map((file) => file.id))).toEqual([
+      ['a-old', 'a-new'],
+      ['b-old', 'b-new'],
+    ]);
   });
 
   it('coalesces concurrent scans for the same library', async () => {
-    const fixture = databaseReturning([row('only-model', ['hash-a'])]);
+    const fixture = databaseReturning([fileRow('only-model', 'hash-a')]);
     const service = new DuplicateScannerService(fixture.database as never);
 
     const [first, second] = await Promise.all([
@@ -135,13 +212,18 @@ describe('DuplicateScannerService', () => {
     ]);
 
     expect(first).toEqual(second);
-    expect(fixture.database.select).toHaveBeenCalledOnce();
+    expect(fixture.database.select).toHaveBeenCalledTimes(2);
   });
 
   it('does not scan or group models without files', async () => {
     const { database } = databaseReturning([]);
 
     await expect(new DuplicateScannerService(database as never).scanDuplicates('library-1'))
-      .resolves.toEqual({ scannedModelCount: 0, groups: [] });
+      .resolves.toEqual({
+        scannedModelCount: 0,
+        scannedFileCount: 0,
+        groups: [],
+        fileGroups: [],
+      });
   });
 });

--- a/apps/backend/src/services/duplicate-scanner.service.ts
+++ b/apps/backend/src/services/duplicate-scanner.service.ts
@@ -21,9 +21,27 @@ export interface DuplicateScanGroup {
   models: DuplicateScanCandidate[];
 }
 
+export interface DuplicateFileScanCandidate {
+  id: string;
+  modelId: string;
+  modelName: string;
+  filename: string;
+  relativePath: string;
+  sizeBytes: number;
+  createdAt: Date;
+  modelCreatedAt: Date;
+}
+
+export interface DuplicateFileScanGroup {
+  hash: string;
+  files: DuplicateFileScanCandidate[];
+}
+
 export interface DuplicateScan {
   scannedModelCount: number;
+  scannedFileCount: number;
   groups: DuplicateScanGroup[];
+  fileGroups: DuplicateFileScanGroup[];
 }
 
 export interface IDuplicateScannerService {
@@ -31,8 +49,9 @@ export interface IDuplicateScannerService {
 }
 
 /**
- * Finds exact model duplicates from their complete multisets of per-file
- * SHA-256 hashes. File names and paths deliberately do not participate.
+ * Finds duplicate files by SHA-256 and exact model duplicates from their
+ * complete multisets of per-file SHA-256 hashes. Names and paths deliberately
+ * do not participate in either identity.
  */
 export class DuplicateScannerService implements IDuplicateScannerService {
   private readonly inFlightByLibrary = new Map<string, Promise<DuplicateScan>>();
@@ -58,9 +77,11 @@ export class DuplicateScannerService implements IDuplicateScannerService {
   }
 
   private async runScan(libraryId: string): Promise<DuplicateScan> {
-    // Aggregate in PostgreSQL so one row crosses the database boundary per
-    // eligible model rather than one repeated model row per stored file.
-    const rows = await this.database
+    // Keep the complete hash multiset aggregation in PostgreSQL so unique-file
+    // detail does not cross the database boundary. The second query returns
+    // candidate detail only for hashes that occur more than once in this same
+    // ready-model/library scope.
+    const modelRowsQuery = this.database
       .select({
         id: models.id,
         name: models.name,
@@ -75,11 +96,66 @@ export class DuplicateScannerService implements IDuplicateScannerService {
       .groupBy(models.id)
       .orderBy(asc(models.createdAt), asc(models.id));
 
-    const groupsByHashMultiset = new Map<string, DuplicateScanGroup>();
+    const duplicateFileRowsQuery = this.database
+      .select({
+        modelId: models.id,
+        modelName: models.name,
+        modelCreatedAt: models.createdAt,
+        fileId: modelFiles.id,
+        filename: modelFiles.filename,
+        relativePath: modelFiles.relativePath,
+        fileSizeBytes: modelFiles.sizeBytes,
+        fileCreatedAt: modelFiles.createdAt,
+        hash: modelFiles.hash,
+      })
+      .from(models)
+      .innerJoin(modelFiles, eq(modelFiles.modelId, models.id))
+      .where(and(
+        eq(models.libraryId, libraryId),
+        eq(models.status, 'ready'),
+        sql<boolean>`${modelFiles.hash} in (
+          select duplicate_file.hash
+          from model_files as duplicate_file
+          inner join models as duplicate_model on duplicate_model.id = duplicate_file.model_id
+          where duplicate_model.library_id = ${libraryId}
+            and duplicate_model.status = 'ready'
+          group by duplicate_file.hash
+          having count(*) > 1
+        )`,
+      ))
+      .orderBy(
+        asc(modelFiles.createdAt),
+        asc(modelFiles.id),
+        asc(modelFiles.hash),
+      );
 
-    for (const row of rows) {
+    const [modelRows, duplicateFileRows] = await Promise.all([
+      modelRowsQuery,
+      duplicateFileRowsQuery,
+    ]);
+
+    const filesByHash = new Map<string, DuplicateFileScanCandidate[]>();
+
+    for (const row of duplicateFileRows) {
+      const file: DuplicateFileScanCandidate = {
+        id: row.fileId,
+        modelId: row.modelId,
+        modelName: row.modelName,
+        filename: row.filename,
+        relativePath: row.relativePath,
+        sizeBytes: row.fileSizeBytes,
+        createdAt: row.fileCreatedAt,
+        modelCreatedAt: row.modelCreatedAt,
+      };
+      const matchingFiles = filesByHash.get(row.hash);
+      if (matchingFiles) matchingFiles.push(file);
+      else filesByHash.set(row.hash, [file]);
+    }
+
+    const groupsByHashMultiset = new Map<string, DuplicateScanGroup>();
+    for (const row of modelRows) {
       // JSON supplies unambiguous element boundaries. Repeated hashes remain
-      // repeated, so multiplicity is part of the exact content identity.
+      // repeated, so multiplicity is part of the exact model identity.
       const hashMultisetKey = JSON.stringify(row.hashes);
       const existing = groupsByHashMultiset.get(hashMultisetKey);
       const candidate: DuplicateScanCandidate = {
@@ -105,15 +181,26 @@ export class DuplicateScannerService implements IDuplicateScannerService {
       .filter((group) => group.models.length > 1)
       .map((group) => ({ ...group, models: [...group.models].sort(compareCandidates) }))
       .sort(compareGroups);
+    const fileGroups = [...filesByHash.entries()]
+      .filter(([, files]) => files.length > 1)
+      .map(([hash, files]) => ({ hash, files: [...files].sort(compareFileCandidates) }))
+      .sort(compareFileGroups);
 
-    const result: DuplicateScan = { scannedModelCount: rows.length, groups };
+    const result: DuplicateScan = {
+      scannedModelCount: modelRows.length,
+      scannedFileCount: modelRows.reduce((sum, row) => sum + row.hashes.length, 0),
+      groups,
+      fileGroups,
+    };
 
     logger.debug(
       {
         service: 'DuplicateScannerService',
         libraryId,
         scannedModelCount: result.scannedModelCount,
-        duplicateGroupCount: result.groups.length,
+        scannedFileCount: result.scannedFileCount,
+        duplicateModelGroupCount: result.groups.length,
+        duplicateFileGroupCount: result.fileGroups.length,
       },
       'Completed duplicate scan',
     );
@@ -132,6 +219,22 @@ function compareGroups(left: DuplicateScanGroup, right: DuplicateScanGroup): num
   return leftOldest.createdAt.getTime() - rightOldest.createdAt.getTime()
     || compareStrings(leftOldest.id, rightOldest.id)
     || compareStrings(left.fingerprint, right.fingerprint);
+}
+
+function compareFileCandidates(
+  left: DuplicateFileScanCandidate,
+  right: DuplicateFileScanCandidate,
+): number {
+  return left.createdAt.getTime() - right.createdAt.getTime()
+    || compareStrings(left.id, right.id)
+    || left.modelCreatedAt.getTime() - right.modelCreatedAt.getTime()
+    || compareStrings(left.modelId, right.modelId);
+}
+
+function compareFileGroups(left: DuplicateFileScanGroup, right: DuplicateFileScanGroup): number {
+  return left.files[0].createdAt.getTime() - right.files[0].createdAt.getTime()
+    || compareStrings(left.hash, right.hash)
+    || compareStrings(left.files[0].id, right.files[0].id);
 }
 
 function compareStrings(left: string, right: string): number {

--- a/apps/backend/src/services/presenter.service.test.ts
+++ b/apps/backend/src/services/presenter.service.test.ts
@@ -604,6 +604,7 @@ describe('buildDuplicateScanResult', () => {
   it('formats duplicate candidates and computes removable-copy totals', () => {
     const result = presenterService.buildDuplicateScanResult({
       scannedModelCount: 3,
+      scannedFileCount: 5,
       groups: [
         {
           fingerprint: 'fingerprint',
@@ -626,12 +627,42 @@ describe('buildDuplicateScanResult', () => {
           ],
         },
       ],
+      fileGroups: [
+        {
+          hash: 'shared-file-hash',
+          files: [
+            {
+              id: 'old-file',
+              modelId: 'old-copy',
+              modelName: 'Original',
+              filename: 'dragon.stl',
+              relativePath: 'parts/dragon.stl',
+              sizeBytes: 40,
+              createdAt: new Date('2026-01-01T01:00:00.000Z'),
+              modelCreatedAt: new Date('2026-01-01T00:00:00.000Z'),
+            },
+            {
+              id: 'new-file',
+              modelId: 'other-model',
+              modelName: 'Other model',
+              filename: 'renamed.stl',
+              relativePath: 'renamed.stl',
+              sizeBytes: 40,
+              createdAt: new Date('2026-03-01T01:00:00.000Z'),
+              modelCreatedAt: new Date('2026-03-01T00:00:00.000Z'),
+            },
+          ],
+        },
+      ],
     });
 
     expect(result).toEqual({
       scannedModelCount: 3,
+      scannedFileCount: 5,
       redundantModelCount: 1,
+      redundantFileCount: 1,
       reclaimableBytes: 120,
+      fileReclaimableBytes: 40,
       groups: [
         {
           fingerprint: 'fingerprint',
@@ -650,6 +681,33 @@ describe('buildDuplicateScanResult', () => {
               name: 'Copy',
               originalFilename: 'copy.zip',
               createdAt: '2026-02-01T00:00:00.000Z',
+            },
+          ],
+        },
+      ],
+      fileGroups: [
+        {
+          hash: 'shared-file-hash',
+          sizeBytes: 40,
+          reclaimableBytes: 40,
+          files: [
+            {
+              id: 'old-file',
+              modelId: 'old-copy',
+              modelName: 'Original',
+              filename: 'dragon.stl',
+              relativePath: 'parts/dragon.stl',
+              sizeBytes: 40,
+              createdAt: '2026-01-01T01:00:00.000Z',
+            },
+            {
+              id: 'new-file',
+              modelId: 'other-model',
+              modelName: 'Other model',
+              filename: 'renamed.stl',
+              relativePath: 'renamed.stl',
+              sizeBytes: 40,
+              createdAt: '2026-03-01T01:00:00.000Z',
             },
           ],
         },

--- a/apps/backend/src/services/presenter.service.ts
+++ b/apps/backend/src/services/presenter.service.ts
@@ -110,11 +110,36 @@ export class PresenterService implements IPresenterService {
       };
     });
 
+    const fileGroups = scan.fileGroups.map((group) => {
+      const reclaimableBytes = group.files
+        .slice(1)
+        .reduce((sum, file) => sum + file.sizeBytes, 0);
+
+      return {
+        hash: group.hash,
+        sizeBytes: group.files[0].sizeBytes,
+        reclaimableBytes,
+        files: group.files.map((file) => ({
+          id: file.id,
+          modelId: file.modelId,
+          modelName: file.modelName,
+          filename: file.filename,
+          relativePath: file.relativePath,
+          sizeBytes: file.sizeBytes,
+          createdAt: file.createdAt.toISOString(),
+        })),
+      };
+    });
+
     return {
       scannedModelCount: scan.scannedModelCount,
+      scannedFileCount: scan.scannedFileCount,
       redundantModelCount: groups.reduce((sum, group) => sum + group.models.length - 1, 0),
+      redundantFileCount: fileGroups.reduce((sum, group) => sum + group.files.length - 1, 0),
       reclaimableBytes: groups.reduce((sum, group) => sum + group.reclaimableBytes, 0),
+      fileReclaimableBytes: fileGroups.reduce((sum, group) => sum + group.reclaimableBytes, 0),
       groups,
+      fileGroups,
     };
   }
 

--- a/apps/frontend/src/pages/ToolsPage.test.tsx
+++ b/apps/frontend/src/pages/ToolsPage.test.tsx
@@ -31,9 +31,39 @@ describe('ToolsPage', () => {
     expect(mockScanDuplicates).not.toHaveBeenCalled();
   });
 
-  it('shows matching models returned by the scanner', async () => {
+  it('leads with matching files and shows whole-model duplicates secondarily', async () => {
     mockScanDuplicates.mockResolvedValue({
       scannedModelCount: 3,
+      scannedFileCount: 8,
+      redundantFileCount: 1,
+      fileReclaimableBytes: 1024,
+      fileGroups: [
+        {
+          hash: 'matching-file',
+          sizeBytes: 1024,
+          reclaimableBytes: 1024,
+          files: [
+            {
+              id: 'file-2',
+              modelId: 'model-2',
+              modelName: 'Dragon copy',
+              filename: 'body-copy.stl',
+              relativePath: 'parts/body-copy.stl',
+              sizeBytes: 1024,
+              createdAt: '2025-02-01T00:00:00.000Z',
+            },
+            {
+              id: 'file-1',
+              modelId: 'model-1',
+              modelName: 'Dragon original',
+              filename: 'body.stl',
+              relativePath: 'meshes/body.stl',
+              sizeBytes: 1024,
+              createdAt: '2025-01-01T00:00:00.000Z',
+            },
+          ],
+        },
+      ],
       redundantModelCount: 1,
       reclaimableBytes: 2048,
       groups: [
@@ -43,8 +73,18 @@ describe('ToolsPage', () => {
           totalSizeBytes: 2048,
           reclaimableBytes: 2048,
           models: [
-            { id: 'model-1', name: 'Dragon original', originalFilename: 'dragon.zip', createdAt: '2025-01-01T00:00:00.000Z' },
-            { id: 'model-2', name: 'Dragon copy', originalFilename: 'copy.zip', createdAt: '2025-02-01T00:00:00.000Z' },
+            {
+              id: 'model-1',
+              name: 'Dragon original',
+              originalFilename: 'dragon.zip',
+              createdAt: '2025-01-01T00:00:00.000Z',
+            },
+            {
+              id: 'model-2',
+              name: 'Dragon copy',
+              originalFilename: 'copy.zip',
+              createdAt: '2025-02-01T00:00:00.000Z',
+            },
           ],
         },
       ],
@@ -53,10 +93,22 @@ describe('ToolsPage', () => {
     render(<ToolsPage />, { wrapper: makeWrapper() });
     fireEvent.click(screen.getByRole('button', { name: /scan library/i }));
 
-    await waitFor(() => expect(screen.getByText('Dragon original')).toBeTruthy());
-    expect(screen.getByText('Dragon copy')).toBeTruthy();
+    await waitFor(() => expect(screen.getByRole('heading', { name: 'Duplicate files' })).toBeTruthy());
+    expect(screen.getByText('body-copy.stl')).toBeTruthy();
+    expect(screen.getByText('meshes/body.stl')).toBeTruthy();
+    expect(
+      screen.getAllByRole('link', { name: 'Dragon original' })[0].getAttribute('href'),
+    ).toBe('/models/model-1');
+    expect(screen.getByText('Suggested keep').parentElement?.textContent).toContain('body.stl');
+    expect(screen.getByRole('heading', { name: 'Whole-model duplicates' })).toBeTruthy();
     expect(screen.getByText('Oldest copy')).toBeTruthy();
-    expect(screen.getAllByText(/2\.0 KB/).length).toBeGreaterThan(0);
+    expect(screen.getByText('Files scanned').nextElementSibling?.textContent).toBe('8');
+
+    const fileHeading = screen.getByRole('heading', { name: 'Duplicate files' });
+    const modelHeading = screen.getByRole('heading', { name: 'Whole-model duplicates' });
+    expect(
+      fileHeading.compareDocumentPosition(modelHeading) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
   });
 
   it('announces scan progress and completion', async () => {
@@ -73,19 +125,55 @@ describe('ToolsPage', () => {
 
     finishScan({
       scannedModelCount: 2,
+      scannedFileCount: 5,
+      redundantFileCount: 1,
+      fileReclaimableBytes: 100,
+      fileGroups: [
+        {
+          hash: 'same-file',
+          sizeBytes: 100,
+          reclaimableBytes: 100,
+          files: [
+            {
+              id: 'file-1',
+              modelId: 'model-1',
+              modelName: 'First model',
+              filename: 'part.stl',
+              relativePath: 'part.stl',
+              sizeBytes: 100,
+              createdAt: '2025-01-01T00:00:00.000Z',
+            },
+            {
+              id: 'file-2',
+              modelId: 'model-2',
+              modelName: 'Second model',
+              filename: 'part-copy.stl',
+              relativePath: 'copies/part-copy.stl',
+              sizeBytes: 100,
+              createdAt: '2025-02-01T00:00:00.000Z',
+            },
+          ],
+        },
+      ],
       redundantModelCount: 0,
       reclaimableBytes: 0,
       groups: [],
     });
 
     await waitFor(() => {
-      expect(screen.getByRole('status').textContent).toMatch(/scan complete/i);
+      expect(screen.getByRole('status').textContent).toMatch(
+        /found 1 duplicate file group with 1 redundant file/i,
+      );
     });
   });
 
-  it('shows a clear result when no duplicates are found', async () => {
+  it('shows a clear result only when no duplicate files or models are found', async () => {
     mockScanDuplicates.mockResolvedValue({
       scannedModelCount: 4,
+      scannedFileCount: 12,
+      redundantFileCount: 0,
+      fileReclaimableBytes: 0,
+      fileGroups: [],
       redundantModelCount: 0,
       reclaimableBytes: 0,
       groups: [],
@@ -94,7 +182,32 @@ describe('ToolsPage', () => {
     render(<ToolsPage />, { wrapper: makeWrapper() });
     fireEvent.click(screen.getByRole('button', { name: /scan library/i }));
 
-    await waitFor(() => expect(screen.getByText(/no duplicate models found/i)).toBeTruthy());
-    expect(screen.getByText(/compared 4 ready models with files/i)).toBeTruthy();
+    await waitFor(() => expect(screen.getByText(/no duplicate files or models found/i)).toBeTruthy());
+    expect(screen.getByText(/compared 12 files across 4 ready models/i)).toBeTruthy();
+  });
+
+  it('announces a failed rescan instead of the retained successful result', async () => {
+    mockScanDuplicates
+      .mockResolvedValueOnce({
+        scannedModelCount: 1,
+        scannedFileCount: 1,
+        redundantFileCount: 0,
+        fileReclaimableBytes: 0,
+        fileGroups: [],
+        redundantModelCount: 0,
+        reclaimableBytes: 0,
+        groups: [],
+      })
+      .mockRejectedValueOnce(new Error('scan failed'));
+
+    render(<ToolsPage />, { wrapper: makeWrapper() });
+    fireEvent.click(screen.getByRole('button', { name: /scan library/i }));
+    await waitFor(() => expect(screen.getByText(/no duplicate files or models found/i)).toBeTruthy());
+
+    fireEvent.click(screen.getByRole('button', { name: /scan again/i }));
+
+    await waitFor(() => expect(screen.getByRole('alert')).toBeTruthy());
+    expect(screen.getByRole('status').textContent).toMatch(/duplicate scan failed/i);
+    expect(screen.getByRole('status').textContent).not.toMatch(/scan complete/i);
   });
 });

--- a/apps/frontend/src/pages/ToolsPage.tsx
+++ b/apps/frontend/src/pages/ToolsPage.tsx
@@ -9,7 +9,7 @@ import {
   Wrench,
 } from 'lucide-react';
 import { Link } from 'react-router-dom';
-import type { DuplicateModel, DuplicateScanResult } from '@alexandria/shared';
+import type { DuplicateFile, DuplicateModel, DuplicateScanResult } from '@alexandria/shared';
 import { scanDuplicates } from '../api/tools';
 import { Badge } from '../components/ui/badge';
 import { Button } from '../components/ui/button';
@@ -57,8 +57,8 @@ export function ToolsPage() {
             <div>
               <h2 className="font-semibold text-foreground">Duplicate scanner</h2>
               <p className="mt-1 max-w-2xl text-sm text-muted-foreground">
-                Find ready models with identical file contents. File names and folder layout do
-                not affect matching.
+                Find individual files with identical contents and ready models with identical
+                file sets. File names and folder layout do not affect matching.
               </p>
             </div>
           </div>
@@ -77,10 +77,12 @@ export function ToolsPage() {
         <div className="p-5">
           <p role="status" aria-live="polite" className="sr-only">
             {scan.isFetching
-              ? 'Scanning library for duplicate models.'
-              : scan.data
-                ? `Scan complete. Found ${scan.data.groups.length} duplicate groups and ${scan.data.redundantModelCount} redundant copies.`
-                : ''}
+              ? 'Scanning library for duplicate files and models.'
+              : scan.isError
+                ? 'The duplicate scan failed.'
+                : scan.data
+                  ? duplicateScanAnnouncement(scan.data)
+                  : ''}
           </p>
           {scan.isFetching && !scan.data ? (
             <div className="flex flex-col items-center justify-center gap-3 py-12 text-center">
@@ -88,7 +90,7 @@ export function ToolsPage() {
               <div>
                 <p className="text-sm font-medium text-foreground">Scanning library…</p>
                 <p className="mt-1 text-sm text-muted-foreground">
-                  Comparing the complete file contents of each eligible model.
+                  Comparing individual file contents and complete model file sets.
                 </p>
               </div>
             </div>
@@ -118,16 +120,34 @@ export function ToolsPage() {
   );
 }
 
+function duplicateScanAnnouncement(result: DuplicateScanResult): string {
+  const fileGroups = countPhrase(result.fileGroups.length, 'duplicate file group');
+  const redundantFiles = countPhrase(result.redundantFileCount, 'redundant file');
+  const modelGroups = countPhrase(result.groups.length, 'duplicate model group');
+  const redundantModels = countPhrase(result.redundantModelCount, 'redundant model');
+
+  return `Scan complete. Found ${fileGroups} with ${redundantFiles}, and ${modelGroups} with ${redundantModels}.`;
+}
+
+function countPhrase(count: number, singular: string): string {
+  return `${count.toLocaleString()} ${singular}${count === 1 ? '' : 's'}`;
+}
+
 function DuplicateResults({ result }: { result: DuplicateScanResult }) {
-  if (result.groups.length === 0) {
+  const hasDuplicateFiles = result.fileGroups.length > 0;
+  const hasDuplicateModels = result.groups.length > 0;
+
+  if (!hasDuplicateFiles && !hasDuplicateModels) {
     return (
       <div className="flex flex-col items-center justify-center gap-3 py-10 text-center">
         <CheckCircle2 className="h-9 w-9 text-emerald-600" />
         <div>
-          <p className="font-medium text-foreground">No duplicate models found</p>
+          <p className="font-medium text-foreground">No duplicate files or models found</p>
           <p className="mt-1 text-sm text-muted-foreground">
-            Compared {result.scannedModelCount}{' '}
-            {result.scannedModelCount === 1 ? 'ready model with files' : 'ready models with files'}.
+            Compared {result.scannedFileCount.toLocaleString()}{' '}
+            {result.scannedFileCount === 1 ? 'file' : 'files'} across{' '}
+            {result.scannedModelCount.toLocaleString()}{' '}
+            {result.scannedModelCount === 1 ? 'ready model' : 'ready models'}.
           </p>
         </div>
       </div>
@@ -136,39 +156,124 @@ function DuplicateResults({ result }: { result: DuplicateScanResult }) {
 
   return (
     <div className="flex flex-col gap-6">
-      <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
-        <ScanStat label="Models scanned" value={result.scannedModelCount.toLocaleString()} />
-        <ScanStat label="Duplicate groups" value={result.groups.length.toLocaleString()} />
-        <ScanStat label="Redundant copies" value={result.redundantModelCount.toLocaleString()} />
-        <ScanStat label="Potential savings" value={formatFileSize(result.reclaimableBytes)} />
-      </div>
+      <section aria-labelledby="duplicate-files-heading" className="flex flex-col gap-4">
+        <div>
+          <h2 id="duplicate-files-heading" className="text-base font-semibold text-foreground">
+            Duplicate files
+          </h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Exact file matches across the library, regardless of their names or locations.
+          </p>
+        </div>
 
-      <div className="flex flex-col gap-4">
-        {result.groups.map((group, index) => (
-          <div key={group.fingerprint} className="overflow-hidden rounded-lg border">
-            <div className="flex flex-col gap-1 border-b bg-muted/30 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
-              <div>
-                <h3 className="text-sm font-semibold text-foreground">Duplicate set {index + 1}</h3>
-                <p className="text-xs text-muted-foreground">
-                  {group.fileCount} {group.fileCount === 1 ? 'file' : 'files'} per model ·{' '}
-                  {formatFileSize(group.totalSizeBytes)} each
-                </p>
-              </div>
-              <Badge variant="outline">
-                {group.models.length} identical models · {formatFileSize(group.reclaimableBytes)} reclaimable
-              </Badge>
-            </div>
-            <div className="divide-y">
-              {group.models.map((model, modelIndex) => (
-                <DuplicateModelRow key={model.id} model={model} suggestedKeep={modelIndex === 0} />
-              ))}
-            </div>
+        <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+          <ScanStat label="Files scanned" value={result.scannedFileCount.toLocaleString()} />
+          <ScanStat label="Duplicate file groups" value={result.fileGroups.length.toLocaleString()} />
+          <ScanStat label="Redundant files" value={result.redundantFileCount.toLocaleString()} />
+          <ScanStat label="File savings" value={formatFileSize(result.fileReclaimableBytes)} />
+        </div>
+
+        {hasDuplicateFiles ? (
+          <div className="flex flex-col gap-4">
+            {result.fileGroups.map((group, index) => {
+              const oldestFileId = group.files.reduce((oldest, file) =>
+                new Date(file.createdAt).getTime() < new Date(oldest.createdAt).getTime()
+                  ? file
+                  : oldest,
+              ).id;
+
+              return (
+                <div key={group.hash} className="overflow-hidden rounded-lg border">
+                  <div className="flex flex-col gap-1 border-b bg-muted/30 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
+                    <div>
+                      <h3 className="text-sm font-semibold text-foreground">
+                        Duplicate file set {index + 1}
+                      </h3>
+                      <p className="text-xs text-muted-foreground">
+                        {group.files.length} identical files · {formatFileSize(group.sizeBytes)} each
+                      </p>
+                    </div>
+                    <Badge variant="outline">
+                      {formatFileSize(group.reclaimableBytes)} reclaimable
+                    </Badge>
+                  </div>
+                  <div className="divide-y">
+                    {group.files.map((file) => (
+                      <DuplicateFileRow
+                        key={file.id}
+                        file={file}
+                        suggestedKeep={file.id === oldestFileId}
+                      />
+                    ))}
+                  </div>
+                </div>
+              );
+            })}
           </div>
-        ))}
-      </div>
+        ) : (
+          <p className="rounded-lg border bg-muted/20 px-4 py-3 text-sm text-muted-foreground">
+            No individual duplicate files were found.
+          </p>
+        )}
+      </section>
+
+      {hasDuplicateModels && (
+        <section
+          aria-labelledby="duplicate-models-heading"
+          className="flex flex-col gap-4 border-t pt-6"
+        >
+          <div>
+            <h2 id="duplicate-models-heading" className="text-base font-semibold text-foreground">
+              Whole-model duplicates
+            </h2>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Ready models whose complete file sets match exactly.
+            </p>
+          </div>
+
+          <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+            <ScanStat label="Models scanned" value={result.scannedModelCount.toLocaleString()} />
+            <ScanStat label="Duplicate model groups" value={result.groups.length.toLocaleString()} />
+            <ScanStat label="Redundant models" value={result.redundantModelCount.toLocaleString()} />
+            <ScanStat label="Model savings" value={formatFileSize(result.reclaimableBytes)} />
+          </div>
+
+          <div className="flex flex-col gap-4">
+            {result.groups.map((group, index) => (
+              <div key={group.fingerprint} className="overflow-hidden rounded-lg border">
+                <div className="flex flex-col gap-1 border-b bg-muted/30 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
+                  <div>
+                    <h3 className="text-sm font-semibold text-foreground">
+                      Duplicate model set {index + 1}
+                    </h3>
+                    <p className="text-xs text-muted-foreground">
+                      {group.fileCount} {group.fileCount === 1 ? 'file' : 'files'} per model ·{' '}
+                      {formatFileSize(group.totalSizeBytes)} each
+                    </p>
+                  </div>
+                  <Badge variant="outline">
+                    {group.models.length} identical models ·{' '}
+                    {formatFileSize(group.reclaimableBytes)} reclaimable
+                  </Badge>
+                </div>
+                <div className="divide-y">
+                  {group.models.map((model, modelIndex) => (
+                    <DuplicateModelRow
+                      key={model.id}
+                      model={model}
+                      suggestedKeep={modelIndex === 0}
+                    />
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
 
       <p className="text-xs text-muted-foreground">
-        Results are informational. Review model metadata and collections before deleting a copy.
+        Results are informational. Review file locations, model metadata, and collections before
+        deleting a copy.
       </p>
     </div>
   );
@@ -179,6 +284,45 @@ function ScanStat({ label, value }: { label: string; value: string }) {
     <div className="rounded-lg border bg-muted/20 p-3">
       <p className="text-xs text-muted-foreground">{label}</p>
       <p className="mt-1 text-lg font-semibold text-foreground">{value}</p>
+    </div>
+  );
+}
+
+function DuplicateFileRow({
+  file,
+  suggestedKeep,
+}: {
+  file: DuplicateFile;
+  suggestedKeep: boolean;
+}) {
+  const libPath = useLibraryPath();
+
+  return (
+    <div className="flex flex-col gap-2 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
+      <div className="min-w-0">
+        <div className="flex items-center gap-2">
+          <p className="truncate text-sm font-medium text-foreground">{file.filename}</p>
+          {suggestedKeep && (
+            <Badge variant="secondary" title="Oldest file in this duplicate set">
+              Suggested keep
+            </Badge>
+          )}
+        </div>
+        <p className="mt-0.5 truncate font-mono text-xs text-muted-foreground" title={file.relativePath}>
+          {file.relativePath}
+        </p>
+      </div>
+      <div className="flex shrink-0 flex-col items-start sm:items-end">
+        <Link
+          to={libPath(`/models/${file.modelId}`)}
+          className="text-sm font-medium text-foreground hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          {file.modelName}
+        </Link>
+        <span className="whitespace-nowrap text-xs text-muted-foreground">
+          Added {formatDate(file.createdAt)}
+        </span>
+      </div>
     </div>
   );
 }

--- a/docs/API.md
+++ b/docs/API.md
@@ -1474,13 +1474,13 @@ Tools are library maintenance operations exposed from the library-scoped Tools p
 
 ### GET /tools/duplicates
 
-Scan the active library for exact duplicate model contents. The scan is read-only and synchronous; it reports candidates but does not merge, delete, or otherwise modify models or files.
+Scan the active library for exact duplicate files and exact duplicate model contents. The scan is read-only and synchronous; it reports candidates but does not merge, delete, or otherwise modify models or files.
 
 **Auth required:** Yes. The route applies `requireAuth` followed by `requireLibrary`.
 
 **Library scope:** Required. `X-Library-Id` selects the active owned library; when the header is absent, the user's default library is used. An unknown or un-owned library returns `404 NOT_FOUND`.
 
-Only `ready` models with at least one file are scanned. Two models are duplicates only when their complete sorted multisets of per-file SHA-256 hashes match. Sorting makes file order irrelevant, while treating the hashes as a multiset preserves multiplicity: a model containing two copies of a file does not match a model containing one copy. Filenames and relative paths do not participate in matching.
+Only `ready` models with at least one file are scanned. PostgreSQL aggregates each eligible model's file hashes into one model row and returns individual file detail only for hashes that occur more than once in the same library/status scope. Individual files are duplicates when their SHA-256 hashes match. Two models are duplicates only when their complete sorted multisets of per-file SHA-256 hashes match. Sorting makes file order irrelevant, while treating the hashes as a multiset preserves multiplicity: a model containing two copies of a file does not match a model containing one copy. Filenames and relative paths do not participate in either comparison.
 
 **Response (200):**
 
@@ -1488,26 +1488,90 @@ Only `ready` models with at least one file are scanned. Two models are duplicate
 {
   "data": {
     "scannedModelCount": 3,
+    "scannedFileCount": 6,
     "redundantModelCount": 1,
-    "reclaimableBytes": 8388608,
+    "redundantFileCount": 3,
+    "reclaimableBytes": 1000,
+    "fileReclaimableBytes": 1100,
     "groups": [
       {
         "fingerprint": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-        "fileCount": 4,
-        "totalSizeBytes": 8388608,
-        "reclaimableBytes": 8388608,
+        "fileCount": 2,
+        "totalSizeBytes": 1000,
+        "reclaimableBytes": 1000,
         "models": [
           {
-            "id": "uuid",
+            "id": "11111111-1111-4111-8111-111111111111",
             "name": "Dragon Bust",
             "originalFilename": "dragon-bust.zip",
             "createdAt": "2026-01-15T10:30:00.000Z"
           },
           {
-            "id": "uuid",
+            "id": "22222222-2222-4222-8222-222222222222",
             "name": "Dragon Bust Copy",
             "originalFilename": "renamed-copy.zip",
             "createdAt": "2026-02-01T12:00:00.000Z"
+          }
+        ]
+      }
+    ],
+    "fileGroups": [
+      {
+        "hash": "1111111111111111111111111111111111111111111111111111111111111111",
+        "sizeBytes": 100,
+        "reclaimableBytes": 200,
+        "files": [
+          {
+            "id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1",
+            "modelId": "11111111-1111-4111-8111-111111111111",
+            "modelName": "Dragon Bust",
+            "filename": "dragon-head.stl",
+            "relativePath": "parts/dragon-head.stl",
+            "sizeBytes": 100,
+            "createdAt": "2026-01-15T10:31:00.000Z"
+          },
+          {
+            "id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa2",
+            "modelId": "22222222-2222-4222-8222-222222222222",
+            "modelName": "Dragon Bust Copy",
+            "filename": "renamed-head.stl",
+            "relativePath": "renamed-head.stl",
+            "sizeBytes": 100,
+            "createdAt": "2026-02-01T12:01:00.000Z"
+          },
+          {
+            "id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa3",
+            "modelId": "33333333-3333-4333-8333-333333333333",
+            "modelName": "Dragon Bust Variant",
+            "filename": "dragon-head.stl",
+            "relativePath": "variant/dragon-head.stl",
+            "sizeBytes": 100,
+            "createdAt": "2026-03-01T09:01:00.000Z"
+          }
+        ]
+      },
+      {
+        "hash": "2222222222222222222222222222222222222222222222222222222222222222",
+        "sizeBytes": 900,
+        "reclaimableBytes": 900,
+        "files": [
+          {
+            "id": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb1",
+            "modelId": "11111111-1111-4111-8111-111111111111",
+            "modelName": "Dragon Bust",
+            "filename": "dragon-base.stl",
+            "relativePath": "parts/dragon-base.stl",
+            "sizeBytes": 900,
+            "createdAt": "2026-01-15T10:32:00.000Z"
+          },
+          {
+            "id": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb2",
+            "modelId": "22222222-2222-4222-8222-222222222222",
+            "modelName": "Dragon Bust Copy",
+            "filename": "base-copy.stl",
+            "relativePath": "base-copy.stl",
+            "sizeBytes": 900,
+            "createdAt": "2026-02-01T12:02:00.000Z"
           }
         ]
       }
@@ -1518,7 +1582,11 @@ Only `ready` models with at least one file are scanned. Two models are duplicate
 }
 ```
 
-`data` is a `DuplicateScanResult`; each member of `groups` is a `DuplicateGroup`, whose `models` are `DuplicateModel` values. The fingerprint is the SHA-256 digest of the encoded sorted file-hash multiset and should be treated as an opaque group identifier. Models within a group are oldest-first, with UUID as the equal-timestamp tie-breaker; groups are likewise ordered by their oldest model. `scannedModelCount` counts eligible models whether or not they belong to a duplicate group. `redundantModelCount` counts duplicate copies beyond the oldest model in each group. Group and scan `reclaimableBytes` sum the stored sizes of those later copies; `totalSizeBytes` is the oldest model's stored total. These values are estimates only—the decision and any deletion remain manual.
+`data` is a `DuplicateScanResult`. Each member of `groups` is a `DuplicateGroup`, whose `models` are `DuplicateModel` values. The fingerprint is the SHA-256 digest of the encoded sorted file-hash multiset and should be treated as an opaque group identifier. Models within a group are oldest-first, with UUID as the equal-timestamp tie-breaker; groups are likewise ordered by their oldest model. `scannedModelCount` counts eligible models whether or not they belong to a duplicate group. `redundantModelCount` counts duplicate copies beyond the oldest model in each group. Group and scan `reclaimableBytes` sum the stored sizes of those later copies; `totalSizeBytes` is the oldest model's stored total.
+
+Each member of `fileGroups` is a `DuplicateFileGroup`, whose `files` are `DuplicateFile` values. `scannedFileCount` counts all files read from eligible models. Within a file group, candidates are ordered by file creation time and file UUID, with owning model creation time and model UUID as later tie-breakers. `sizeBytes` is the oldest candidate's stored size, while `reclaimableBytes` sums every later candidate's size. `redundantFileCount` and `fileReclaimableBytes` aggregate those later candidates across all file groups. File groups are ordered by their oldest file's creation time, then hash and oldest file UUID.
+
+The example's `Dragon Bust Variant` has one file identical to both whole-model copies but different remaining content, so it appears in a file group without joining the whole-model group. File-level savings are independent from and may overlap whole-model savings; do not add `fileReclaimableBytes` to `reclaimableBytes`. All byte values are estimates only—the decision and any deletion remain manual.
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -351,11 +351,13 @@ On startup, S3 mode performs `HeadBucket` validation before database migration a
 
 ### DuplicateScannerService
 
-**Owns:** Read-only detection and reporting of exact duplicate models within one authenticated user's active library.
+**Owns:** Read-only detection and reporting of exact duplicate files and exact duplicate models within one authenticated user's active library.
 
 **Does not own:** File hashing, model deletion, model merging, or any other mutation.
 
-**Behavior:** `scanDuplicates(libraryId)` considers only `ready` models that have at least one file. The route supplies the ownership-checked `request.libraryId` produced by `requireLibrary`. PostgreSQL aggregates the ordered file-hash multiset into one row per model before results cross the database boundary, and concurrent requests for the same library share one in-flight scan. Sorting makes file order irrelevant while preserving repeated hashes, so a model containing the same file twice does not match one containing it once. Filenames and relative paths do not participate in matching. Only identities shared by at least two models are returned. PresenterService formats timestamps and assembles per-group and aggregate counts and reclaimable-byte estimates. The operation is report-only and never changes models or files.
+**Behavior:** `scanDuplicates(libraryId)` considers only `ready` models that have at least one file. The route supplies the ownership-checked `request.libraryId` produced by `requireLibrary`, and concurrent requests for the same library share one in-flight scan. PostgreSQL aggregates every eligible model's complete sorted multiset of file hashes into one row per model; a second query returns file detail only for hashes that occur more than once in the same scope. This bounds transferred and retained detail to actual duplicate-file candidates instead of every stored file. Whole-model identity remains independent of file order while preserving repeated hashes: a model containing the same file twice does not match one containing it once. Filenames and relative paths participate in neither form of matching, and only file hashes or whole-model identities shared by at least two candidates are returned.
+
+File candidates are ordered by file creation time and file UUID, with owning-model creation time and model UUID as later tie-breakers. File groups are ordered by their oldest file's creation time, then hash and oldest file UUID. Whole-model candidates remain oldest-first by model creation time and UUID, and whole-model groups are ordered by their oldest model, with fingerprint as the final tie-breaker. PresenterService formats timestamps and assembles per-group and aggregate counts and two independent reclaimable-byte estimates. File-level savings can overlap whole-model savings, so clients must not add `fileReclaimableBytes` to `reclaimableBytes`. The operation is report-only and never changes models or files.
 
 ### ModelService
 
@@ -480,7 +482,7 @@ Provider base URLs are user-configured and contacted from the backend, so they a
 - `buildCollectionDetail(collection)` → collection with children and model count
 - `buildCollectionList(userId, params)` → all collections for a user, with optional depth expansion
 - `buildMetadataFieldList(fields)` → field definitions with value counts
-- `buildDuplicateScanResult(scan)` → duplicate groups, summary counts, and reclaimable-byte estimates
+- `buildDuplicateScanResult(scan)` → whole-model and file duplicate groups, summary counts, and independent reclaimable-byte estimates
 
 ---
 
@@ -759,7 +761,7 @@ All provider routes apply `requireAuth` and enforce provider ownership in `AiPro
 **Tools**
 | Method | Route | Purpose | Service Chain | Library-scoped |
 |--------|-------|---------|---------------|---------------|
-| GET | /tools/duplicates | Report ready models with identical complete file-hash multisets | DuplicateScannerService → PresenterService | Yes |
+| GET | /tools/duplicates | Report exact duplicate files and ready models with identical complete file-hash multisets | DuplicateScannerService → PresenterService | Yes |
 
 **Bulk Operations**
 | Method | Route | Purpose | Service Chain | Library-scoped |

--- a/docs/TYPES.md
+++ b/docs/TYPES.md
@@ -531,15 +531,38 @@ interface DuplicateGroup {
   models: DuplicateModel[];  // oldest first; UUID breaks equal-timestamp ties
 }
 
+interface DuplicateFile {
+  id: string;
+  modelId: string;
+  modelName: string;
+  filename: string;
+  relativePath: string;
+  sizeBytes: number;
+  createdAt: string;
+}
+
+interface DuplicateFileGroup {
+  hash: string;                // exact SHA-256 shared by every file in the group
+  sizeBytes: number;           // stored size of the oldest file candidate
+  reclaimableBytes: number;    // summed sizes of every later file candidate
+  files: DuplicateFile[];
+}
+
 interface DuplicateScanResult {
   scannedModelCount: number;   // ready, non-empty models considered
+  scannedFileCount: number;    // files read from those models
   redundantModelCount: number; // duplicate copies beyond the oldest model in each group
+  redundantFileCount: number;  // duplicate files beyond the oldest file in each group
   reclaimableBytes: number;
+  fileReclaimableBytes: number;
   groups: DuplicateGroup[];
+  fileGroups: DuplicateFileGroup[];
 }
 ```
 
-Duplicate identity uses the complete sorted multiset of per-file SHA-256 hashes. File order, filenames, and relative paths are ignored, but hash multiplicity is preserved. Models that are not `ready` or contain no files are excluded. Groups are ordered by their oldest model, using model UUID and then fingerprint as deterministic tie-breakers. These response types describe a report only; scanning does not delete, merge, or otherwise modify a model.
+PostgreSQL aggregates each `ready`, non-empty model's file hashes into one model row and returns file detail only for hashes that occur more than once in the same scope. Individual file identity is exact SHA-256 equality. Whole-model identity uses the complete sorted multiset of per-file SHA-256 hashes. File order, filenames, and relative paths are ignored, but hash multiplicity is preserved. Models that are not `ready` or contain no files are excluded.
+
+Files within a `DuplicateFileGroup` are ordered by file creation time and file UUID, with owning model creation time and model UUID as later tie-breakers. File groups are ordered by their oldest file's creation time, then hash and oldest file UUID. Models within a `DuplicateGroup` are ordered by creation time and UUID; whole-model groups are ordered by their oldest model, with fingerprint as the final tie-breaker. `fileReclaimableBytes` is independent from `reclaimableBytes` and can describe some of the same stored data, so the two estimates must not be added together. These response types describe a report only; scanning does not delete, merge, or otherwise modify a model or file.
 
 ### Metadata Response Types
 

--- a/packages/shared/src/types/tools.ts
+++ b/packages/shared/src/types/tools.ts
@@ -13,9 +13,30 @@ export interface DuplicateGroup {
   models: DuplicateModel[];
 }
 
+export interface DuplicateFile {
+  id: string;
+  modelId: string;
+  modelName: string;
+  filename: string;
+  relativePath: string;
+  sizeBytes: number;
+  createdAt: string;
+}
+
+export interface DuplicateFileGroup {
+  hash: string;
+  sizeBytes: number;
+  reclaimableBytes: number;
+  files: DuplicateFile[];
+}
+
 export interface DuplicateScanResult {
   scannedModelCount: number;
+  scannedFileCount: number;
   redundantModelCount: number;
+  redundantFileCount: number;
   reclaimableBytes: number;
+  fileReclaimableBytes: number;
   groups: DuplicateGroup[];
+  fileGroups: DuplicateFileGroup[];
 }


### PR DESCRIPTION
## What changed

- detect exact duplicate files by SHA-256 across and within ready models
- keep the existing whole-model duplicate groups as a secondary report
- add file-level counts, candidates, paths, owning model links, and reclaimable-byte estimates to the shared API contract
- lead the Tools page with duplicate-file results and preserve accessible scan state announcements
- document the additive API, ordering, scoping, and overlapping savings estimates

## Why

The scanner previously compared only each model's complete file-hash multiset. It could identify two entirely identical models, but it missed an individual duplicate file when the surrounding models contained different files.

## Implementation notes

PostgreSQL still aggregates complete hash multisets into one row per eligible model. A second scoped query returns detail only for hashes that occur more than once, avoiding transfer and retention of unique-file detail. The operation remains read-only.

## Validation

- `npm test` (915 backend tests; frontend suite successful/cached)
- `npm run build`
- `npm run lint`
- focused duplicate scanner, route integration, presenter, and Tools page tests
- reviewer pass; findings for rescan announcements and unique-file materialization were addressed
