### PR TITLE
docs: streamline review workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,8 +125,14 @@ already have and usually costs more than it returns.
 
 When delegating, hand over only the relevant architecture section, types, and source files.
 
-Run `reviewer` at the end of a feature or a non-trivial fix — not for a typo or a one-line change.
-Run `documentation` when a change alters an endpoint, a type contract, or the architecture.
+Run `reviewer` once at the end of a feature or a non-trivial fix, after implementation, tests, and
+documentation are stable — not for a typo or a one-line change. Treat its findings as one
+consolidated correction pass; do not automatically run another full review after every fix.
+Request at most one targeted follow-up review only when the correction materially changes a
+security boundary, concurrency behavior, data integrity, architecture, or a public type/API
+contract, or when the reviewer explicitly could not validate the original issue without it.
+
+Run `documentation` once, after endpoint, type-contract, or architecture changes have settled.
 
 ---
 


### PR DESCRIPTION
## Summary

- run one consolidated reviewer pass only after implementation, tests, and docs are stable
- avoid automatic full re-reviews after each correction
- allow at most one targeted follow-up for materially risky changes or findings that could not previously be validated
- run documentation review once contracts and architecture changes have settled

## Why

The previous wording required a final review but did not constrain follow-up reviews, which allowed thorough work to expand into repeated review/fix cycles. This keeps the safety net while making the default workflow substantially faster.

## Validation

- inspected the resulting workflow text
- `git diff --check`
