### PR TITLE
feat: add MCP model file listing tool

### DIFF
--- a/apps/backend/src/mcp/repository.test.ts
+++ b/apps/backend/src/mcp/repository.test.ts
@@ -254,6 +254,50 @@ describe('raw MCP model repository integration', () => {
       .resolves.toEqual([modelFileRow.storagePath, thumbnailRow.storagePath].sort());
   });
 
+  it('lists raw model-file rows in relative-path order', async () => {
+    const unique = randomUUID().replaceAll('-', '');
+    const [orderedModel] = await db.insert(models).values({
+      name: 'MCP ordered file list',
+      slug: `mcp-ordered-file-list-${unique}`,
+      userId: fixture.userIds[0],
+      libraryId: fixture.libraryIds[0],
+      sourceType: 'manual',
+      status: 'ready',
+    }).returning();
+    fixture.modelIds.push(orderedModel.id);
+
+    await db.insert(modelFiles).values([
+      {
+        modelId: orderedModel.id,
+        filename: 'z.stl',
+        relativePath: 'parts/z.stl',
+        fileType: 'stl',
+        mimeType: 'model/stl',
+        sizeBytes: 2,
+        storagePath: `models/${orderedModel.id}/parts/z.stl`,
+        hash: 'c'.repeat(64),
+      },
+      {
+        modelId: orderedModel.id,
+        filename: 'a.stl',
+        relativePath: 'parts/a.stl',
+        fileType: 'stl',
+        mimeType: 'model/stl',
+        sizeBytes: 1,
+        storagePath: `models/${orderedModel.id}/parts/a.stl`,
+        hash: 'b'.repeat(64),
+      },
+    ]);
+
+    const result = await handlers.getModelFiles({ modelId: orderedModel.id });
+
+    expect(result.fileCount).toBe(2);
+    expect(result.files.map((file) => file.relativePath)).toEqual([
+      'parts/a.stl',
+      'parts/z.stl',
+    ]);
+  });
+
   it('returns complete model and related table rows after enforcing ownership scope', async () => {
     const result = await handlers.getModel({ modelId: ownedModelRow.id });
 

--- a/apps/backend/src/mcp/tools.test.ts
+++ b/apps/backend/src/mcp/tools.test.ts
@@ -14,6 +14,25 @@ const USER_ID = '11111111-1111-4111-8111-111111111111';
 const LIBRARY_ID = '22222222-2222-4222-8222-222222222222';
 const MODEL_ID = '33333333-3333-4333-8333-333333333333';
 
+function modelFileRow(
+  id: string,
+  relativePath: string,
+) {
+  return {
+    id,
+    modelId: MODEL_ID,
+    filename: relativePath.split('/').at(-1)!,
+    relativePath,
+    fileType: 'stl',
+    mimeType: 'model/stl',
+    sizeBytes: 12,
+    storagePath: `models/${MODEL_ID}/${relativePath}`,
+    hash: 'a'.repeat(64),
+    isDuplicate: false,
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+  };
+}
+
 function modelRow(id = MODEL_ID) {
   return {
     id,
@@ -151,6 +170,49 @@ describe('Alexandria MCP handlers', () => {
     });
 
     expect(deps.rawModels.getRelatedModelInformation).not.toHaveBeenCalled();
+  });
+
+  it('checks ownership before returning raw model-file rows in service order', async () => {
+    const deps = dependencies();
+    const files = [
+      modelFileRow('44444444-4444-4444-8444-444444444444', 'parts/a.stl'),
+      modelFileRow('55555555-5555-4555-8555-555555555555', 'parts/b.stl'),
+    ];
+    vi.mocked(deps.model.getModelFiles).mockResolvedValueOnce(files);
+    const { handlers } = await createAlexandriaMcpHandlers({ userId: USER_ID }, deps);
+
+    const result = await handlers.getModelFiles({ modelId: MODEL_ID });
+
+    expect(deps.model.requireOwnedModel).toHaveBeenCalledWith(
+      MODEL_ID,
+      USER_ID,
+      LIBRARY_ID,
+    );
+    expect(deps.model.getModelFiles).toHaveBeenCalledWith(MODEL_ID);
+    expect(vi.mocked(deps.model.requireOwnedModel).mock.invocationCallOrder[0])
+      .toBeLessThan(vi.mocked(deps.model.getModelFiles).mock.invocationCallOrder[0]);
+    expect(result).toEqual({
+      modelId: MODEL_ID,
+      fileCount: 2,
+      files: files.map((file) => ({
+        ...file,
+        createdAt: file.createdAt.toISOString(),
+      })),
+    });
+  });
+
+  it('does not query model files when model ownership validation fails', async () => {
+    const deps = dependencies();
+    vi.mocked(deps.model.requireOwnedModel).mockRejectedValueOnce(
+      notFound('Model not found'),
+    );
+    const { handlers } = await createAlexandriaMcpHandlers({ userId: USER_ID }, deps);
+
+    await expect(handlers.getModelFiles({ modelId: MODEL_ID })).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+    });
+
+    expect(deps.model.getModelFiles).not.toHaveBeenCalled();
   });
 
   it('returns empty raw search results without running an ownership lookup', async () => {
@@ -364,6 +426,7 @@ describe('Alexandria MCP registration', () => {
       expect(listed.tools.map((tool) => tool.name)).toEqual([
         'alexandria_search_models',
         'alexandria_get_model',
+        'alexandria_get_model_files',
         'alexandria_download_model_files',
         'alexandria_update_model',
         'alexandria_merge_models',
@@ -379,6 +442,12 @@ describe('Alexandria MCP registration', () => {
             openWorldHint: false,
           },
           alexandria_get_model: {
+            readOnlyHint: true,
+            destructiveHint: false,
+            idempotentHint: true,
+            openWorldHint: false,
+          },
+          alexandria_get_model_files: {
             readOnlyHint: true,
             destructiveHint: false,
             idempotentHint: true,
@@ -415,6 +484,51 @@ describe('Alexandria MCP registration', () => {
             openWorldHint: false,
           },
         });
+      const modelFilesTool = listed.tools.find(
+        (tool) => tool.name === 'alexandria_get_model_files',
+      );
+      expect(modelFilesTool?.outputSchema).toMatchObject({
+        type: 'object',
+        additionalProperties: false,
+        required: ['modelId', 'fileCount', 'files'],
+        properties: {
+          modelId: { type: 'string', format: 'uuid' },
+          fileCount: { type: 'integer', minimum: 0 },
+          files: {
+            type: 'array',
+            items: {
+              type: 'object',
+              additionalProperties: false,
+              required: [
+                'id',
+                'modelId',
+                'filename',
+                'relativePath',
+                'fileType',
+                'mimeType',
+                'sizeBytes',
+                'storagePath',
+                'hash',
+                'isDuplicate',
+                'createdAt',
+              ],
+              properties: {
+                id: { type: 'string', format: 'uuid' },
+                modelId: { type: 'string', format: 'uuid' },
+                filename: { type: 'string' },
+                relativePath: { type: 'string' },
+                fileType: { enum: ['stl', 'image', 'document', 'other'] },
+                mimeType: { type: 'string' },
+                sizeBytes: { type: 'integer', minimum: 0 },
+                storagePath: { type: 'string' },
+                hash: { type: 'string' },
+                isDuplicate: { type: 'boolean' },
+                createdAt: { type: 'string', format: 'date-time' },
+              },
+            },
+          },
+        },
+      });
 
       const searchResult = await client.callTool({
         name: 'alexandria_search_models',
@@ -488,6 +602,42 @@ describe('Alexandria MCP registration', () => {
         },
       });
       expect(JSON.stringify(failure)).not.toContain('database password');
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+
+  it('returns raw model-file rows through the registered transport tool', async () => {
+    const deps = dependencies();
+    const files = [
+      modelFileRow('44444444-4444-4444-8444-444444444444', 'parts/a.stl'),
+      modelFileRow('55555555-5555-4555-8555-555555555555', 'parts/b.stl'),
+    ];
+    vi.mocked(deps.model.getModelFiles).mockResolvedValueOnce(files);
+    const server = await createAlexandriaMcpServer({ userId: USER_ID }, deps);
+    const client = new Client({ name: 'test-client', version: '1.0.0' });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+    try {
+      const result = await client.callTool({
+        name: 'alexandria_get_model_files',
+        arguments: { modelId: MODEL_ID },
+      });
+
+      expect(result.isError).not.toBe(true);
+      expect(result.structuredContent).toEqual({
+        modelId: MODEL_ID,
+        fileCount: 2,
+        files: files.map((file) => ({
+          ...file,
+          createdAt: file.createdAt.toISOString(),
+        })),
+      });
+      expect(((result.content as Array<{ text: string }>)[0]).text)
+        .toContain(`Loaded 2 file(s) for model ${MODEL_ID}.`);
     } finally {
       await client.close();
       await server.close();

--- a/apps/backend/src/mcp/tools.ts
+++ b/apps/backend/src/mcp/tools.ts
@@ -32,6 +32,25 @@ import {
 const logger = createLogger('McpTools');
 
 const modelIdSchema = z.object({ modelId: z.string().uuid() });
+const modelFileOutputSchema = z.object({
+  id: z.string().uuid(),
+  modelId: z.string().uuid(),
+  filename: z.string(),
+  relativePath: z.string(),
+  fileType: z.enum(['stl', 'image', 'document', 'other']),
+  mimeType: z.string(),
+  sizeBytes: z.number().int().nonnegative(),
+  storagePath: z.string(),
+  hash: z.string(),
+  isDuplicate: z.boolean(),
+  createdAt: z.string().datetime(),
+}).strict();
+const modelFileListOutputSchema = z.object({
+  modelId: z.string().uuid(),
+  fileCount: z.number().int().nonnegative(),
+  files: z.array(modelFileOutputSchema),
+}).strict();
+type ModelFileListOutput = z.infer<typeof modelFileListOutputSchema>;
 const mergeModelInputSchema = z.object({ targetModelId: z.string().uuid() })
   .merge(mergeModelsSchema);
 const downloadInputSchema = z.object({
@@ -115,6 +134,7 @@ const defaultDependencies: McpDependencies = {
 export interface AlexandriaMcpHandlers {
   searchModels(params: ModelSearchParams): Promise<Record<string, unknown>>;
   getModel(input: z.infer<typeof modelIdSchema>): Promise<RawModelInformation>;
+  getModelFiles(input: z.infer<typeof modelIdSchema>): Promise<ModelFileListOutput>;
   downloadFiles(input: z.infer<typeof downloadInputSchema>): Promise<Record<string, unknown>>;
   updateModel(input: z.infer<typeof updateInputSchema>): Promise<Record<string, unknown>>;
   mergeModels(input: z.infer<typeof mergeModelInputSchema>): Promise<Record<string, unknown>>;
@@ -223,6 +243,16 @@ export async function createAlexandriaMcpHandlers(
       const model = await requireOwnedModel(modelId);
       const related = await dependencies.rawModels.getRelatedModelInformation(modelId);
       return { model, ...related } as RawModelInformation;
+    },
+
+    async getModelFiles({ modelId }) {
+      await requireOwnedModel(modelId);
+      const rawFiles = await dependencies.model.getModelFiles(modelId);
+      return modelFileListOutputSchema.parse({
+        modelId,
+        fileCount: rawFiles.length,
+        files: rawFiles.map((file) => jsonSafe(file)),
+      });
     },
 
     async downloadFiles({ modelId, fileIds, subdirectory, overwrite }) {
@@ -412,6 +442,25 @@ export async function createAlexandriaMcpServer(
     summary: `Loaded complete raw information for model ${input.modelId}.`,
     result: await handlers.getModel(input),
   })));
+
+  server.registerTool('alexandria_get_model_files', {
+    title: 'Get Alexandria model files',
+    description: 'Return every raw model-file row for an owned model in relative-path order.',
+    inputSchema: modelIdSchema,
+    outputSchema: modelFileListOutputSchema,
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+  }, safely(async (input) => {
+    const result = await handlers.getModelFiles(input);
+    return {
+      summary: `Loaded ${String(result.fileCount)} file(s) for model ${input.modelId}.`,
+      result,
+    };
+  }));
 
   server.registerTool('alexandria_download_model_files', {
     title: 'Download Alexandria model files',

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -243,13 +243,17 @@ migrations, or seed logic. The process requires `ALEXANDRIA_MCP_USER_ID`, resolv
 user's owned `ALEXANDRIA_MCP_LIBRARY_ID` or their default library, and applies both values as a
 server-owned scope to every tool call. Tool input can never select a different user or library.
 
-The MCP adapter exposes search, raw model inspection, managed-file download, model and metadata
-updates, tag changes, merge, and delete. Mutations delegate to `ModelService`, `MetadataService`,
-`LibraryService`, and the configured `IStorageService` rather than duplicating domain rules. Raw
-inspection is the deliberate exception to presenter DTOs: a dedicated read repository returns all
-columns from the model and related model-file, folder, metadata-definition/value, tag-membership,
+The MCP adapter exposes search, raw model inspection, a focused raw model-file listing, managed-file
+download, model and metadata updates, tag changes, merge, and delete. Mutations delegate to
+`ModelService`, `MetadataService`, `LibraryService`, and the configured `IStorageService` rather
+than duplicating domain rules.
+
+Raw inspection is the deliberate exception to presenter DTOs: a dedicated read repository returns
+all columns from the model and related model-file, folder, metadata-definition/value, tag-membership,
 collection-membership, and thumbnail rows so MCP clients can inspect information the UI does not
 render. Ownership and library membership are checked before those related rows are queried.
+The focused file-list tool applies the same ownership check, then returns the model-file rows in
+relative-path order without querying the model's other relationships.
 
 Downloads stream through `IStorageService`, so local and S3-backed libraries behave identically.
 They may write only beneath a pre-created `ALEXANDRIA_MCP_DOWNLOAD_DIR`; relative-path validation, real-path and

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -4,19 +4,20 @@ Alexandria includes a local Model Context Protocol server for trusted stdio clie
 
 ## Tools
 
-The server exposes exactly seven tools. MCP clients receive the input schemas during tool discovery.
+The server exposes exactly eight tools. MCP clients receive the input schemas during tool discovery.
 
 | Tool | Capability |
 |---|---|
 | `alexandria_search_models` | Searches the configured library using Alexandria's model search parameters, including text, tags, collection, file type, status, metadata filters, sorting, cursor, and page size. Results contain complete raw model table rows rather than presenter-shaped model summaries. |
 | `alexandria_get_model` | Returns every column from the owned model row plus its model-file, folder, metadata value and definition, tag and tag-membership, collection and collection-membership, and thumbnail rows. This includes stored information that the web UI does not render. |
+| `alexandria_get_model_files` | Accepts `{ modelId: UUID }` and returns `{ modelId, fileCount, files }` after verifying that the configured user owns the model in the configured library. `files` contains `id`, `modelId`, `filename`, `relativePath`, `fileType`, `mimeType`, `sizeBytes`, `storagePath`, `hash`, `isDuplicate`, and ISO 8601 `createdAt` fields in relative-path order. The file IDs are accepted by `alexandria_download_model_files`; unlike `alexandria_get_model`, this tool does not load other relationships. |
 | `alexandria_download_model_files` | Downloads all files for an owned model, or the selected `fileIds`, into a required `subdirectory` beneath the configured download root. `overwrite` defaults to `false`. |
 | `alexandria_update_model` | Updates core model fields, metadata values keyed by field slug, or both. Core and metadata changes run in one ownership-locked database transaction. |
 | `alexandria_merge_models` | Merges one to 100 owned, ready source models into an owned, ready target model. It moves their files and applicable relationships to the target and deletes the source model rows. |
 | `alexandria_delete_model` | Deletes one owned model and its database relationships, then attempts best-effort cleanup of every managed file. |
 | `alexandria_tag_model` | Adds, removes, or replaces tags on one owned model through Alexandria's metadata normalization and validation. An empty tag list is valid only for `replace`, where it clears the tags. |
 
-Dates in tool results are serialized as ISO 8601 strings and bigint values as strings. `alexandria_search_models` returns raw model rows only; use `alexandria_get_model` when related table rows are required.
+Dates in tool results are serialized as ISO 8601 strings and bigint values as strings. `alexandria_search_models` returns raw model rows only; use `alexandria_get_model_files` when only file rows are required, or `alexandria_get_model` for the model's complete related data.
 
 ## Prerequisites and environment
 

--- a/docs/TYPES.md
+++ b/docs/TYPES.md
@@ -99,6 +99,7 @@ interface ModelFile {
   sizeBytes: number;
   storagePath: string; // backend-independent logical key, never a public URL
   hash: string;
+  isDuplicate: boolean;
   createdAt: string;
 }
 


### PR DESCRIPTION
## Summary

- add a read-only `alexandria_get_model_files` MCP tool scoped to the configured user and library
- publish and validate its exact structured output schema, including downloadable file IDs
- document the new tool and cover authorization, discovery, serialization, and database-backed ordering

## Validation

- `npm test -w @alexandria/backend -- src/mcp/tools.test.ts`
- `npm test -w @alexandria/backend -- src/mcp/repository.test.ts`
- `npm run build -w @alexandria/backend`
- `git diff --check`