### PR TITLE
Add manual preview Smart Collection rule

### DIFF
--- a/apps/backend/src/routes/smart-collections.test.ts
+++ b/apps/backend/src/routes/smart-collections.test.ts
@@ -13,6 +13,7 @@
  *   over-deep tree → 400.
  * - Status-default regression: tree without status → only ready models; a tree
  *   whose rule references status='processing' surfaces processing models.
+ * - Manual-preview rules: exists/notExists distinguish pinned previews from fallback images.
  * - Library isolation: a model in another library never appears.
  * - Auth guard: no cookie → 401.
  */
@@ -151,6 +152,36 @@ beforeAll(async () => {
     sizeBytes: 1000,
     storagePath: `models/${dragonModelId}/dragon.stl`,
     hash: 'a'.repeat(64),
+  });
+
+  const [dragonPreview] = await db
+    .insert(modelFiles)
+    .values({
+      modelId: dragonModelId,
+      filename: 'dragon-preview.png',
+      relativePath: 'dragon-preview.png',
+      fileType: 'image',
+      mimeType: 'image/png',
+      sizeBytes: 2000,
+      storagePath: `models/${dragonModelId}/dragon-preview.png`,
+      hash: 'b'.repeat(64),
+    })
+    .returning();
+  await db
+    .update(models)
+    .set({ previewImageFileId: dragonPreview.id })
+    .where(eq(models.id, dragonModelId));
+
+  // This image supplies a fallback preview, but is intentionally not pinned.
+  await db.insert(modelFiles).values({
+    modelId: modelIds[1],
+    filename: 'fantasy-preview.png',
+    relativePath: 'fantasy-preview.png',
+    fileType: 'image',
+    mimeType: 'image/png',
+    sizeBytes: 2000,
+    storagePath: `models/${modelIds[1]}/fantasy-preview.png`,
+    hash: 'c'.repeat(64),
   });
 
   // Dragon tag on the dragon model
