### PR TITLE
Fix atomic selected-file deletion

### DIFF
--- a/apps/backend/src/routes/models.delete-files.test.ts
+++ b/apps/backend/src/routes/models.delete-files.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import Fastify, { type FastifyInstance } from 'fastify';
+
+const USER_ID = '11111111-1111-4111-8111-111111111111';
+const LIBRARY_ID = '22222222-2222-4222-8222-222222222222';
+const MODEL_ID = '33333333-3333-4333-8333-333333333333';
+const FILE_IDS = [
+  '44444444-4444-4444-8444-444444444444',
+  '55555555-5555-4555-8555-555555555555',
+];
+
+const mocks = vi.hoisted(() => ({
+  requireAuth: vi.fn(async (request: { user?: unknown }) => {
+    request.user = { id: USER_ID };
+  }),
+  requireLibrary: vi.fn(async (request: { libraryId?: string }) => {
+    request.libraryId = LIBRARY_ID;
+  }),
+  requireOwnedModel: vi.fn(),
+  deleteModelFiles: vi.fn(),
+  buildModelDetail: vi.fn(),
+}));
+
+vi.mock('../middleware/auth.js', () => ({ requireAuth: mocks.requireAuth }));
+vi.mock('../middleware/library.js', () => ({ requireLibrary: mocks.requireLibrary }));
+vi.mock('../services/model.service.js', () => ({
+  modelService: {
+    requireOwnedModel: mocks.requireOwnedModel,
+    deleteModelFiles: mocks.deleteModelFiles,
+  },
+}));
+vi.mock('../services/presenter.service.js', () => ({
+  presenterService: { buildModelDetail: mocks.buildModelDetail },
+}));
+
+import { modelRoutes } from './models.js';
+
+describe('Model selected-file delete route', () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mocks.buildModelDetail.mockResolvedValue({ id: MODEL_ID, fileCount: 1 });
+    app = Fastify();
+    await app.register(modelRoutes, { prefix: '/models' });
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('validates and delegates all selected files as one operation', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: `/models/${MODEL_ID}/files/delete`,
+      payload: { fileIds: FILE_IDS },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(mocks.requireOwnedModel).toHaveBeenCalledWith(MODEL_ID, USER_ID, LIBRARY_ID);
+    expect(mocks.deleteModelFiles).toHaveBeenCalledOnce();
+    expect(mocks.deleteModelFiles).toHaveBeenCalledWith(MODEL_ID, FILE_IDS);
+    expect(response.json()).toEqual({
+      data: { id: MODEL_ID, fileCount: 1 },
+      meta: null,
+      errors: null,
+    });
+  });
+
+  it('rejects duplicate file IDs before deleting anything', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: `/models/${MODEL_ID}/files/delete`,
+      payload: { fileIds: [FILE_IDS[0], FILE_IDS[0]] },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(mocks.deleteModelFiles).not.toHaveBeenCalled();
+  });
+
+  it('rejects an empty selection before deleting anything', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: `/models/${MODEL_ID}/files/delete`,
+      payload: { fileIds: [] },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(mocks.deleteModelFiles).not.toHaveBeenCalled();
+  });
+
+  it('rejects selections larger than the supported batch size', async () => {
+    const fileIds = Array.from(
+      { length: 501 },
+      (_, index) => `00000000-0000-4000-8000-${index.toString().padStart(12, '0')}`,
+    );
+    const response = await app.inject({
+      method: 'POST',
+      url: `/models/${MODEL_ID}/files/delete`,
+      payload: { fileIds },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(mocks.deleteModelFiles).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/routes/models.ts
+++ b/apps/backend/src/routes/models.ts
@@ -15,6 +15,7 @@ import type {
   UpdateModelFileRequest,
   UpdateModelFolderRequest,
   DeleteModelFolderRequest,
+  DeleteModelFilesRequest,
   SplitModelFolderRequest,
   CompressModelFolderRequest,
   ExtractImportSessionArchiveRequest,
@@ -23,6 +24,7 @@ import type {
 import {
   createModelFolderSchema,
   deleteModelFolderSchema,
+  deleteModelFilesSchema,
   splitModelFolderSchema,
   compressModelFolderSchema,
   importConfigSchema,
@@ -641,6 +643,21 @@ export async function modelRoutes(app: FastifyInstance): Promise<void> {
       const { id, fileId } = request.params as { id: string; fileId: string };
       await modelService.requireOwnedModel(id, request.user!.id, request.libraryId!);
       await modelService.deleteModelFile(id, fileId);
+      const detail = await presenterService.buildModelDetail(id);
+
+      return reply.status(200).send({ data: detail, meta: null, errors: null });
+    },
+  );
+
+  // POST /:id/files/delete — delete selected files from a model atomically
+  app.post(
+    '/:id/files/delete',
+    { preHandler: [requireAuth, requireLibrary, validate(deleteModelFilesSchema)] },
+    async (request, reply) => {
+      const { id } = request.params as { id: string };
+      const body = request.body as DeleteModelFilesRequest;
+      await modelService.requireOwnedModel(id, request.user!.id, request.libraryId!);
+      await modelService.deleteModelFiles(id, body.fileIds);
       const detail = await presenterService.buildModelDetail(id);
 
       return reply.status(200).send({ data: detail, meta: null, errors: null });

--- a/apps/backend/src/services/model-delete.service.test.ts
+++ b/apps/backend/src/services/model-delete.service.test.ts
@@ -1,0 +1,218 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { eq, inArray } from 'drizzle-orm';
+import type { DatabaseExecutor } from '../db/index.js';
+
+const storageMocks = vi.hoisted(() => ({
+  deleteMany: vi.fn(),
+}));
+
+vi.mock('./storage.service.js', () => ({
+  storageService: { deleteMany: storageMocks.deleteMany },
+}));
+
+import { db, pool } from '../db/index.js';
+import { libraries, modelFiles, models, thumbnails, users } from '../db/schema/index.js';
+import { ModelService } from './model.service.js';
+
+const TEST_EMAIL = 'model-delete-test@example.com';
+const service = new ModelService();
+
+let userId: string;
+let libraryId: string;
+let modelId: string;
+let selectedFileIds: string[];
+
+async function deleteTestUser(): Promise<void> {
+  const rows = await db.select({ id: users.id }).from(users).where(eq(users.email, TEST_EMAIL));
+  if (rows.length === 0) return;
+  const userIds = rows.map((row) => row.id);
+  await db.delete(models).where(inArray(models.userId, userIds));
+  await db.delete(libraries).where(inArray(libraries.userId, userIds));
+  await db.delete(users).where(inArray(users.id, userIds));
+}
+
+async function waitForBlockedModelLock(): Promise<number[]> {
+  const deadline = Date.now() + 2_000;
+  while (Date.now() < deadline) {
+    const result = await pool.query<{ blockingPids: number[] }>(`
+      SELECT pg_blocking_pids(pid) AS "blockingPids"
+      FROM pg_stat_activity
+      WHERE datname = current_database()
+        AND wait_event_type = 'Lock'
+        AND query ILIKE '%"models"%'
+        AND cardinality(pg_blocking_pids(pid)) > 0
+    `);
+    const blocked = result.rows[0]?.blockingPids;
+    if (blocked && blocked.length > 0) return blocked;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error('Expected a model-row lock waiter');
+}
+
+beforeAll(async () => {
+  await deleteTestUser();
+  const [user] = await db.insert(users).values({
+    email: TEST_EMAIL,
+    displayName: 'Model Delete Test',
+    passwordHash: 'not-a-real-hash',
+    role: 'admin',
+  }).returning();
+  userId = user.id;
+
+  const [library] = await db.insert(libraries).values({
+    name: 'Model Delete Library',
+    slug: `model-delete-library-${Date.now()}`,
+    userId,
+    isDefault: true,
+  }).returning();
+  libraryId = library.id;
+});
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  storageMocks.deleteMany.mockResolvedValue([]);
+
+  const [model] = await db.insert(models).values({
+    name: 'Delete Selection Model',
+    slug: `model-delete-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+    userId,
+    libraryId,
+    sourceType: 'manual',
+    status: 'ready',
+    fileCount: 3,
+    totalSizeBytes: 600,
+  }).returning();
+  modelId = model.id;
+
+  const files = await db.insert(modelFiles).values([
+    {
+      modelId,
+      filename: 'one.png',
+      relativePath: 'one.png',
+      fileType: 'image',
+      mimeType: 'image/png',
+      sizeBytes: 100,
+      storagePath: `models/${modelId}/one.png`,
+      hash: 'delete-one-hash',
+    },
+    {
+      modelId,
+      filename: 'two.stl',
+      relativePath: 'two.stl',
+      fileType: 'stl',
+      mimeType: 'model/stl',
+      sizeBytes: 200,
+      storagePath: `models/${modelId}/two.stl`,
+      hash: 'delete-two-hash',
+    },
+    {
+      modelId,
+      filename: 'keep.stl',
+      relativePath: 'keep.stl',
+      fileType: 'stl',
+      mimeType: 'model/stl',
+      sizeBytes: 300,
+      storagePath: `models/${modelId}/keep.stl`,
+      hash: 'delete-keep-hash',
+    },
+  ]).returning();
+  selectedFileIds = files.slice(0, 2).map((file) => file.id);
+  await db.insert(thumbnails).values({
+    sourceFileId: files[0].id,
+    storagePath: `thumbnails/${modelId}/one-grid.webp`,
+    width: 400,
+    height: 400,
+    format: 'webp',
+  });
+});
+
+afterEach(async () => {
+  await db.delete(models).where(eq(models.userId, userId));
+});
+
+afterAll(async () => {
+  await deleteTestUser();
+});
+
+describe('ModelService – deleteModelFiles', () => {
+  it('deletes the complete selection and recalculates stats once', async () => {
+    await service.deleteModelFiles(modelId, selectedFileIds);
+
+    expect((await service.getModelFiles(modelId)).map((file) => file.relativePath))
+      .toEqual(['keep.stl']);
+    expect(await service.getModelById(modelId)).toMatchObject({
+      fileCount: 1,
+      totalSizeBytes: 300,
+    });
+    expect(await db.select().from(thumbnails).where(inArray(
+      thumbnails.sourceFileId,
+      selectedFileIds,
+    ))).toEqual([]);
+    expect(storageMocks.deleteMany).toHaveBeenCalledOnce();
+    expect(storageMocks.deleteMany).toHaveBeenCalledWith(expect.arrayContaining([
+      `models/${modelId}/one.png`,
+      `models/${modelId}/two.stl`,
+      `thumbnails/${modelId}/one-grid.webp`,
+    ]));
+  });
+
+  it('leaves every selected file intact when any ID is missing', async () => {
+    await expect(service.deleteModelFiles(modelId, [
+      selectedFileIds[0],
+      '99999999-9999-4999-8999-999999999999',
+    ])).rejects.toMatchObject({ code: 'NOT_FOUND' });
+
+    expect(await service.getModelFiles(modelId)).toHaveLength(3);
+    expect(await service.getModelById(modelId)).toMatchObject({
+      fileCount: 3,
+      totalSizeBytes: 600,
+    });
+    expect(storageMocks.deleteMany).not.toHaveBeenCalled();
+  });
+
+  it('serializes concurrent deletions before recalculating model statistics', async () => {
+    let resolveFirstRecalculation!: () => void;
+    let releaseFirstRecalculation!: () => void;
+    const firstRecalculationEntered = new Promise<void>((resolve) => {
+      resolveFirstRecalculation = resolve;
+    });
+    const firstRecalculationReleased = new Promise<void>((resolve) => {
+      releaseFirstRecalculation = resolve;
+    });
+
+    class BlockingModelService extends ModelService {
+      recalculationCount = 0;
+
+      override async recalculateModelStats(
+        recalculatedModelId: string,
+        executor?: DatabaseExecutor,
+      ): Promise<void> {
+        this.recalculationCount += 1;
+        if (this.recalculationCount === 1) {
+          resolveFirstRecalculation();
+          await firstRecalculationReleased;
+        }
+        await super.recalculateModelStats(recalculatedModelId, executor);
+      }
+    }
+
+    const blockingService = new BlockingModelService();
+    const firstDelete = blockingService.deleteModelFile(modelId, selectedFileIds[0]);
+    await firstRecalculationEntered;
+    const secondDelete = blockingService.deleteModelFile(modelId, selectedFileIds[1]);
+
+    try {
+      expect(await waitForBlockedModelLock()).not.toEqual([]);
+      expect(blockingService.recalculationCount).toBe(1);
+    } finally {
+      releaseFirstRecalculation();
+    }
+
+    await Promise.all([firstDelete, secondDelete]);
+    expect(blockingService.recalculationCount).toBe(2);
+    expect(await service.getModelById(modelId)).toMatchObject({
+      fileCount: 1,
+      totalSizeBytes: 300,
+    });
+  });
+});

--- a/apps/backend/src/services/model.service.ts
+++ b/apps/backend/src/services/model.service.ts
@@ -11,6 +11,7 @@ import type {
   UpdateModelFileRequest,
   UpdateModelFolderRequest,
 } from '@alexandria/shared';
+import { MAX_MODEL_FILE_SELECTION_COUNT } from '@alexandria/shared';
 import { db } from '../db/index.js';
 import type { DatabaseExecutor } from '../db/index.js';
 import {
@@ -29,6 +30,9 @@ import { storageService } from './storage.service.js';
 import { generateSlug } from '../utils/slug.js';
 import { metadataService } from './metadata.service.js';
 import { duplicateScannerService } from './duplicate-scanner.service.js';
+import { createLogger } from '../utils/logger.js';
+
+const logger = createLogger('ModelService');
 
 export interface CreateModelData {
   id?: string;
@@ -236,7 +240,7 @@ export class ModelService {
     updates?: UpdateModelStatusData,
   ): Promise<void> {
     await db.transaction(async (tx) => {
-      const model = await this.getModelById(modelId, tx);
+      const model = await this.lockModelById(modelId, tx);
       await tx
         .update(models)
         .set({
@@ -256,7 +260,7 @@ export class ModelService {
   ): Promise<void> {
     if (!executor) {
       await db.transaction(async (tx) => {
-        const model = await this.getModelById(modelId, tx);
+        const model = await this.lockModelById(modelId, tx);
         await this.recalculateModelStats(modelId, tx);
         await duplicateScannerService.reconcileDuplicateFlags(model.libraryId, tx);
       });
@@ -286,7 +290,7 @@ export class ModelService {
     file: CreateModelFileData,
   ): Promise<{ id: string }> {
     return db.transaction(async (tx) => {
-      const model = await this.getModelById(modelId, tx);
+      const model = await this.lockModelById(modelId, tx);
       const [created] = await this.createModelFiles(modelId, [file], tx);
       await this.recalculateModelStats(modelId, tx);
       await duplicateScannerService.reconcileDuplicateFlags(model.libraryId, tx);
@@ -296,6 +300,20 @@ export class ModelService {
 
   async getModelById(id: string, executor: DatabaseExecutor = db): Promise<Model> {
     const [row] = await executor.select().from(models).where(eq(models.id, id)).limit(1);
+
+    if (!row) {
+      throw notFound(`Model not found: ${id}`);
+    }
+
+    return row;
+  }
+
+  private async lockModelById(id: string, executor: DatabaseExecutor): Promise<Model> {
+    const [row] = await executor
+      .select()
+      .from(models)
+      .where(eq(models.id, id))
+      .for('update');
 
     if (!row) {
       throw notFound(`Model not found: ${id}`);
@@ -817,33 +835,82 @@ export class ModelService {
   }
 
   async deleteModelFile(modelId: string, fileId: string): Promise<void> {
-    const [file] = await db
-      .select()
-      .from(modelFiles)
-      .where(and(eq(modelFiles.modelId, modelId), eq(modelFiles.id, fileId)))
-      .limit(1);
-    if (!file) {
-      throw notFound(`File not found: ${fileId}`);
+    await this.deleteModelFileSelection(modelId, [fileId], `File not found: ${fileId}`);
+  }
+
+  async deleteModelFiles(modelId: string, fileIds: string[]): Promise<void> {
+    await this.deleteModelFileSelection(
+      modelId,
+      fileIds,
+      'One or more selected files were not found',
+    );
+  }
+
+  private async deleteModelFileSelection(
+    modelId: string,
+    fileIds: string[],
+    missingMessage: string,
+  ): Promise<void> {
+    if (fileIds.length === 0 || fileIds.length > MAX_MODEL_FILE_SELECTION_COUNT) {
+      throw validationError(
+        `File selection must contain between 1 and ${MAX_MODEL_FILE_SELECTION_COUNT} IDs`,
+        'fileIds',
+      );
+    }
+    if (new Set(fileIds).size !== fileIds.length) {
+      throw validationError('File IDs must be unique', 'fileIds');
     }
 
-    await db.transaction(async (tx) => {
-      const model = await this.getModelById(modelId, tx);
-      const [deletedFile] = await tx
+    const storagePaths = await db.transaction(async (tx) => {
+      const model = await this.lockModelById(modelId, tx);
+      const selectedFiles = await tx
+        .select({ id: modelFiles.id })
+        .from(modelFiles)
+        .where(and(
+          eq(modelFiles.modelId, modelId),
+          inArray(modelFiles.id, fileIds),
+        ));
+      if (selectedFiles.length !== fileIds.length) {
+        throw notFound(missingMessage);
+      }
+
+      const selectedThumbnails = await tx
+        .select({ storagePath: thumbnails.storagePath })
+        .from(thumbnails)
+        .where(inArray(thumbnails.sourceFileId, fileIds));
+
+      const removedFiles = await tx
         .delete(modelFiles)
         .where(and(
-          eq(modelFiles.id, file.id),
           eq(modelFiles.modelId, modelId),
-          eq(modelFiles.relativePath, file.relativePath),
-          eq(modelFiles.storagePath, file.storagePath),
+          inArray(modelFiles.id, fileIds),
         ))
-        .returning({ id: modelFiles.id });
-      if (!deletedFile) {
-        throw conflict('File changed while it was being deleted; try again');
+        .returning({ id: modelFiles.id, storagePath: modelFiles.storagePath });
+      if (removedFiles.length !== fileIds.length) {
+        throw conflict('One or more files changed while they were being deleted; try again');
       }
       await this.recalculateModelStats(modelId, tx);
       await duplicateScannerService.reconcileDuplicateFlags(model.libraryId, tx);
+      return [
+        ...removedFiles.map((file) => file.storagePath),
+        ...selectedThumbnails.map((thumbnail) => thumbnail.storagePath),
+      ];
     });
-    await storageService.delete(file.storagePath).catch(() => {});
+
+    try {
+      const failures = await storageService.deleteMany(storagePaths);
+      for (const failure of failures) {
+        logger.warn(
+          { modelId, storagePath: failure.filePath, err: failure.reason },
+          'Best-effort selected-file storage cleanup failed',
+        );
+      }
+    } catch (error) {
+      logger.warn(
+        { modelId, err: error },
+        'Best-effort selected-file storage cleanup failed',
+      );
+    }
   }
 
   async deleteModelFolder(modelId: string, requestedPath: string): Promise<void> {
@@ -866,7 +933,7 @@ export class ModelService {
       ));
 
     await db.transaction(async (tx) => {
-      const model = await this.getModelById(modelId, tx);
+      const model = await this.lockModelById(modelId, tx);
       await tx
         .delete(modelFiles)
         .where(and(

--- a/apps/frontend/src/api/models.test.ts
+++ b/apps/frontend/src/api/models.test.ts
@@ -13,12 +13,26 @@ vi.mock('./client', () => ({
 import { del, post, postForLibrary, putRaw } from './client';
 import {
   compressModelFolder,
+  deleteModelFiles,
   scanMultipartUpload,
   scanUpload,
   splitModelFolder,
 } from './models';
 
 const envelope = <T,>(data: T) => ({ data, meta: null, errors: null });
+
+describe('deleteModelFiles', () => {
+  it('posts all selected file IDs in one request', async () => {
+    const detail = { id: 'model-1' };
+    vi.mocked(post).mockResolvedValueOnce(envelope(detail));
+
+    await expect(deleteModelFiles('model-1', ['file-1', 'file-2'])).resolves.toEqual(detail);
+
+    expect(post).toHaveBeenCalledWith('/models/model-1/files/delete', {
+      fileIds: ['file-1', 'file-2'],
+    });
+  });
+});
 
 describe('splitModelFolder', () => {
   it('posts the folder path and new model name and unwraps the response', async () => {

--- a/apps/frontend/src/api/models.ts
+++ b/apps/frontend/src/api/models.ts
@@ -90,6 +90,11 @@ export async function deleteModelFile(id: string, fileId: string): Promise<Model
   return response.data;
 }
 
+export async function deleteModelFiles(id: string, fileIds: string[]): Promise<ModelDetail> {
+  const response = await post<ModelDetail>(`/models/${id}/files/delete`, { fileIds });
+  return response.data;
+}
+
 export async function extractModelArchive(
   id: string,
   fileId: string,

--- a/apps/frontend/src/components/models/FileTree.test.tsx
+++ b/apps/frontend/src/components/models/FileTree.test.tsx
@@ -360,5 +360,10 @@ describe('FileTree', () => {
       'title',
       'Select no more than 500 files to split',
     );
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Delete' })).toHaveAttribute(
+      'title',
+      'Select no more than 500 files to delete',
+    );
   });
 });

--- a/apps/frontend/src/components/models/FileTree.tsx
+++ b/apps/frontend/src/components/models/FileTree.tsx
@@ -20,7 +20,12 @@ import {
   Scissors,
   Copy,
 } from 'lucide-react';
-import { MAX_SPLIT_FILE_COUNT, type FileTreeNode, type FileType } from '@alexandria/shared';
+import {
+  MAX_MODEL_FILE_SELECTION_COUNT,
+  MAX_SPLIT_FILE_COUNT,
+  type FileTreeNode,
+  type FileType,
+} from '@alexandria/shared';
 import { formatFileSize } from '../../lib/format';
 import { cn } from '../../lib/utils';
 import { Model3DIcon } from '../icons';
@@ -1020,7 +1025,14 @@ export function FileTree({
                 setSelectedFileIds(new Set());
               }
             }}
-            disabled={disabled || selectedFiles.length === 0}
+            disabled={
+              disabled ||
+              selectedFiles.length === 0 ||
+              selectedFiles.length > MAX_MODEL_FILE_SELECTION_COUNT
+            }
+            title={selectedFiles.length > MAX_MODEL_FILE_SELECTION_COUNT
+              ? `Select no more than ${MAX_MODEL_FILE_SELECTION_COUNT} files to delete`
+              : 'Delete selected files'}
             className="inline-flex h-7 items-center gap-1 rounded-md px-2 text-xs text-destructive hover:bg-destructive/10 disabled:opacity-50"
           >
             <Trash2 className="h-3.5 w-3.5" />

--- a/apps/frontend/src/pages/ModelDetailPage.test.tsx
+++ b/apps/frontend/src/pages/ModelDetailPage.test.tsx
@@ -22,6 +22,7 @@ vi.mock('../api/models', () => ({
   compressModelFolder: vi.fn(),
   createModelFolder: vi.fn(),
   deleteModelFile: vi.fn(),
+  deleteModelFiles: vi.fn(),
   deleteModelFolder: vi.fn(),
   extractModelArchive: vi.fn(),
   getModel: vi.fn(),
@@ -62,6 +63,7 @@ interface DetailPanelTestProps {
   fileActionsDisabled?: boolean;
   fileActionStatus?: string;
   onCompressFolder?: (path: string, name: string) => void;
+  onDeleteFiles?: (fileIds: string[]) => void;
 }
 
 vi.mock('../components/models/ModelDetailPanel', () => ({
@@ -71,6 +73,7 @@ vi.mock('../components/models/ModelDetailPanel', () => ({
     fileActionsDisabled,
     fileActionStatus,
     onCompressFolder,
+    onDeleteFiles,
     onSplitFolder,
     onSplitFiles,
   }: DetailPanelTestProps) => (
@@ -97,6 +100,13 @@ vi.mock('../components/models/ModelDetailPanel', () => ({
       >
         {fileActionStatus ?? 'Compress folder'}
       </button>
+      <button
+        type="button"
+        disabled={fileActionsDisabled}
+        onClick={() => onDeleteFiles?.(['file-1', 'file-2'])}
+      >
+        Delete selected files
+      </button>
     </>
   ),
 }));
@@ -104,6 +114,7 @@ vi.mock('../components/models/ModelDetailPanel', () => ({
 import { addModelsToCollection, getCollections } from '../api/collections';
 import {
   compressModelFolder,
+  deleteModelFiles,
   getModel,
   getModelFiles,
   splitModelFolder,
@@ -298,6 +309,31 @@ describe('ModelDetailPage mutations', () => {
         metadataFieldSlugs: [],
       });
     });
+  });
+
+  it('deletes selected files in one mutation request', async () => {
+    vi.mocked(deleteModelFiles).mockResolvedValue(model);
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries');
+    renderPage(queryClient);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Delete selected files' }));
+
+    await waitFor(() => {
+      expect(deleteModelFiles).toHaveBeenCalledOnce();
+      expect(deleteModelFiles).toHaveBeenCalledWith('model-1', ['file-1', 'file-2']);
+      expect(mocks.toast).toHaveBeenCalledWith({ title: '2 files deleted' });
+    });
+    for (const queryKey of [
+      ['model', 'model-1'],
+      ['model-files', 'model-1'],
+      ['models'],
+      ['search'],
+    ]) {
+      expect(invalidateQueries).toHaveBeenCalledWith({ queryKey });
+    }
   });
 
   it('should show compression progress, refresh model data, and name the created archive', async () => {

--- a/apps/frontend/src/pages/ModelDetailPage.tsx
+++ b/apps/frontend/src/pages/ModelDetailPage.tsx
@@ -8,6 +8,7 @@ import {
   compressModelFolder,
   createModelFolder,
   deleteModelFile,
+  deleteModelFiles,
   deleteModelFolder,
   extractModelArchive,
   getModel,
@@ -192,7 +193,7 @@ export function ModelDetailPage() {
           );
           return `${action.fileIds.length} file${action.fileIds.length === 1 ? '' : 's'} moved`;
         case 'delete-files':
-          await Promise.all(action.fileIds.map((fileId) => deleteModelFile(id, fileId)));
+          await deleteModelFiles(id, action.fileIds);
           return `${action.fileIds.length} file${action.fileIds.length === 1 ? '' : 's'} deleted`;
         case 'rename-folder':
           await updateModelFolder(id, { path: action.path, name: action.name });
@@ -215,6 +216,7 @@ export function ModelDetailPage() {
         queryClient.invalidateQueries({ queryKey: ['model', id] }),
         queryClient.invalidateQueries({ queryKey: ['model-files', id] }),
         queryClient.invalidateQueries({ queryKey: ['models'] }),
+        queryClient.invalidateQueries({ queryKey: ['search'] }),
       ]);
       toast({ title });
     },

--- a/docs/API.md
+++ b/docs/API.md
@@ -1287,6 +1287,37 @@ Retrieve the file tree for a model. The flat list of `ModelFile` records is asse
 
 ---
 
+### POST /models/:id/files/delete
+
+Delete a selected set of files from one model. The model must belong to the authenticated user and the active library selected by `X-Library-Id`, or the user's default library when the header is omitted.
+
+**Auth required:** Yes. The model must belong to the authenticated user and active library.
+
+**Path parameter:** `id` — model UUID
+
+**Request body:**
+
+```json
+{
+  "fileIds": [
+    "55555555-5555-4555-8555-555555555555",
+    "66666666-6666-4666-8666-666666666666"
+  ]
+}
+```
+
+`fileIds` must contain 1–500 unique `ModelFile` UUIDs. Every selected file must belong to the model identified by `id`.
+
+**Response (200):** Returns the updated `ModelDetail`, in the same shape as `GET /models/:id`.
+
+The database operation is atomic. Before deleting anything, the service verifies that the complete selection still belongs to the model. It then deletes all selected file rows, recalculates the model's file count and total size, and reconciles duplicate-review flags in one transaction. A failure in any of these steps rolls back the complete selection; the endpoint never commits a partial database deletion.
+
+After the transaction commits, the service batch-deletes the selected files' and their thumbnails' managed-storage objects on a best-effort basis. Cleanup failures are logged but do not roll back the database deletion or change the successful response.
+
+The endpoint returns `400 VALIDATION_ERROR` when `fileIds` contains fewer than 1 or more than 500 values, contains duplicates, or contains a value that is not a UUID. It returns `404 NOT_FOUND` when the model is not owned by the authenticated user in the active library, or when one or more selected files do not belong to that model. It returns `409 CONFLICT` when the selected files change concurrently between verification and deletion. All of these failures leave the database selection unchanged.
+
+---
+
 ### POST /models/:id/folders/split
 
 Move either one folder's contents or a selected set of files into one new model. The request must

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -193,7 +193,7 @@ This index makes the enforcement race-safe: the database rejects a second `is_de
 
 Routes that apply `requireLibrary` (as of P5):
 
-- `GET /models`, `GET /models/:id`, `GET /models/:id/files`, `GET /models/:id/status`, `POST /models/:id/folders/compress`
+- `GET /models`, `GET /models/:id`, `GET /models/:id/files`, `GET /models/:id/status`, `POST /models/:id/files/delete`, `POST /models/:id/folders/compress`
 - `GET /collections`, `POST /collections`, `GET /collections/:id`, `GET /collections/:id/models`
 - `GET /metadata/fields/:slug/values`
 - `POST /models/upload`, `POST /models/upload/:uploadId/complete`, `POST /models/upload/multipart/complete`, `POST /models/import`
@@ -368,6 +368,8 @@ File candidates are ordered by file creation time and file UUID, with owning-mod
 **Owns:** Model, ModelFile, and ModelFolder CRUD. Creating, reading, updating, and deleting Model records; managing file and persisted-folder relationships; and coordinating structural operations such as model merge and splitting one folder or a selected set of files into a new model.
 
 **Does not own:** Metadata CRUD (delegates to MetadataService), collection membership, ingestion pipeline, search, storage implementation, or thumbnail generation. Structural operations may copy existing metadata relationships as part of their transaction. Structural file operations use StorageService's backend-independent copy/delete interface.
+
+**Selected-file deletion behavior:** `deleteModelFiles` accepts 1–500 unique file IDs from an owned model in the active library. It locks the model to serialize file-membership aggregate updates, verifies the complete selection, captures file and thumbnail storage paths, deletes the file rows, recalculates model statistics, and reconciles duplicate-review flags in one transaction. A missing file aborts without deleting any of the selection, while a concurrent selection change produces a conflict and rolls back the transaction. After commit, batched deletion of the captured storage objects is best-effort, logs individual failures, and cannot change the successful database result.
 
 **Split behavior:** The split endpoint accepts exactly one selection from an owned, ready model in the active library. `splitModelFolder` accepts a folder containing at least one file. Its files become the root contents of a new ready, `manual` model; descendant paths are rebased by removing the selected folder prefix, while persisted nested folders, including empty descendants, are preserved. `splitModelFiles` accepts 1–500 unique file IDs from the source model, moves all selected files into the same new model, and preserves each file's relative path. Existing ModelFile IDs and thumbnail records remain attached to their files. If the source model's selected preview is among the moved files, its preview selection and crop values transfer to the new model and are cleared on the source. Both models' file count and total size are recalculated. The new model receives the requested name and only the populated metadata values selected by field slug. The special `tags` slug copies tag memberships. Copied metadata remains on the source model; collection memberships, description, and other source provenance are never copied.
 
@@ -689,10 +691,11 @@ Because `ModelViewer3DScene` is lazy-loaded, Vite emits three.js as a separate a
 | DELETE | /models/import-sessions/:id | Discard session + staged files | IngestionService | No (userId) |
 | GET | /models/:id/status | Processing status | ModelService | Yes |
 | PATCH | /models/:id | Update model | ModelService → PresenterService | No (userId) |
+| POST | /models/:id/files/delete | Atomically delete selected files, then best-effort clean captured storage objects | ModelService → PresenterService + StorageService | Yes |
 | POST | /models/:id/folders/split | Move one folder or selected files into a new model | ModelService → StorageService | Yes |
 | DELETE | /models/:id | Delete model + files | ModelService → StorageService | No (userId) |
 
-"Library-scoped" means the route applies the `requireLibrary` preHandler and scopes its read or write to `request.libraryId`. Routes marked `No (userId)` enforce ownership but do not use the active library. Read/detail model routes and the folder-compression mutation enforce active-library scope; the folder-split route does the same because it creates another model in that library. The top-level `PATCH` and `DELETE` model mutations remain owned by `userId` only.
+"Library-scoped" means the route applies the `requireLibrary` preHandler and scopes its read or write to `request.libraryId`. Routes marked `No (userId)` enforce ownership but do not use the active library. Read/detail model routes and the folder-compression mutation enforce active-library scope; selected-file deletion and folder splitting do the same for their source model. The top-level `PATCH` and `DELETE` model mutations remain owned by `userId` only.
 
 **Collections**
 | Method | Route | Purpose | Service Chain | Library-scoped |

--- a/docs/TYPES.md
+++ b/docs/TYPES.md
@@ -961,6 +961,10 @@ interface UpdateModelRequest {
   previewImageFileId?: string | null; // set to a ModelFile UUID to pin cover; null to revert to fallback
 }
 
+interface DeleteModelFilesRequest {
+  fileIds: string[]; // 1–500 unique ModelFile UUIDs owned by the target model
+}
+
 interface SplitModelRequestBase {
   name: string; // trimmed new-model name; 1–255 characters
   metadataFieldSlugs?: string[]; // selected source fields to copy; defaults to [] when omitted

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -1,6 +1,7 @@
 export const DEFAULT_PAGE_SIZE = 50;
 export const MAX_PAGE_SIZE = 200;
-export const MAX_SPLIT_FILE_COUNT = 500;
+export const MAX_MODEL_FILE_SELECTION_COUNT = 500;
+export const MAX_SPLIT_FILE_COUNT = MAX_MODEL_FILE_SELECTION_COUNT;
 
 export const SUPPORTED_IMAGE_FORMATS = ['jpg', 'jpeg', 'png', 'webp', 'tif', 'tiff'] as const;
 export const SUPPORTED_DOCUMENT_FORMATS = ['pdf', 'txt', 'md'] as const;

--- a/packages/shared/src/types/model.ts
+++ b/packages/shared/src/types/model.ts
@@ -121,6 +121,10 @@ export interface DeleteModelFolderRequest {
   path: string;
 }
 
+export interface DeleteModelFilesRequest {
+  fileIds: string[];
+}
+
 interface SplitModelRequestBase {
   name: string;
   metadataFieldSlugs?: string[];

--- a/packages/shared/src/validation/model.ts
+++ b/packages/shared/src/validation/model.ts
@@ -1,5 +1,8 @@
 import { z } from 'zod';
-import { MAX_SPLIT_FILE_COUNT } from '../constants/index.js';
+import {
+  MAX_MODEL_FILE_SELECTION_COUNT,
+  MAX_SPLIT_FILE_COUNT,
+} from '../constants/index.js';
 
 const relativePathSchema = z.string().min(1).max(1000);
 const optionalParentPathSchema = z.string().max(1000).optional();
@@ -50,6 +53,13 @@ export const updateModelFolderSchema = z
 
 export const deleteModelFolderSchema = z.object({
   path: relativePathSchema,
+});
+
+export const deleteModelFilesSchema = z.object({
+  fileIds: z.array(z.string().uuid()).min(1).max(MAX_MODEL_FILE_SELECTION_COUNT)
+    .refine((ids) => new Set(ids).size === ids.length, {
+      message: 'File IDs must be unique',
+    }),
 });
 
 export const splitModelFolderSchema = z.object({


### PR DESCRIPTION
## Summary
- replace parallel per-file delete requests with one validated bulk endpoint and transaction
- serialize model aggregate updates, clean file and thumbnail objects in bounded storage batches, and refresh search caches
- document the API/type/architecture contract and add route, integration, concurrency, cleanup, and frontend regression tests

## Validation
- npm test -w @alexandria/backend (61 files, 987 tests passed)
- focused frontend suites (3 files, 38 tests passed)
- npm run lint
- npm run build
- git diff --check

## Test note
The full frontend run passed 380 of 381 tests; the existing 501-file FileTree stress test exceeded its fixed 5-second timeout under full-suite load. The same FileTree test file passes 16 of 16 in isolation, including the updated 500-file delete limit assertion.