@@ -326,6 +357,47 @@ describe('POST /smart-collections/preview — dry run', () => {
     const body = res.json();
     // empty root = match all READY models in the library (2 of 3; one is processing)
     expect(body.meta.total).toBe(2);
+  });
+});
+
+describe('manual preview rules', () => {
+  it('should return only models with a manually set preview when using exists', async () => {
+    const res = await authedPost('/smart-collections/preview', {
+      definition: {
+        kind: 'condition',
+        field: { source: 'builtin', field: 'manualPreview' },
+        operator: 'exists',
+        value: null,
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.errors).toBeNull();
+    expect(body.meta.total).toBe(1);
+    expect(body.data.map((model: { id: string }) => model.id)).toEqual([dragonModelId]);
+  });
+
+  it('should include a model with only a fallback image when using notExists', async () => {
+    const createRes = await authedPost('/smart-collections', {
+      name: 'Models without manual previews',
+      definition: {
+        kind: 'condition',
+        field: { source: 'builtin', field: 'manualPreview' },
+        operator: 'notExists',
+        value: null,
+      },
+    });
+
+    expect(createRes.statusCode).toBe(201);
+    expect(createRes.json().data.modelCount).toBe(1);
+
+    const res = await authedGet(`/smart-collections/${createRes.json().data.id}/models`);
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.errors).toBeNull();
+    expect(body.meta.total).toBe(1);
+    expect(body.data.map((model: { id: string }) => model.id)).toEqual([modelIds[1]]);
   });
 });
 

--- a/apps/backend/src/services/rule-engine.test.ts
+++ b/apps/backend/src/services/rule-engine.test.ts
@@ -68,6 +68,15 @@ describe('buildLeafCondition — builtin fields', () => {
     expect(renderLeaf(cond(builtin('status'), 'isNot', 'ready')).sql).toContain('<>');
   });
 
+  it('manualPreview/exists and notExists check for an explicitly pinned cover', () => {
+    expect(renderLeaf(cond(builtin('manualPreview'), 'exists')).sql).toContain(
+      '"preview_image_file_id" IS NOT NULL',
+    );
+    expect(renderLeaf(cond(builtin('manualPreview'), 'notExists')).sql).toContain(
+      '"preview_image_file_id" IS NULL',
+    );
+  });
+
   it('fileType/has is an EXISTS subquery; notHas negates it', () => {
     const has = renderLeaf(cond(builtin('fileType'), 'has', 'stl'));
     expect(has.sql).toContain('EXISTS');

--- a/apps/backend/src/services/rule-engine.ts
+++ b/apps/backend/src/services/rule-engine.ts
@@ -13,10 +13,10 @@ import { validationError } from '../utils/errors.js';
 // build its own conditions via `buildLeafCondition` too, so there is a single
 // source of truth for "what SQL a filter on dimension X looks like".
 //
-// The compiler is pure: no I/O, no DB access, no context needed. All v1
-// operators are text comparisons, so it never needs a metadata field's type to
-// emit SQL. Validation that a field exists and that its operator is legal for
-// its type happens in SmartCollectionService before compilation.
+// The compiler is pure: no I/O, no DB access, no context needed. It never needs
+// a metadata field's type to emit SQL. Validation that a field exists and that
+// its operator is legal for its type happens in SmartCollectionService before
+// compilation.
 // ---------------------------------------------------------------------------
 
 /**
@@ -92,6 +92,12 @@ function buildBuiltinCondition(leaf: RuleCondition): SQL {
     case 'status': {
       if (op === 'is') return sql`${models.status} = ${requireValue(leaf)}`;
       if (op === 'isNot') return sql`${models.status} <> ${requireValue(leaf)}`;
+      return illegal(leaf);
+    }
+
+    case 'manualPreview': {
+      if (op === 'exists') return sql`${models.previewImageFileId} IS NOT NULL`;
+      if (op === 'notExists') return sql`${models.previewImageFileId} IS NULL`;
       return illegal(leaf);
     }
 

--- a/apps/frontend/src/components/smart/ConditionRow.test.tsx
+++ b/apps/frontend/src/components/smart/ConditionRow.test.tsx
@@ -1,0 +1,66 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { DraftCondition } from '../../hooks/use-smart-collection-draft';
+import { ConditionRow } from './ConditionRow';
+
+const manualPreviewField = 'manualPreview';
+
+function makeNode(overrides: Partial<DraftCondition> = {}): DraftCondition {
+  return {
+    _id: 'condition-1',
+    kind: 'condition',
+    field: { source: 'builtin', field: 'name' },
+    operator: 'contains',
+    value: '',
+    ...overrides,
+  };
+}
+
+describe('ConditionRow', () => {
+  it('should clear the value when manually set preview is selected', () => {
+    const onChange = vi.fn();
+    render(
+      <ConditionRow
+        node={makeNode()}
+        fields={[]}
+        onChange={onChange}
+        onRemove={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByRole('combobox', { name: 'Field' }), {
+      target: { value: 'builtin:manualPreview' },
+    });
+
+    expect(onChange).toHaveBeenCalledWith({
+      field: { source: 'builtin', field: manualPreviewField },
+      operator: 'exists',
+      value: null,
+    });
+  });
+
+  it('should offer only presence operators without a value input for manually set preview', () => {
+    render(
+      <ConditionRow
+        node={makeNode({
+          field: { source: 'builtin', field: manualPreviewField },
+          operator: 'exists',
+          value: null,
+        })}
+        fields={[]}
+        onChange={vi.fn()}
+        onRemove={vi.fn()}
+      />,
+    );
+
+    const fieldPicker = screen.getByRole('combobox', { name: 'Field' });
+    expect(fieldPicker).toHaveDisplayValue('Manually set preview');
+
+    const operatorPicker = screen.getByRole('combobox', { name: 'Operator' });
+    expect(operatorPicker).toHaveTextContent('is set');
+    expect(operatorPicker).toHaveTextContent('is not set');
+    expect(operatorPicker.querySelectorAll('option')).toHaveLength(2);
+    expect(screen.getAllByRole('combobox')).toHaveLength(2);
+    expect(screen.queryByRole('textbox', { name: 'Value' })).not.toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/components/smart/ConditionRow.tsx
+++ b/apps/frontend/src/components/smart/ConditionRow.tsx
@@ -19,12 +19,13 @@ import type { DraftCondition } from '../../hooks/use-smart-collection-draft';
 
 // Builtin fields exposed in the composer. `collection` is supported by the rule
 // engine but omitted here in v1 (it needs a collection picker, not a raw id).
-const BUILTIN_FIELD_OPTIONS: { field: string; label: string }[] = [
+const BUILTIN_FIELD_OPTIONS: { field: BuiltinRuleField; label: string }[] = [
   { field: 'name', label: 'Name' },
   { field: 'description', label: 'Description' },
   { field: 'tag', label: 'Tag' },
   { field: 'status', label: 'Status' },
   { field: 'fileType', label: 'File type' },
+  { field: 'manualPreview', label: 'Manually set preview' },
 ];
 
 const OPERATOR_LABELS: Record<RuleOperator, string> = {

--- a/docs/API.md
+++ b/docs/API.md
@@ -2090,7 +2090,20 @@ Create a smart collection.
 | `description` | string (optional) | Maximum 2000 characters |
 | `definition` | RuleNode | Required; a valid rule tree (see below) |
 
-**Rule tree validation:** The tree must not exceed depth 3 (group nesting), 50 total nodes, or 20 children per group. A bare condition or an empty root group (`{ kind: "group", op: "and", children: [] }`) is valid. For leaf conditions: the operator must be legal for the field (e.g., `contains` and `equals` for `name`; `hasTag`/`notHasTag` for `tag`). Operators `exists` and `notExists` take a null value; all others require a non-empty string. Metadata field slugs are validated server-side against the live field definitions; unknown slugs return `400`.
+**Rule tree validation:** The tree must not exceed depth 3 (group nesting), 50 total nodes, or 20 children per group. A bare condition or an empty root group (`{ kind: "group", op: "and", children: [] }`) is valid. For leaf conditions: the operator must be legal for the field (e.g., `contains` and `equals` for `name`; `hasTag`/`notHasTag` for `tag`). Operators `exists` and `notExists` take a null value; all others require a non-empty string. For the built-in `manualPreview` field, `exists` tests `previewImageFileId IS NOT NULL` and `notExists` tests `previewImageFileId IS NULL`. This tests whether a preview was explicitly pinned, not whether the model has any image files. Metadata field slugs are validated server-side against the live field definitions; unknown slugs return `400`.
+
+For example, this leaf matches models with a manually set preview:
+
+```json
+{
+  "kind": "condition",
+  "field": { "source": "builtin", "field": "manualPreview" },
+  "operator": "exists",
+  "value": null
+}
+```
+
+Use `notExists` with the same null value to match models without a manually set preview, including models that have no image files.
 
 **Response (201):** Returns the created `SmartCollectionDetail` (includes a live `modelCount`).
 

--- a/docs/TYPES.md
+++ b/docs/TYPES.md
@@ -247,6 +247,7 @@ type BuiltinRuleField =
   | 'name'         // full-text search / exact match on model name
   | 'description'  // ILIKE substring match on description
   | 'status'       // models.status column
+  | 'manualPreview' // whether previewImageFileId is explicitly set
   | 'fileType'     // EXISTS in model_files for the given file_type
   | 'collection'   // membership in a collection (by UUID value)
   | 'tag';         // tag membership (by name, case-insensitive)
@@ -267,9 +268,15 @@ type RuleOperator =
   | 'notHasTag'
   | 'inCollection'     // collection membership
   | 'notInCollection'
-  | 'exists'           // metadata field has any value (no value required)
+  | 'exists'           // field/state is set (no value required)
   | 'notExists';
 ```
+
+For the built-in `manualPreview` field, `exists` matches models with an explicitly pinned
+preview image (`previewImageFileId` is non-null), while `notExists` matches models without one
+(`previewImageFileId` is null). Both operators take a `null` value. This rule does not test
+whether the model has image files; a model without a pinned preview uses the automatic
+first-image fallback when an image is available.
 
 Legal operator combinations — which operators are valid for which fields — are defined in `LEGAL_OPERATORS_BY_BUILTIN` and `LEGAL_OPERATORS_BY_METADATA_TYPE` in `packages/shared/src/types/smart-collection.ts`. The shared validator enforces built-in legality; metadata legality is checked server-side once the field definition is resolved.
 

--- a/packages/shared/src/types/smart-collection.ts
+++ b/packages/shared/src/types/smart-collection.ts
@@ -18,6 +18,7 @@ export type BuiltinRuleField =
   | 'name' // models.search_vector / models.name
   | 'description' // models.search_vector
   | 'status' // models.status
+  | 'manualPreview' // models.preview_image_file_id (user-pinned cover)
   | 'fileType' // model_files.file_type (EXISTS)
   | 'collection' // collection_models membership
   | 'tag'; // model_tags + tags membership
@@ -26,6 +27,7 @@ export const BUILTIN_RULE_FIELDS: readonly BuiltinRuleField[] = [
   'name',
   'description',
   'status',
+  'manualPreview',
   'fileType',
   'collection',
   'tag',
@@ -60,7 +62,7 @@ export type RuleOperator =
   | 'notHasTag'
   | 'inCollection'
   | 'notInCollection'
-  | 'exists' // metadata field has any value
+  | 'exists' // field has a value (metadata or supported built-in)
   | 'notExists';
 
 export const RULE_OPERATORS: readonly RuleOperator[] = [
@@ -107,6 +109,7 @@ export const LEGAL_OPERATORS_BY_BUILTIN: Record<BuiltinRuleField, readonly RuleO
   name: ['contains', 'equals'],
   description: ['contains'],
   status: ['is', 'isNot'],
+  manualPreview: ['exists', 'notExists'],
   fileType: ['has', 'notHas'],
   collection: ['inCollection', 'notInCollection'],
   tag: ['hasTag', 'notHasTag'],


### PR DESCRIPTION
## Summary
- add a `manualPreview` built-in Smart Collection field with `is set` / `is not set` operators
- compile the rule against the explicit `previewImageFileId` pointer so fallback images remain distinct
- expose the rule in the composer and document the API contract
- cover SQL generation, UI behavior, preview results, and saved collection results

## Validation
- `npm test -w @alexandria/backend -- src/services/rule-engine.test.ts`
- `npm test -w @alexandria/backend -- src/routes/smart-collections.test.ts`
- `npm test -w @alexandria/frontend -- --run src/components/smart/ConditionRow.test.tsx`
- `npm test` (376/377 frontend tests passed; unrelated `FileTree` stress test timed out at 5s, then passed 16/16 on isolated rerun)
- `npm run lint`
- `npm run build`
- `git diff --check`