### PR TITLE
feat: staged Telegram import with an operator reorganization pause

### DIFF
--- a/docs/superpowers/plans/2026-07-25-alexandria-metadata-json-prefill.md
+++ b/docs/superpowers/plans/2026-07-25-alexandria-metadata-json-prefill.md
@@ -1,0 +1,463 @@
+# Alexandria metadata.json Prefill Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When an uploaded archive contains `metadata.json` at its root, detect it during the scan phase and surface it on the import session so the review form prefills.
+
+**Architecture:** Purely additive to the existing scan-phase detection. `IngestionService.detectImportMetadata` gains a root-directory parameter, reads `metadata.json` from the extracted tree, validates it leniently against the existing `batchUploadMetadataSchema`, and stores the result on `DetectedImportMetadata.metadataFile`. **Never auto-applied at commit** — the client always sends the metadata it intends, so this change cannot alter the outcome of any existing upload path.
+
+**Tech Stack:** Fastify, TypeScript, Drizzle, Zod, Vitest; React + Vite frontend.
+
+**Spec:** `docs/superpowers/specs/2026-07-25-telegram-staged-import-design.md` §5
+
+**Relationship to the importer plan:** Independent. `docs/superpowers/plans/2026-07-25-telegram-staged-import.md` does not depend on this, because the importer sends `batchMetadata` explicitly at commit — which is what lets an upload-as-is `.7z`, whose bytes the backend cannot modify, still carry its metadata. This plan is what makes a hand-made zip dropped into the web UI prefill too.
+
+**Conventions in this codebase you must follow:**
+- Run tests with `npm test -w @alexandria/backend`; backend tests need `npm run services:up` first.
+- Do **not** export `DATABASE_URL` — `apps/backend/vitest.config.ts` pins the test database.
+- Do **not** run `npx vitest` from the repo root.
+- Never commit to `main`; this plan's work belongs on its own branch and PR.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `packages/shared/src/types/upload.ts` (modify) | `DetectedMetadataFile` type, `metadataFile` field on `DetectedImportMetadata` |
+| `packages/shared/src/validation/upload.ts` (modify) | `metadataFileSchema` — lenient parse of an archive's `metadata.json` |
+| `apps/backend/src/services/ingestion.service.ts` (modify) | Read and validate `metadata.json` during detection |
+| `apps/backend/src/services/ingestion.service.test.ts` (modify) | Detection tests |
+| `apps/frontend/…` review form (modify) | Prefill empty fields from `detected.metadataFile` |
+| `docs/TYPES.md`, `docs/API.md` (modify) | Document the new field |
+
+---
+
+## Task 1: Shared type and lenient schema
+
+**Files:**
+- Modify: `packages/shared/src/types/upload.ts`
+- Modify: `packages/shared/src/validation/upload.ts`
+- Test: `packages/shared/src/validation/upload.test.ts` (create if absent)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create or append to `packages/shared/src/validation/upload.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { metadataFileSchema } from './upload.js';
+
+describe('metadataFileSchema', () => {
+  it('should keep known commit fields', () => {
+    const result = metadataFileSchema.safeParse({
+      modelName: 'Dragon Knight',
+      description: 'A dragon',
+      artist: 'Foo Studios',
+      tags: ['dragon', 'fantasy'],
+      metadata: { scale: '32mm' },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual({
+      modelName: 'Dragon Knight',
+      description: 'A dragon',
+      artist: 'Foo Studios',
+      tags: ['dragon', 'fantasy'],
+      metadata: { scale: '32mm' },
+    });
+  });
+
+  it('should strip keys the commit endpoint does not accept', () => {
+    const result = metadataFileSchema.safeParse({
+      modelName: 'Dragon',
+      schemaVersion: 1,
+      source: { channelId: -100 },
+      result: { modelId: 'abc' },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual({ modelName: 'Dragon' });
+  });
+
+  it('should drop individually invalid fields rather than rejecting the file', () => {
+    const result = metadataFileSchema.safeParse({
+      modelName: 'Dragon',
+      tags: 'not-an-array',
+      artist: 12345,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual({ modelName: 'Dragon' });
+  });
+
+  it('should reject a non-object root', () => {
+    expect(metadataFileSchema.safeParse([1, 2]).success).toBe(false);
+    expect(metadataFileSchema.safeParse('nope').success).toBe(false);
+  });
+
+  it('should accept an empty object', () => {
+    const result = metadataFileSchema.safeParse({});
+
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual({});
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npm test -w @alexandria/shared`
+Expected: FAIL — `metadataFileSchema` is not exported
+
+- [ ] **Step 3: Add the type**
+
+In `packages/shared/src/types/upload.ts`, add above `DetectedImportMetadata`:
+
+```typescript
+/**
+ * A `metadata.json` found at the root of an uploaded archive. Prefill only —
+ * never applied automatically at commit. The client always sends the metadata
+ * it intends, so detection cannot change an upload's outcome.
+ */
+export type DetectedMetadataFile = Pick<
+  BatchUploadMetadata,
+  'modelName' | 'description' | 'artist' | 'tags' | 'metadata' | 'collectionId' | 'newCollectionName'
+>;
+```
+
+Add this field to the `DetectedImportMetadata` interface, immediately after `archives`:
+
+```typescript
+  /** Parsed root-level metadata.json, when the archive carried one. */
+  metadataFile?: DetectedMetadataFile;
+```
+
+Verify `BatchUploadMetadata` is already imported or defined in that file; if it lives in the validation module, import the type.
+
+- [ ] **Step 4: Add the schema**
+
+In `packages/shared/src/validation/upload.ts`, add after `batchUploadMetadataSchema`:
+
+```typescript
+/**
+ * Lenient parse of an archive's metadata.json. Every field is independently
+ * optional and catches to undefined, so one malformed value never costs the
+ * operator the rest of a hand-written file.
+ */
+export const metadataFileSchema = z.object({
+  modelName: z.string().min(1).max(255).optional().catch(undefined),
+  description: z.string().max(2000).optional().catch(undefined),
+  artist: z.string().max(255).optional().catch(undefined),
+  tags: z.array(z.string().min(1).max(100)).max(50).optional().catch(undefined),
+  metadata: setModelMetadataSchema.optional().catch(undefined),
+  collectionId: z.string().uuid().optional().catch(undefined),
+  newCollectionName: z.string().min(1).max(255).optional().catch(undefined),
+}).strip();
+
+export type DetectedMetadataFileInput = z.infer<typeof metadataFileSchema>;
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `npm test -w @alexandria/shared`
+Expected: PASS, 5 tests
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/shared/src/types/upload.ts packages/shared/src/validation/upload.ts packages/shared/src/validation/upload.test.ts
+git commit -m "feat: add a lenient schema for archive metadata.json prefill"
+```
+
+---
+
+## Task 2: Detect metadata.json during the scan
+
+**Files:**
+- Modify: `apps/backend/src/services/ingestion.service.ts`
+- Test: `apps/backend/src/services/ingestion.service.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `apps/backend/src/services/ingestion.service.test.ts`. Match the file's existing import and setup style — read its first 40 lines before writing.
+
+```typescript
+describe('metadata.json detection', () => {
+  let rootDir: string;
+
+  beforeEach(async () => {
+    rootDir = await fsPromises.mkdtemp(path.join(os.tmpdir(), 'alexandria-metadata-'));
+  });
+
+  afterEach(async () => {
+    await fsPromises.rm(rootDir, { recursive: true, force: true });
+  });
+
+  async function writeMetadata(contents: string): Promise<void> {
+    await fsPromises.writeFile(path.join(rootDir, 'metadata.json'), contents, 'utf8');
+  }
+
+  it('should surface a valid root metadata.json', async () => {
+    await writeMetadata(JSON.stringify({ modelName: 'Dragon', tags: ['dragon'] }));
+
+    const detected = await readMetadataFile(rootDir);
+
+    expect(detected).toEqual({ modelName: 'Dragon', tags: ['dragon'] });
+  });
+
+  it('should strip importer-only keys', async () => {
+    await writeMetadata(
+      JSON.stringify({ modelName: 'Dragon', schemaVersion: 1, source: { channelId: -1 } }),
+    );
+
+    expect(await readMetadataFile(rootDir)).toEqual({ modelName: 'Dragon' });
+  });
+
+  it('should return undefined when the file is absent', async () => {
+    expect(await readMetadataFile(rootDir)).toBeUndefined();
+  });
+
+  it('should return undefined for unparseable JSON', async () => {
+    await writeMetadata('{not json');
+
+    expect(await readMetadataFile(rootDir)).toBeUndefined();
+  });
+
+  it('should return undefined for a non-object root', async () => {
+    await writeMetadata('[1, 2, 3]');
+
+    expect(await readMetadataFile(rootDir)).toBeUndefined();
+  });
+
+  it('should return undefined for a file over the size cap', async () => {
+    await writeMetadata(JSON.stringify({ description: 'x'.repeat(70 * 1024) }));
+
+    expect(await readMetadataFile(rootDir)).toBeUndefined();
+  });
+
+  it('should ignore a metadata.json nested below the archive root', async () => {
+    await fsPromises.mkdir(path.join(rootDir, 'inner'), { recursive: true });
+    await fsPromises.writeFile(
+      path.join(rootDir, 'inner', 'metadata.json'),
+      JSON.stringify({ modelName: 'Nested' }),
+      'utf8',
+    );
+
+    expect(await readMetadataFile(rootDir)).toBeUndefined();
+  });
+
+  it('should return an empty object for a file with no usable fields', async () => {
+    await writeMetadata(JSON.stringify({ source: { channelId: -1 } }));
+
+    expect(await readMetadataFile(rootDir)).toEqual({});
+  });
+});
+```
+
+Import `readMetadataFile` from the service module, plus `fsPromises`, `path`, and `os`.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npm run services:up` then `npm test -w @alexandria/backend -- ingestion.service`
+Expected: FAIL — `readMetadataFile` is not exported
+
+- [ ] **Step 3: Write the implementation**
+
+In `apps/backend/src/services/ingestion.service.ts`, add near the other module-level constants:
+
+```typescript
+const METADATA_FILENAME = 'metadata.json';
+const MAX_METADATA_FILE_BYTES = 64 * 1024;
+```
+
+Import `metadataFileSchema` and the `DetectedMetadataFile` type from `@alexandria/shared`.
+
+Add this exported function at module level (not a class method — it is pure and directly testable):
+
+```typescript
+/**
+ * Read an archive root's metadata.json for review-form prefill.
+ *
+ * Best-effort by design: an unreadable, oversized, or malformed file is
+ * skipped rather than failing the scan, because detection must never be able
+ * to break an upload that would otherwise have succeeded.
+ */
+export async function readMetadataFile(
+  rootDir: string,
+): Promise<DetectedMetadataFile | undefined> {
+  const filePath = path.join(rootDir, METADATA_FILENAME);
+  try {
+    const stats = await fsPromises.stat(filePath);
+    if (!stats.isFile() || stats.size > MAX_METADATA_FILE_BYTES) return undefined;
+    const parsed: unknown = JSON.parse(await fsPromises.readFile(filePath, 'utf8'));
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      return undefined;
+    }
+    const result = metadataFileSchema.safeParse(parsed);
+    if (!result.success) return undefined;
+    return Object.fromEntries(
+      Object.entries(result.data).filter(([, value]) => value !== undefined),
+    ) as DetectedMetadataFile;
+  } catch {
+    return undefined;
+  }
+}
+```
+
+Change `detectImportMetadata`'s signature to accept the root directory:
+
+```typescript
+  private async detectImportMetadata(
+    manifest: FileManifest,
+    originalFilename: string,
+    libraryId: string,
+    rootDir: string,
+  ): Promise<DetectedImportMetadata> {
+```
+
+Inside it, change the `Promise.all` to also read the file, and add the field to the returned object:
+
+```typescript
+    const [artist, tagsGuessed, metadataFile] = await Promise.all([
+      this.guessArtist(entries, originalFilename, libraryId),
+      this.guessTags(entries, libraryId),
+      readMetadataFile(rootDir),
+    ]);
+```
+
+```typescript
+      archives: entries
+        .filter((entry) => Boolean(detectArchiveExtension(entry.filename)))
+        .map((entry) => ({
+          filename: entry.filename,
+          relativePath: entry.relativePath,
+          sizeBytes: entry.sizeBytes,
+        })),
+      ...(metadataFile ? { metadataFile } : {}),
+    };
+```
+
+Update all three call sites to pass the root they already have in scope:
+- Line ~226 in `processScanJob` → pass `extractDir`
+- Line ~310 → pass `stagingRoot`
+- Line ~378 → pass `stagingRoot`
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `npm test -w @alexandria/backend -- ingestion.service`
+Expected: PASS, including the 8 new tests and every pre-existing one
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/backend/src/services/ingestion.service.ts apps/backend/src/services/ingestion.service.test.ts
+git commit -m "feat: detect a root metadata.json during import scanning"
+```
+
+---
+
+## Task 3: Prefill the review form
+
+**Files:**
+- Modify: the import review form under `apps/frontend/src`
+
+- [ ] **Step 1: Locate the review form**
+
+Run: `grep -rln "tagsGuessed\|detected\." apps/frontend/src`
+
+The component consuming `detected.artist` and `detected.tagsGuessed` for the commit form is the one to change. Read it fully before editing.
+
+- [ ] **Step 2: Write the failing test**
+
+Follow the test style already used beside that component. The test must assert:
+
+- Given a session whose `detected.metadataFile` is `{ modelName: 'Dragon', artist: 'Foo', tags: ['dragon'] }`, the form's name, artist, and tags inputs are populated with those values on first render.
+- Given a `metadataFile` **and** a user-entered value, the user's value wins — prefill never overwrites input the user has already made.
+- Given `metadataFile` absent, behavior is exactly as before this change (existing tests must cover this; if none does, add one).
+
+Run the test and confirm it fails before implementing.
+
+- [ ] **Step 3: Implement the prefill**
+
+Apply `detected.metadataFile` values as the initial form state, taking precedence over `detected.artist` / `detected.tagsGuessed` (an explicit file beats a heuristic guess) but never over state the user has already changed.
+
+- [ ] **Step 4: Run the frontend suite**
+
+Run: `npm test -w @alexandria/frontend`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/frontend/src
+git commit -m "feat: prefill the import review form from a detected metadata.json"
+```
+
+---
+
+## Task 4: Documentation
+
+**Files:**
+- Modify: `docs/TYPES.md`, `docs/API.md`
+
+- [ ] **Step 1: Update the docs**
+
+In `docs/TYPES.md`, document `DetectedMetadataFile` and the `metadataFile` field on `DetectedImportMetadata`, stating that it is prefill only and never auto-applied at commit.
+
+In `docs/API.md`, update the import-session response documentation for `GET /models/import-sessions/{id}` to include `detected.metadataFile`, with a note on the 64 KB cap, root-only lookup, and best-effort parsing.
+
+Per `CLAUDE.md`, run the `documentation` agent for this task — the change alters a type contract and an endpoint response.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/TYPES.md docs/API.md
+git commit -m "docs: document detected metadata.json prefill"
+```
+
+---
+
+## Task 5: Full verification and PR
+
+- [ ] **Step 1: Run everything**
+
+```bash
+npm test
+npm run lint
+npm run build
+```
+
+Expected: all pass.
+
+- [ ] **Step 2: Verify the commit path is genuinely unchanged**
+
+Run: `npm test -w @alexandria/backend -- upload.service import-session.service`
+Expected: PASS with no assertion changes. A commit with no `batchMetadata` must still produce a model with no metadata applied — detection must not have leaked into `applyBatchMetadata`. If any of those assertions needed changing, the prefill-only guarantee was broken; stop and report it.
+
+- [ ] **Step 3: Run the reviewer agent**
+
+Per `CLAUDE.md`, run the `reviewer` agent over the diff.
+
+- [ ] **Step 4: Open the PR**
+
+```bash
+gh pr create --title "feat: prefill import review from a metadata.json in the archive" --body "..."
+```
+
+The body must state the prefill-only guarantee and that no existing upload path changes behavior. Do not merge.
+
+---
+
+## Self-Review Notes
+
+Checked against spec §5:
+
+- Lenient validation against `batchUploadMetadataSchema` with unknown keys stripped → Task 1.
+- Invalid JSON, non-object root, >64 KB skipped with no scan failure → Task 2.
+- Surfaced as an optional field on `detected`, added to `packages/shared` → Tasks 1, 2.
+- Documented in `docs/TYPES.md` and `docs/API.md` → Task 4.
+- Frontend prefills empty fields → Task 3.
+- Never auto-applied at commit → guaranteed by construction (nothing in this plan touches `applyBatchMetadata`) and verified explicitly in Task 5 Step 2.
+
+Tasks 3 and 4 intentionally specify assertions and required content rather than literal code: the frontend component and doc sections must be read before editing, and inventing their current contents here would produce edits that do not apply. Every backend and shared-package change — where the existing code was read directly — carries complete code.

--- a/docs/superpowers/plans/2026-07-25-telegram-staged-import.md
+++ b/docs/superpowers/plans/2026-07-25-telegram-staged-import.md
@@ -1,0 +1,2576 @@
+# Telegram Staged Import Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Split the Telegram importer into a download phase that stages bundles as folders on disk and an upload phase that ingests folders into Alexandria, with an operator intervention window between them.
+
+**Architecture:** Three new modules in `tools/telegram-importer` — `folder_metadata.py` (pure JSON read/write/merge), `staging.py` (Telegram → folders), `folder_upload.py` (folders → Alexandria). They reuse `TelegramSource`, `AlexandriaClient`, `grouping`, and `progress` directly. `importer.py` and `ChannelImporter` are **not** modified: the existing direct-import path keeps its dedupe, session-recovery, and signature-gate semantics, none of which the staged flow wants.
+
+**Tech Stack:** Python 3.12, `uv`, pytest with `asyncio_mode = "auto"`, SQLite via stdlib `sqlite3`, `httpx`, Telethon.
+
+**Spec:** `docs/superpowers/specs/2026-07-25-telegram-staged-import-design.md`
+
+**Conventions in this codebase you must follow:**
+- Test names read `test_should_<behavior>`. See `tests/test_importer.py`.
+- All modules start with `from __future__ import annotations`.
+- Dataclasses are `@dataclass(frozen=True, slots=True)`.
+- Run tests with `uv run pytest` from `tools/telegram-importer`.
+- Lint with `uv run ruff check .` from the same directory.
+- Commit style is conventional commits: `<type>: <description>`.
+
+**Working directory for every command in this plan:** `tools/telegram-importer`
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `src/alexandria_telegram_importer/folder_metadata.py` (new) | `metadata.json` read/write, inheritance merge, folder-name → model-name |
+| `src/alexandria_telegram_importer/staging.py` (new) | Bundle keys, folder naming, downloading a bundle into a folder |
+| `src/alexandria_telegram_importer/folder_upload.py` (new) | Discovery walk, `models/` classification, upload/commit, disposal |
+| `src/alexandria_telegram_importer/tracker.py` (modify) | `staged_bundles` table and accessors |
+| `src/alexandria_telegram_importer/cli.py` (modify) | New flags, mutual exclusion, the pause |
+| `tests/test_folder_metadata.py` (new) | Task 1 |
+| `tests/test_staging.py` (new) | Tasks 2–4 |
+| `tests/test_folder_upload.py` (new) | Tasks 5–8 |
+| `tests/test_cli.py` (modify) | Task 9 |
+
+---
+
+## Task 1: Folder metadata read, write, and merge
+
+**Files:**
+- Create: `src/alexandria_telegram_importer/folder_metadata.py`
+- Test: `tests/test_folder_metadata.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_folder_metadata.py`:
+
+```python
+from __future__ import annotations
+
+import json
+
+from alexandria_telegram_importer.folder_metadata import (
+    SCHEMA_VERSION,
+    batch_metadata,
+    merge_chain,
+    model_name_from_folder,
+    read_metadata,
+    write_metadata,
+)
+
+
+def test_should_return_none_for_a_folder_without_metadata(tmp_path) -> None:
+    assert read_metadata(tmp_path) is None
+
+
+def test_should_return_none_for_unparseable_or_non_object_metadata(tmp_path) -> None:
+    (tmp_path / "metadata.json").write_text("{not json", encoding="utf-8")
+    assert read_metadata(tmp_path) is None
+
+    (tmp_path / "metadata.json").write_text("[1, 2]", encoding="utf-8")
+    assert read_metadata(tmp_path) is None
+
+
+def test_should_round_trip_metadata_preserving_unknown_keys(tmp_path) -> None:
+    write_metadata(tmp_path, {"modelName": "Dragon", "somethingNew": {"a": 1}})
+
+    loaded = read_metadata(tmp_path)
+
+    assert loaded["modelName"] == "Dragon"
+    assert loaded["somethingNew"] == {"a": 1}
+    assert loaded["schemaVersion"] == SCHEMA_VERSION
+    assert json.loads((tmp_path / "metadata.json").read_text(encoding="utf-8"))
+
+
+def test_should_let_the_nearest_level_win_for_scalars() -> None:
+    merged = merge_chain(
+        [
+            {"artist": "Release Studios", "description": "release blurb"},
+            {"artist": "Child Studios"},
+        ],
+    )
+
+    assert merged["artist"] == "Child Studios"
+    assert merged["description"] == "release blurb"
+
+
+def test_should_merge_tags_across_levels_without_duplicates() -> None:
+    merged = merge_chain(
+        [{"tags": ["dragon", "fantasy"]}, {"tags": ["knight", "dragon"]}],
+    )
+
+    assert merged["tags"] == ["dragon", "fantasy", "knight"]
+
+
+def test_should_merge_metadata_and_options_key_by_key() -> None:
+    merged = merge_chain(
+        [
+            {"metadata": {"scale": "32mm", "license": "personal"}, "options": {"markNsfw": True}},
+            {"metadata": {"license": "commercial"}},
+        ],
+    )
+
+    assert merged["metadata"] == {"scale": "32mm", "license": "commercial"}
+    assert merged["options"] == {"markNsfw": True}
+
+
+def test_should_never_inherit_model_name_from_a_container() -> None:
+    merged = merge_chain([{"modelName": "Dragon Set"}, {"artist": "Foo"}])
+
+    assert "modelName" not in merged
+
+
+def test_should_take_model_name_from_the_leaf_level_only() -> None:
+    merged = merge_chain([{"modelName": "Dragon Set"}, {"modelName": "Dragon Knight"}])
+
+    assert merged["modelName"] == "Dragon Knight"
+
+
+def test_should_ignore_null_values_when_merging() -> None:
+    merged = merge_chain([{"artist": "Foo"}, {"artist": None}])
+
+    assert merged["artist"] == "Foo"
+
+
+def test_should_derive_a_model_name_from_a_staged_folder_name() -> None:
+    assert model_name_from_folder("002501-dragon-knight") == "dragon knight"
+    assert model_name_from_folder("dragon_knight") == "dragon knight"
+    assert model_name_from_folder("123-abc") == "123 abc"
+
+
+def test_should_strip_non_commit_keys_from_batch_metadata() -> None:
+    payload = batch_metadata(
+        {
+            "modelName": "Dragon",
+            "tags": ["a"],
+            "schemaVersion": 1,
+            "source": {"channelId": -100},
+            "result": None,
+            "artist": None,
+        },
+    )
+
+    assert payload == {"modelName": "Dragon", "tags": ["a"]}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `uv run pytest tests/test_folder_metadata.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'alexandria_telegram_importer.folder_metadata'`
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/alexandria_telegram_importer/folder_metadata.py`:
+
+```python
+from __future__ import annotations
+
+import json
+import logging
+import re
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+SCHEMA_VERSION = 1
+METADATA_FILENAME = "metadata.json"
+
+# Fields the commit endpoint accepts. Kept in sync with
+# packages/shared/src/validation/upload.ts batchUploadMetadataSchema.
+COMMIT_FIELDS = (
+    "modelName",
+    "description",
+    "collectionId",
+    "newCollectionName",
+    "artist",
+    "tags",
+    "metadata",
+    "options",
+)
+_INHERITED_SCALARS = ("description", "collectionId", "newCollectionName", "artist")
+_INHERITED_MAPPINGS = ("metadata", "options")
+
+_FOLDER_PREFIX_RE = re.compile(r"^\d{4,}-")
+
+
+def read_metadata(folder: Path) -> dict[str, Any] | None:
+    """Read one folder's metadata.json, or None when it is absent or unusable."""
+    path = folder / METADATA_FILENAME
+    if not path.is_file():
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as error:
+        log.warning("Ignoring unreadable %s: %s", path, error)
+        return None
+    if not isinstance(payload, dict):
+        log.warning("Ignoring %s: expected a JSON object", path)
+        return None
+    return payload
+
+
+def write_metadata(folder: Path, payload: dict[str, Any]) -> None:
+    folder.mkdir(parents=True, exist_ok=True)
+    document = {"schemaVersion": SCHEMA_VERSION, **payload}
+    (folder / METADATA_FILENAME).write_text(
+        json.dumps(document, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+
+def merge_chain(chain: Sequence[dict[str, Any]]) -> dict[str, Any]:
+    """Merge metadata from outermost container to model folder.
+
+    modelName deliberately does not inherit: a release-level name would
+    otherwise commit every model in the release under one title.
+    """
+    merged: dict[str, Any] = {}
+    tags: list[str] = []
+    for level, payload in enumerate(chain):
+        for key in _INHERITED_SCALARS:
+            if payload.get(key) is not None:
+                merged[key] = payload[key]
+        for key in _INHERITED_MAPPINGS:
+            value = payload.get(key)
+            if isinstance(value, dict):
+                merged.setdefault(key, {}).update(value)
+        for tag in payload.get("tags") or []:
+            if tag not in tags:
+                tags.append(tag)
+        if level == len(chain) - 1 and payload.get("modelName"):
+            merged["modelName"] = payload["modelName"]
+    if tags:
+        merged["tags"] = tags
+    return merged
+
+
+def batch_metadata(effective: dict[str, Any]) -> dict[str, Any]:
+    """Reduce merged metadata to the fields the commit endpoint accepts."""
+    return {
+        key: effective[key]
+        for key in COMMIT_FIELDS
+        if effective.get(key) is not None
+    }
+
+
+def model_name_from_folder(name: str) -> str:
+    stripped = _FOLDER_PREFIX_RE.sub("", name)
+    cleaned = stripped.replace("_", " ").replace("-", " ").strip()
+    return cleaned or name
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `uv run pytest tests/test_folder_metadata.py -v`
+Expected: PASS, 11 tests
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/alexandria_telegram_importer/folder_metadata.py tests/test_folder_metadata.py
+git commit -m "feat: add staged folder metadata read, write, and inheritance merge"
+```
+
+---
+
+## Task 2: staged_bundles table on the tracker
+
+**Files:**
+- Modify: `src/alexandria_telegram_importer/tracker.py`
+- Test: `tests/test_tracker.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_tracker.py`:
+
+```python
+def test_should_record_and_read_back_a_staged_bundle(tmp_path) -> None:
+    tracker = ImportTracker(tmp_path / "state.sqlite3")
+    try:
+        tracker.record_staged(
+            bundle_key="abc123",
+            source_channel_id=-100987654,
+            folder_name="002501-dragon-set",
+            model_message_ids=(2501, 2502),
+        )
+
+        staged = tracker.get_staged("abc123")
+
+        assert staged is not None
+        assert staged.folder_name == "002501-dragon-set"
+        assert staged.model_message_ids == (2501, 2502)
+        assert staged.status == "downloaded"
+        assert staged.downloaded_at
+    finally:
+        tracker.close()
+
+
+def test_should_report_staged_keys_for_one_channel_only(tmp_path) -> None:
+    tracker = ImportTracker(tmp_path / "state.sqlite3")
+    try:
+        tracker.record_staged(
+            bundle_key="mine",
+            source_channel_id=-100987654,
+            folder_name="a",
+            model_message_ids=(1,),
+        )
+        tracker.record_staged(
+            bundle_key="theirs",
+            source_channel_id=-100111111,
+            folder_name="b",
+            model_message_ids=(2,),
+        )
+
+        assert tracker.staged_keys(-100987654) == {"mine"}
+    finally:
+        tracker.close()
+
+
+def test_should_treat_recording_the_same_bundle_twice_as_idempotent(tmp_path) -> None:
+    tracker = ImportTracker(tmp_path / "state.sqlite3")
+    try:
+        tracker.record_staged(
+            bundle_key="abc123",
+            source_channel_id=-100987654,
+            folder_name="first",
+            model_message_ids=(1,),
+        )
+        tracker.record_staged(
+            bundle_key="abc123",
+            source_channel_id=-100987654,
+            folder_name="second",
+            model_message_ids=(1,),
+        )
+
+        staged = tracker.get_staged("abc123")
+
+        assert staged is not None
+        assert staged.folder_name == "first"
+        assert tracker.staged_keys(-100987654) == {"abc123"}
+    finally:
+        tracker.close()
+
+
+def test_should_add_the_staged_bundles_table_to_an_existing_state_file(tmp_path) -> None:
+    path = tmp_path / "state.sqlite3"
+    legacy = sqlite3.connect(path)
+    legacy.execute(
+        "CREATE TABLE imports ("
+        "import_key TEXT PRIMARY KEY, source_channel_id INTEGER NOT NULL, "
+        "logical_filename TEXT NOT NULL, upload_filename TEXT NOT NULL, "
+        "model_message_ids TEXT NOT NULL, attachment_message_ids TEXT NOT NULL, "
+        "status TEXT NOT NULL, session_id TEXT, model_id TEXT, error TEXT, "
+        "created_at TEXT NOT NULL, updated_at TEXT NOT NULL)",
+    )
+    legacy.commit()
+    legacy.close()
+
+    tracker = ImportTracker(path)
+    try:
+        tracker.record_staged(
+            bundle_key="abc123",
+            source_channel_id=-100987654,
+            folder_name="002501-dragon-set",
+            model_message_ids=(2501,),
+        )
+
+        assert tracker.get_staged("abc123") is not None
+    finally:
+        tracker.close()
+```
+
+`sqlite3` and `ImportTracker` are already imported at the top of `tests/test_tracker.py`. Verify with `head -20 tests/test_tracker.py` and add any missing import.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `uv run pytest tests/test_tracker.py -v -k staged`
+Expected: FAIL — `AttributeError: 'ImportTracker' object has no attribute 'record_staged'`
+
+- [ ] **Step 3: Write the implementation**
+
+In `src/alexandria_telegram_importer/tracker.py`, add this dataclass immediately after the existing `ImportRecord` dataclass (after line 26):
+
+```python
+@dataclass(frozen=True, slots=True)
+class StagedBundle:
+    bundle_key: str
+    source_channel_id: int
+    folder_name: str
+    model_message_ids: tuple[int, ...]
+    status: str
+    downloaded_at: str
+```
+
+In `ImportTracker.__init__`, insert this immediately before the final `self._connection.commit()` (currently line 85):
+
+```python
+        self._connection.execute(
+            """
+            CREATE TABLE IF NOT EXISTS staged_bundles (
+                bundle_key TEXT PRIMARY KEY,
+                source_channel_id INTEGER NOT NULL,
+                folder_name TEXT NOT NULL,
+                model_message_ids TEXT NOT NULL,
+                status TEXT NOT NULL,
+                downloaded_at TEXT NOT NULL
+            )
+            """,
+        )
+        self._connection.execute(
+            "CREATE INDEX IF NOT EXISTS staged_bundles_channel_idx "
+            "ON staged_bundles (source_channel_id)",
+        )
+```
+
+Add these three methods to `ImportTracker`, immediately before `def counts`:
+
+```python
+    def record_staged(
+        self,
+        *,
+        bundle_key: str,
+        source_channel_id: int,
+        folder_name: str,
+        model_message_ids: tuple[int, ...],
+    ) -> StagedBundle:
+        now = datetime.now(UTC).isoformat()
+        with self._connection:
+            self._connection.execute(
+                """
+                INSERT INTO staged_bundles (
+                    bundle_key, source_channel_id, folder_name,
+                    model_message_ids, status, downloaded_at
+                ) VALUES (?, ?, ?, ?, 'downloaded', ?)
+                ON CONFLICT(bundle_key) DO NOTHING
+                """,
+                (
+                    bundle_key,
+                    source_channel_id,
+                    folder_name,
+                    json.dumps(model_message_ids),
+                    now,
+                ),
+            )
+        staged = self.get_staged(bundle_key)
+        assert staged is not None
+        return staged
+
+    def get_staged(self, bundle_key: str) -> StagedBundle | None:
+        row = self._connection.execute(
+            "SELECT * FROM staged_bundles WHERE bundle_key = ?",
+            (bundle_key,),
+        ).fetchone()
+        if row is None:
+            return None
+        return StagedBundle(
+            bundle_key=row["bundle_key"],
+            source_channel_id=row["source_channel_id"],
+            folder_name=row["folder_name"],
+            model_message_ids=tuple(json.loads(row["model_message_ids"])),
+            status=row["status"],
+            downloaded_at=row["downloaded_at"],
+        )
+
+    def staged_keys(self, source_channel_id: int) -> set[str]:
+        rows = self._connection.execute(
+            "SELECT bundle_key FROM staged_bundles WHERE source_channel_id = ?",
+            (source_channel_id,),
+        ).fetchall()
+        return {row["bundle_key"] for row in rows}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `uv run pytest tests/test_tracker.py -v`
+Expected: PASS, including the four new tests and every pre-existing one
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/alexandria_telegram_importer/tracker.py tests/test_tracker.py
+git commit -m "feat: track staged Telegram bundles in the importer state file"
+```
+
+---
+
+## Task 3: Bundle keys and folder names
+
+**Files:**
+- Create: `src/alexandria_telegram_importer/staging.py`
+- Test: `tests/test_staging.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_staging.py`:
+
+```python
+from __future__ import annotations
+
+from alexandria_telegram_importer.grouping import build_bundles
+from alexandria_telegram_importer.models import MediaKind
+from alexandria_telegram_importer.staging import bundle_folder_name, bundle_key
+
+
+def test_should_produce_a_stable_bundle_key_regardless_of_discovery_order(
+    media_ref,
+) -> None:
+    forward = list(
+        build_bundles(
+            -100987654,
+            [media_ref(2501, "dragon-knight.zip"), media_ref(2502, "dragon-mage.zip")],
+        ),
+    )
+    reverse = list(
+        build_bundles(
+            -100987654,
+            [media_ref(2502, "dragon-mage.zip"), media_ref(2501, "dragon-knight.zip")],
+        ),
+    )
+
+    assert bundle_key(-100987654, forward[0]) == bundle_key(-100987654, reverse[0])
+
+
+def test_should_produce_different_bundle_keys_for_different_channels(media_ref) -> None:
+    [bundle] = build_bundles(-100987654, [media_ref(2501, "dragon.zip")])
+
+    assert bundle_key(-100987654, bundle) != bundle_key(-100111111, bundle)
+
+
+def test_should_not_collide_with_the_logical_model_key_for_the_same_messages(
+    media_ref,
+) -> None:
+    [bundle] = build_bundles(-100987654, [media_ref(2501, "dragon.zip")])
+
+    assert bundle_key(-100987654, bundle) != bundle.models[0].key
+
+
+def test_should_name_a_folder_from_the_first_message_id_and_first_model(
+    media_ref,
+) -> None:
+    [bundle] = build_bundles(
+        -100987654,
+        [
+            media_ref(2499, "render.jpg", kind=MediaKind.ATTACHMENT),
+            media_ref(2501, "Dragon_Knight Set.zip"),
+            media_ref(2502, "dragon-mage.zip"),
+        ],
+    )
+
+    assert bundle_folder_name(bundle) == "002501-dragon-knight-set"
+
+
+def test_should_slug_awkward_model_names_into_a_safe_folder_name(media_ref) -> None:
+    [bundle] = build_bundles(-100987654, [media_ref(7, "Dragon!!! (v2) [final].zip")])
+
+    assert bundle_folder_name(bundle) == "000007-dragon-v2-final"
+
+
+def test_should_fall_back_to_the_message_id_when_a_name_slugs_to_nothing(
+    media_ref,
+) -> None:
+    [bundle] = build_bundles(-100987654, [media_ref(7, "!!!.zip")])
+
+    assert bundle_folder_name(bundle) == "000007"
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `uv run pytest tests/test_staging.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'alexandria_telegram_importer.staging'`
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/alexandria_telegram_importer/staging.py`:
+
+```python
+from __future__ import annotations
+
+import hashlib
+import re
+
+from .grouping import model_name_from_filename
+from .models import ImportBundle
+
+MAX_SLUG_LENGTH = 60
+
+_SLUG_STRIP_RE = re.compile(r"[^a-z0-9]+")
+
+
+def bundle_message_ids(bundle: ImportBundle) -> tuple[int, ...]:
+    return tuple(
+        sorted(part.message_id for unit in bundle.models for part in unit.parts)
+    )
+
+
+def bundle_key(channel_id: int, bundle: ImportBundle) -> str:
+    """Key one staged bundle.
+
+    The `staged:` prefix keeps this key space disjoint from grouping's
+    per-logical-model `import_key`, which hashes the same message IDs.
+    """
+    ids = ",".join(str(message_id) for message_id in bundle_message_ids(bundle))
+    return hashlib.sha256(f"staged:{channel_id}:{ids}".encode()).hexdigest()[:24]
+
+
+def slug(value: str) -> str:
+    return _SLUG_STRIP_RE.sub("-", value.lower()).strip("-")[:MAX_SLUG_LENGTH].strip("-")
+
+
+def bundle_folder_name(bundle: ImportBundle) -> str:
+    # partition_logical_models sorts by first_message_id, so models[0] is earliest.
+    first_message_id = min(unit.first_message_id for unit in bundle.models)
+    name = slug(model_name_from_filename(bundle.models[0].logical_filename))
+    return f"{first_message_id:06d}-{name}" if name else f"{first_message_id:06d}"
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `uv run pytest tests/test_staging.py -v`
+Expected: PASS, 6 tests
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/alexandria_telegram_importer/staging.py tests/test_staging.py
+git commit -m "feat: add staged bundle keys and folder naming"
+```
+
+---
+
+## Task 4: Stage a bundle to disk
+
+**Files:**
+- Modify: `src/alexandria_telegram_importer/staging.py`
+- Test: `tests/test_staging.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_staging.py`. Add these imports at the top of the file:
+
+```python
+import json
+from pathlib import Path
+
+from alexandria_telegram_importer.staging import (
+    BundleStager,
+    bundle_description,
+    unique_child,
+)
+```
+
+Then append:
+
+```python
+class FakeTelegram:
+    """Stands in for TelegramSource: writes a file named after the ref."""
+
+    def __init__(self, channel_id: int = -100987654, username: str | None = "chan"):
+        self.channel_id = channel_id
+        self.channel_username = username
+        self.downloaded: list[str] = []
+        self.fail_on: set[str] = set()
+
+    async def download(self, ref, directory, *, on_progress=None) -> Path:
+        if ref.filename in self.fail_on:
+            raise RuntimeError(f"boom: {ref.filename}")
+        directory.mkdir(parents=True, exist_ok=True)
+        target = directory / f"{ref.message_id}_{ref.filename}"
+        target.write_bytes(ref.filename.encode())
+        self.downloaded.append(ref.filename)
+        return target
+
+    def message_link(self, message_id: int) -> str | None:
+        if self.channel_username:
+            return f"https://t.me/{self.channel_username}/{message_id}"
+        return None
+
+
+def test_should_suffix_a_colliding_folder_name(tmp_path) -> None:
+    (tmp_path / "dragon").mkdir()
+    (tmp_path / "dragon-2").mkdir()
+
+    assert unique_child(tmp_path, "dragon").name == "dragon-3"
+    assert unique_child(tmp_path, "wizard").name == "wizard"
+
+
+async def test_should_stage_models_and_images_into_their_subfolders(
+    tmp_path, media_ref
+) -> None:
+    [bundle] = build_bundles(
+        -100987654,
+        [
+            media_ref(2499, "render.jpg", kind=MediaKind.ATTACHMENT),
+            media_ref(2501, "dragon-knight.zip"),
+            media_ref(2502, "dragon-mage.zip"),
+        ],
+    )
+    telegram = FakeTelegram()
+
+    folder = await BundleStager(telegram=telegram, root=tmp_path).stage(bundle)
+
+    assert folder.name == "002501-dragon-knight"
+    assert sorted(p.name for p in (folder / "models").iterdir()) == [
+        "dragon-knight.zip",
+        "dragon-mage.zip",
+    ]
+    assert [p.name for p in (folder / "images").iterdir()] == ["render.jpg"]
+    assert (folder / "models" / "dragon-knight.zip").read_bytes() == b"dragon-knight.zip"
+
+
+async def test_should_always_create_both_subfolders_even_when_empty(
+    tmp_path, media_ref
+) -> None:
+    [bundle] = build_bundles(-100987654, [media_ref(2501, "dragon.zip")])
+
+    folder = await BundleStager(telegram=FakeTelegram(), root=tmp_path).stage(bundle)
+
+    assert (folder / "models").is_dir()
+    assert (folder / "images").is_dir()
+
+
+async def test_should_write_metadata_with_source_provenance(tmp_path, media_ref) -> None:
+    [bundle] = build_bundles(
+        -100987654,
+        [
+            media_ref(2499, "render.jpg", kind=MediaKind.ATTACHMENT, caption="Dragons!"),
+            media_ref(2501, "dragon-knight.zip"),
+            media_ref(2502, "dragon-mage.zip"),
+        ],
+    )
+
+    folder = await BundleStager(telegram=FakeTelegram(), root=tmp_path).stage(bundle)
+    payload = json.loads((folder / "metadata.json").read_text(encoding="utf-8"))
+
+    assert payload["schemaVersion"] == 1
+    assert payload["modelName"] == "dragon knight"
+    assert "Dragons!" in payload["description"]
+    assert "https://t.me/chan/2501" in payload["description"]
+    assert payload["result"] is None
+    assert payload["source"]["channelId"] == -100987654
+    assert payload["source"]["modelMessageIds"] == [2501, 2502]
+    assert payload["source"]["attachmentMessageIds"] == [2499]
+    assert payload["source"]["bundleKey"] == bundle_key(-100987654, bundle)
+
+
+async def test_should_suffix_colliding_filenames_within_a_folder(
+    tmp_path, media_ref
+) -> None:
+    [bundle] = build_bundles(
+        -100987654,
+        [media_ref(2501, "dragon.zip"), media_ref(2502, "dragon.zip")],
+    )
+
+    folder = await BundleStager(telegram=FakeTelegram(), root=tmp_path).stage(bundle)
+
+    assert sorted(p.name for p in (folder / "models").iterdir()) == [
+        "dragon-2.zip",
+        "dragon.zip",
+    ]
+
+
+async def test_should_remove_the_partial_folder_when_staging_fails(
+    tmp_path, media_ref
+) -> None:
+    [bundle] = build_bundles(
+        -100987654,
+        [media_ref(2501, "dragon-knight.zip"), media_ref(2502, "dragon-mage.zip")],
+    )
+    telegram = FakeTelegram()
+    telegram.fail_on = {"dragon-mage.zip"}
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await BundleStager(telegram=telegram, root=tmp_path).stage(bundle)
+
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_should_compose_a_bundle_description_from_every_caption(media_ref) -> None:
+    [bundle] = build_bundles(
+        -100987654,
+        [
+            media_ref(2499, "a.jpg", kind=MediaKind.ATTACHMENT, caption="First"),
+            media_ref(2500, "b.jpg", kind=MediaKind.ATTACHMENT, caption="First"),
+            media_ref(2501, "dragon.zip", caption="Second"),
+        ],
+    )
+
+    description = bundle_description(FakeTelegram(), bundle)
+
+    assert description.count("First") == 1
+    assert "Second" in description
+    assert "model message(s): 2501" in description
+    assert description.endswith("https://t.me/chan/2501")
+```
+
+Add `import pytest` to the top of the file.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `uv run pytest tests/test_staging.py -v`
+Expected: FAIL — `ImportError: cannot import name 'BundleStager'`
+
+- [ ] **Step 3: Write the implementation**
+
+Add to the top of `src/alexandria_telegram_importer/staging.py`:
+
+```python
+import logging
+import shutil
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Protocol
+
+from .folder_metadata import write_metadata
+from .grouping import safe_filename
+from .models import ImportBundle, MediaRef
+from .progress import ModelProgress, NullModelProgress
+
+log = logging.getLogger(__name__)
+
+MAX_DESCRIPTION_LENGTH = 2000
+```
+
+Keep the existing `hashlib`, `re`, `model_name_from_filename`, and `ImportBundle` imports; merge rather than duplicate.
+
+Append to the same file:
+
+```python
+class MediaDownloader(Protocol):
+    channel_id: int
+
+    async def download(
+        self, ref: MediaRef, directory: Path, *, on_progress: Any = None
+    ) -> Path: ...
+
+    def message_link(self, message_id: int) -> str | None: ...
+
+
+def unique_child(parent: Path, name: str) -> Path:
+    """A path under parent that does not exist yet, suffixing -2, -3 on collision."""
+    candidate = parent / name
+    index = 2
+    while candidate.exists():
+        candidate = parent / f"{name}-{index}"
+        index += 1
+    return candidate
+
+
+def _unique_filename(directory: Path, filename: str) -> Path:
+    stem, dot, extension = filename.partition(".")
+    candidate = directory / filename
+    index = 2
+    while candidate.exists():
+        candidate = directory / f"{stem}-{index}{dot}{extension}"
+        index += 1
+    return candidate
+
+
+def bundle_description(source: MediaDownloader, bundle: ImportBundle) -> str:
+    """Compose one description for a whole bundle.
+
+    Mirrors importer.build_description, but scoped to every model in the
+    bundle rather than one logical model, since a staged folder is a bundle.
+    """
+    sections: list[str] = []
+    seen: set[str] = set()
+    parts = [part for unit in bundle.models for part in unit.parts]
+    for ref in (*bundle.attachments, *parts):
+        if ref.caption and ref.caption not in seen:
+            sections.append(ref.caption)
+            seen.add(ref.caption)
+
+    ids = ", ".join(str(message_id) for message_id in bundle_message_ids(bundle))
+    source_line = (
+        f"Imported from Telegram channel {source.channel_id}; model message(s): {ids}."
+    )
+    first = min(unit.first_message_id for unit in bundle.models)
+    if link := source.message_link(first):
+        source_line += f" Source: {link}"
+    sections.append(source_line)
+    description = "\n\n".join(sections)
+    if len(description) > MAX_DESCRIPTION_LENGTH:
+        return description[: MAX_DESCRIPTION_LENGTH - 1] + "…"
+    return description
+
+
+class BundleStager:
+    def __init__(self, *, telegram: MediaDownloader, root: Path) -> None:
+        self.telegram = telegram
+        self.root = root
+
+    async def stage(
+        self, bundle: ImportBundle, handle: ModelProgress | None = None
+    ) -> Path:
+        """Download one bundle into its own folder, or leave nothing behind."""
+        handle = handle or NullModelProgress()
+        self.root.mkdir(parents=True, exist_ok=True)
+        folder = unique_child(self.root, bundle_folder_name(bundle))
+        folder.mkdir()
+        try:
+            models_dir = folder / "models"
+            images_dir = folder / "images"
+            models_dir.mkdir()
+            images_dir.mkdir()
+
+            parts = [part for unit in bundle.models for part in unit.parts]
+            for ref in parts:
+                await self._fetch(ref, models_dir, handle)
+            for ref in bundle.attachments:
+                await self._fetch(ref, images_dir, handle)
+
+            write_metadata(
+                folder,
+                {
+                    "modelName": model_name_from_filename(
+                        bundle.models[0].logical_filename
+                    ),
+                    "description": bundle_description(self.telegram, bundle),
+                    "artist": None,
+                    "tags": [],
+                    "metadata": {},
+                    "options": {},
+                    "collectionId": None,
+                    "newCollectionName": None,
+                    "source": {
+                        "channelId": self.telegram.channel_id,
+                        "channelUsername": getattr(
+                            self.telegram, "channel_username", None
+                        ),
+                        "bundleKey": bundle_key(self.telegram.channel_id, bundle),
+                        "modelMessageIds": list(bundle_message_ids(bundle)),
+                        "attachmentMessageIds": [
+                            ref.message_id for ref in bundle.attachments
+                        ],
+                        "link": self.telegram.message_link(
+                            min(unit.first_message_id for unit in bundle.models)
+                        ),
+                        "downloadedAt": datetime.now(UTC).isoformat(),
+                    },
+                    "result": None,
+                },
+            )
+        except BaseException:
+            # A half-staged folder would upload as an incomplete model, so the
+            # bundle is left entirely unstaged and retried on the next run.
+            shutil.rmtree(folder, ignore_errors=True)
+            raise
+        return folder
+
+    async def _fetch(self, ref: MediaRef, directory: Path, handle: ModelProgress) -> None:
+        with handle.transfer("download", ref.filename) as transfer:
+            downloaded = await self.telegram.download(
+                ref, directory, on_progress=transfer.advance
+            )
+        target = _unique_filename(directory, safe_filename(ref.filename, "media"))
+        downloaded.rename(target)
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `uv run pytest tests/test_staging.py -v`
+Expected: PASS, 13 tests
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/alexandria_telegram_importer/staging.py tests/test_staging.py
+git commit -m "feat: stage Telegram bundles into models and images folders"
+```
+
+---
+
+## Task 5: Discover model folders and containers
+
+**Files:**
+- Create: `src/alexandria_telegram_importer/folder_upload.py`
+- Test: `tests/test_folder_upload.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_folder_upload.py`:
+
+```python
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from alexandria_telegram_importer.folder_upload import discover
+
+
+def make_folder(path: Path, *, models=(), images=(), metadata=None) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    if models:
+        (path / "models").mkdir(exist_ok=True)
+        for name in models:
+            (path / "models" / name).write_bytes(name.encode())
+    if images:
+        (path / "images").mkdir(exist_ok=True)
+        for name in images:
+            (path / "images" / name).write_bytes(name.encode())
+    if metadata is not None:
+        (path / "metadata.json").write_text(json.dumps(metadata), encoding="utf-8")
+    return path
+
+
+def test_should_discover_a_single_model_folder(tmp_path) -> None:
+    make_folder(tmp_path / "002501-dragon", models=["dragon.zip"])
+
+    found, ambiguous = discover(tmp_path)
+
+    assert [folder.path.name for folder in found] == ["002501-dragon"]
+    assert ambiguous == []
+
+
+def test_should_recurse_into_a_container_of_model_folders(tmp_path) -> None:
+    release = tmp_path / "002501-dragon-set"
+    release.mkdir()
+    make_folder(release / "knight", models=["knight.zip"])
+    make_folder(release / "mage", models=["mage.zip"])
+
+    found, ambiguous = discover(tmp_path)
+
+    assert sorted(folder.path.name for folder in found) == ["knight", "mage"]
+    assert ambiguous == []
+
+
+def test_should_flag_a_parent_that_has_both_models_and_child_model_folders(
+    tmp_path,
+) -> None:
+    release = make_folder(tmp_path / "002501-dragon-set", models=["leftover.zip"])
+    make_folder(release / "knight", models=["knight.zip"])
+
+    found, ambiguous = discover(tmp_path)
+
+    assert found == []
+    assert [path.name for path, _ in ambiguous] == ["002501-dragon-set"]
+    assert "models/" in ambiguous[0][1]
+
+
+def test_should_skip_the_uploaded_and_failed_directories(tmp_path) -> None:
+    make_folder(tmp_path / "pending", models=["a.zip"])
+    make_folder(tmp_path / "uploaded" / "done", models=["b.zip"])
+    make_folder(tmp_path / "failed" / "broken", models=["c.zip"])
+
+    found, ambiguous = discover(tmp_path)
+
+    assert [folder.path.name for folder in found] == ["pending"]
+    assert ambiguous == []
+
+
+def test_should_build_the_inheritance_chain_from_root_to_leaf(tmp_path) -> None:
+    release = tmp_path / "002501-dragon-set"
+    release.mkdir()
+    (release / "metadata.json").write_text(
+        json.dumps({"artist": "Foo Studios", "tags": ["dragon"]}), encoding="utf-8"
+    )
+    make_folder(
+        release / "knight", models=["knight.zip"], metadata={"modelName": "Knight"}
+    )
+
+    [folder], _ = discover(tmp_path)
+
+    assert folder.chain[0]["artist"] == "Foo Studios"
+    assert folder.chain[-1]["modelName"] == "Knight"
+    assert folder.metadata["artist"] == "Foo Studios"
+    assert folder.metadata["tags"] == ["dragon"]
+    assert folder.metadata["modelName"] == "Knight"
+
+
+def test_should_collect_container_image_directories(tmp_path) -> None:
+    release = tmp_path / "002501-dragon-set"
+    release.mkdir()
+    (release / "images").mkdir()
+    (release / "images" / "group.jpg").write_bytes(b"group")
+    make_folder(release / "knight", models=["knight.zip"], images=["knight.jpg"])
+
+    [folder], _ = discover(tmp_path)
+
+    assert [path.name for path in folder.container_image_dirs] == ["images"]
+    assert folder.container_image_dirs[0].parent.name == "002501-dragon-set"
+
+
+def test_should_name_a_model_from_its_folder_when_metadata_is_absent(tmp_path) -> None:
+    make_folder(tmp_path / "002501-dragon-knight", models=["a.zip"])
+
+    [folder], _ = discover(tmp_path)
+
+    assert folder.model_name == "dragon knight"
+
+
+def test_should_prefer_an_explicit_model_name_over_the_folder_name(tmp_path) -> None:
+    make_folder(
+        tmp_path / "002501-dragon", models=["a.zip"], metadata={"modelName": "Real Name"}
+    )
+
+    [folder], _ = discover(tmp_path)
+
+    assert folder.model_name == "Real Name"
+
+
+def test_should_ignore_a_directory_with_neither_models_nor_subfolders(tmp_path) -> None:
+    (tmp_path / "empty").mkdir()
+    (tmp_path / "empty" / "notes.txt").write_text("hello", encoding="utf-8")
+
+    found, ambiguous = discover(tmp_path)
+
+    assert found == []
+    assert ambiguous == []
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `uv run pytest tests/test_folder_upload.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'alexandria_telegram_importer.folder_upload'`
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/alexandria_telegram_importer/folder_upload.py`:
+
+```python
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .folder_metadata import merge_chain, model_name_from_folder, read_metadata
+
+log = logging.getLogger(__name__)
+
+MODELS_DIRNAME = "models"
+IMAGES_DIRNAME = "images"
+UPLOADED_DIRNAME = "uploaded"
+FAILED_DIRNAME = "failed"
+RESERVED_DIRNAMES = frozenset({UPLOADED_DIRNAME, FAILED_DIRNAME})
+
+
+@dataclass(frozen=True, slots=True)
+class ModelFolder:
+    path: Path
+    chain: tuple[dict[str, Any], ...]
+    container_image_dirs: tuple[Path, ...]
+
+    @property
+    def metadata(self) -> dict[str, Any]:
+        return merge_chain(self.chain)
+
+    @property
+    def model_name(self) -> str:
+        return self.metadata.get("modelName") or model_name_from_folder(self.path.name)
+
+    @property
+    def models_dir(self) -> Path:
+        return self.path / MODELS_DIRNAME
+
+    @property
+    def image_dirs(self) -> tuple[Path, ...]:
+        own = self.path / IMAGES_DIRNAME
+        return (*self.container_image_dirs, *((own,) if own.is_dir() else ()))
+
+
+def discover(root: Path) -> tuple[list[ModelFolder], list[tuple[Path, str]]]:
+    """Walk the staging root, returning model folders and ambiguous folders.
+
+    A directory holding `models/` is a model folder. A directory holding only
+    subdirectories is a container and is recursed into. A directory holding
+    both is a half-finished split: uploading it would commit the leftovers
+    and silently drop everything already moved into the children, so it is
+    reported instead.
+    """
+    found: list[ModelFolder] = []
+    ambiguous: list[tuple[Path, str]] = []
+    if not root.is_dir():
+        return found, ambiguous
+    for child in sorted(root.iterdir()):
+        if child.is_dir() and child.name not in RESERVED_DIRNAMES:
+            _visit(child, (), (), found, ambiguous)
+    return found, ambiguous
+
+
+def _visit(
+    directory: Path,
+    chain: tuple[dict[str, Any], ...],
+    image_dirs: tuple[Path, ...],
+    found: list[ModelFolder],
+    ambiguous: list[tuple[Path, str]],
+) -> None:
+    chain = (*chain, read_metadata(directory) or {})
+    has_models = (directory / MODELS_DIRNAME).is_dir()
+    subdirectories = [
+        child
+        for child in sorted(directory.iterdir())
+        if child.is_dir() and child.name not in {MODELS_DIRNAME, IMAGES_DIRNAME}
+    ]
+
+    if has_models:
+        nested: list[ModelFolder] = []
+        nested_ambiguous: list[tuple[Path, str]] = []
+        for child in subdirectories:
+            _visit(child, chain, image_dirs, nested, nested_ambiguous)
+        if nested or nested_ambiguous:
+            ambiguous.append(
+                (
+                    directory,
+                    f"holds its own {MODELS_DIRNAME}/ and model folders beneath it; "
+                    f"finish the split by emptying {MODELS_DIRNAME}/",
+                ),
+            )
+            return
+        found.append(
+            ModelFolder(
+                path=directory, chain=chain, container_image_dirs=image_dirs
+            ),
+        )
+        return
+
+    own_images = directory / IMAGES_DIRNAME
+    if own_images.is_dir():
+        image_dirs = (*image_dirs, own_images)
+    for child in subdirectories:
+        _visit(child, chain, image_dirs, found, ambiguous)
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `uv run pytest tests/test_folder_upload.py -v`
+Expected: PASS, 9 tests
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/alexandria_telegram_importer/folder_upload.py tests/test_folder_upload.py
+git commit -m "feat: discover staged model folders and containers"
+```
+
+---
+
+## Task 6: Classify a models/ directory
+
+**Files:**
+- Modify: `src/alexandria_telegram_importer/folder_upload.py`
+- Test: `tests/test_folder_upload.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_folder_upload.py`. Add `import pytest` and extend the `folder_upload` import to include `ModelsPlan`, `plan_models_dir`, and `build_upload_paths`.
+
+```python
+def models_dir(tmp_path: Path, names, subdir_files=()) -> Path:
+    target = tmp_path / "models"
+    target.mkdir(parents=True, exist_ok=True)
+    for name in names:
+        (target / name).write_bytes(name.encode())
+    for relative in subdir_files:
+        path = target / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(relative.encode())
+    return target
+
+
+def test_should_upload_a_lone_archive_as_is(tmp_path) -> None:
+    plan = plan_models_dir(models_dir(tmp_path, ["dragon.7z"]))
+
+    assert plan.kind == "as_is"
+    assert [path.name for path in plan.paths] == ["dragon.7z"]
+
+
+def test_should_detect_a_rar_split_set_in_part_order(tmp_path) -> None:
+    plan = plan_models_dir(
+        models_dir(tmp_path, ["dragon.part2.rar", "dragon.part1.rar"]),
+    )
+
+    assert plan.kind == "split"
+    assert [path.name for path in plan.paths] == [
+        "dragon.part1.rar",
+        "dragon.part2.rar",
+    ]
+
+
+def test_should_detect_a_classic_zip_split_set(tmp_path) -> None:
+    plan = plan_models_dir(models_dir(tmp_path, ["dragon.z01", "dragon.zip"]))
+
+    assert plan.kind == "split"
+    assert [path.name for path in plan.paths] == ["dragon.z01", "dragon.zip"]
+
+
+def test_should_detect_a_numbered_zip_split_set(tmp_path) -> None:
+    plan = plan_models_dir(
+        models_dir(tmp_path, ["dragon.zip.001", "dragon.zip.002"]),
+    )
+
+    assert plan.kind == "split"
+
+
+def test_should_zip_an_incomplete_split_set_rather_than_guessing(tmp_path) -> None:
+    plan = plan_models_dir(
+        models_dir(tmp_path, ["dragon.part1.rar", "dragon.part3.rar"]),
+    )
+
+    assert plan.kind == "zip"
+
+
+def test_should_zip_a_set_that_mixes_two_base_names(tmp_path) -> None:
+    plan = plan_models_dir(
+        models_dir(tmp_path, ["dragon.part1.rar", "wizard.part2.rar"]),
+    )
+
+    assert plan.kind == "zip"
+
+
+def test_should_zip_an_archive_that_sits_beside_another_file(tmp_path) -> None:
+    plan = plan_models_dir(models_dir(tmp_path, ["dragon.7z", "readme.txt"]))
+
+    assert plan.kind == "zip"
+
+
+def test_should_zip_loose_model_files(tmp_path) -> None:
+    plan = plan_models_dir(models_dir(tmp_path, ["knight.stl", "base.stl"]))
+
+    assert plan.kind == "zip"
+
+
+def test_should_zip_a_lone_subdirectory(tmp_path) -> None:
+    plan = plan_models_dir(models_dir(tmp_path, [], subdir_files=["parts/knight.stl"]))
+
+    assert plan.kind == "zip"
+
+
+def test_should_reject_an_empty_or_missing_models_directory(tmp_path) -> None:
+    with pytest.raises(ValueError, match="empty"):
+        plan_models_dir(models_dir(tmp_path, []))
+
+    with pytest.raises(ValueError, match="missing"):
+        plan_models_dir(tmp_path / "absent")
+
+
+def test_should_build_a_zip_preserving_paths_relative_to_models(tmp_path) -> None:
+    import zipfile
+
+    source = models_dir(tmp_path, ["knight.stl"], subdir_files=["parts/base.stl"])
+    work = tmp_path / "work"
+    work.mkdir()
+
+    paths, multipart = build_upload_paths(
+        plan_models_dir(source), work, "Dragon Knight"
+    )
+
+    assert multipart is False
+    assert len(paths) == 1
+    assert paths[0].name == "Dragon Knight.zip"
+    with zipfile.ZipFile(paths[0]) as archive:
+        assert sorted(archive.namelist()) == ["knight.stl", "parts/base.stl"]
+
+
+def test_should_pass_an_as_is_archive_through_without_repacking(tmp_path) -> None:
+    source = models_dir(tmp_path, ["dragon.7z"])
+    work = tmp_path / "work"
+    work.mkdir()
+
+    paths, multipart = build_upload_paths(plan_models_dir(source), work, "Dragon")
+
+    assert multipart is False
+    assert paths == (source / "dragon.7z",)
+    assert paths[0].read_bytes() == b"dragon.7z"
+
+
+def test_should_report_a_split_set_as_multipart(tmp_path) -> None:
+    source = models_dir(tmp_path, ["dragon.part1.rar", "dragon.part2.rar"])
+    work = tmp_path / "work"
+    work.mkdir()
+
+    paths, multipart = build_upload_paths(plan_models_dir(source), work, "Dragon")
+
+    assert multipart is True
+    assert [path.name for path in paths] == [
+        "dragon.part1.rar",
+        "dragon.part2.rar",
+    ]
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `uv run pytest tests/test_folder_upload.py -v -k plan or upload_paths`
+Expected: FAIL — `ImportError: cannot import name 'plan_models_dir'`
+
+- [ ] **Step 3: Write the implementation**
+
+Add these imports to `src/alexandria_telegram_importer/folder_upload.py`:
+
+```python
+import zipfile
+
+from .grouping import (
+    ARCHIVE_EXTENSIONS,
+    multipart_part_role,
+    partition_logical_models,
+    safe_filename,
+    validate_logical_model,
+)
+from .models import MediaKind, MediaRef
+```
+
+Append to the same file:
+
+```python
+@dataclass(frozen=True, slots=True)
+class ModelsPlan:
+    kind: str  # "as_is" | "split" | "zip"
+    paths: tuple[Path, ...]
+
+
+def _is_split_member(filename: str) -> bool:
+    try:
+        multipart_part_role(filename)
+    except ValueError:
+        return False
+    return True
+
+
+def _split_order(entries: list[Path]) -> tuple[Path, ...] | None:
+    """Order entries as one split set, or None when they are not one.
+
+    Reuses grouping's part detection and validation so the importer and the
+    staged flow agree on what a complete set is.
+    """
+    if len(entries) < 2 or not all(entry.is_file() for entry in entries):
+        return None
+    if not all(_is_split_member(entry.name) for entry in entries):
+        return None
+    refs = [
+        MediaRef(message_id=index, filename=entry.name, kind=MediaKind.MODEL)
+        for index, entry in enumerate(entries)
+    ]
+    units = partition_logical_models(0, refs)
+    if len(units) != 1 or not units[0].multipart:
+        return None
+    try:
+        validate_logical_model(units[0])
+    except ValueError as error:
+        log.info("Not treating %s as a split set: %s", entries[0].parent, error)
+        return None
+    order = {part.filename: index for index, part in enumerate(units[0].parts)}
+    return tuple(sorted(entries, key=lambda entry: order[entry.name]))
+
+
+def plan_models_dir(models_dir: Path) -> ModelsPlan:
+    if not models_dir.is_dir():
+        raise ValueError(f"{models_dir} is missing")
+    entries = sorted(models_dir.iterdir())
+    if not entries:
+        raise ValueError(f"{models_dir} is empty")
+
+    only = entries[0]
+    if (
+        len(entries) == 1
+        and only.is_file()
+        and only.name.lower().endswith(ARCHIVE_EXTENSIONS)
+    ):
+        return ModelsPlan(kind="as_is", paths=(only,))
+
+    if ordered := _split_order(entries):
+        return ModelsPlan(kind="split", paths=ordered)
+
+    return ModelsPlan(kind="zip", paths=tuple(entries))
+
+
+def build_upload_paths(
+    plan: ModelsPlan, work_dir: Path, model_name: str
+) -> tuple[tuple[Path, ...], bool]:
+    """Resolve a plan into paths to upload and whether they are a split set.
+
+    An `as_is` or `split` plan uploads the operator's own files untouched —
+    that is what makes hand-made compression worth doing.
+    """
+    if plan.kind == "as_is":
+        return plan.paths, False
+    if plan.kind == "split":
+        return plan.paths, True
+
+    models_dir = plan.paths[0].parent
+    archive_path = work_dir / f"{safe_filename(model_name, 'model')}.zip"
+    with zipfile.ZipFile(archive_path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        for path in sorted(models_dir.rglob("*")):
+            if path.is_file():
+                archive.write(path, arcname=str(path.relative_to(models_dir)))
+    return (archive_path,), False
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `uv run pytest tests/test_folder_upload.py -v`
+Expected: PASS, 22 tests
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/alexandria_telegram_importer/folder_upload.py tests/test_folder_upload.py
+git commit -m "feat: classify a staged models directory into an upload plan"
+```
+
+---
+
+## Task 7: Dispose of a folder after upload
+
+**Files:**
+- Modify: `src/alexandria_telegram_importer/folder_upload.py`
+- Test: `tests/test_folder_upload.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_folder_upload.py`, extending the `folder_upload` import with `dispose`.
+
+```python
+def test_should_move_a_successful_folder_under_uploaded_preserving_its_path(
+    tmp_path,
+) -> None:
+    release = tmp_path / "002501-dragon-set"
+    release.mkdir()
+    (release / "metadata.json").write_text(
+        json.dumps({"artist": "Foo"}), encoding="utf-8"
+    )
+    folder = make_folder(release / "knight", models=["knight.zip"])
+
+    destination = dispose(folder, tmp_path, "uploaded", {"modelId": "abc"})
+
+    assert destination == tmp_path / "uploaded" / "002501-dragon-set" / "knight"
+    assert (destination / "models" / "knight.zip").is_file()
+    assert not folder.exists()
+
+
+def test_should_copy_container_metadata_alongside_a_disposed_folder(tmp_path) -> None:
+    release = tmp_path / "002501-dragon-set"
+    release.mkdir()
+    (release / "metadata.json").write_text(
+        json.dumps({"artist": "Foo"}), encoding="utf-8"
+    )
+    make_folder(release / "knight", models=["knight.zip"])
+    make_folder(release / "mage", models=["mage.zip"])
+
+    dispose(release / "knight", tmp_path, "uploaded", {"modelId": "abc"})
+
+    copied = tmp_path / "uploaded" / "002501-dragon-set" / "metadata.json"
+    assert json.loads(copied.read_text(encoding="utf-8"))["artist"] == "Foo"
+    assert (release / "metadata.json").is_file()
+    assert (release / "mage").is_dir()
+
+
+def test_should_write_the_result_into_the_disposed_metadata(tmp_path) -> None:
+    folder = make_folder(
+        tmp_path / "002501-dragon", models=["a.zip"], metadata={"modelName": "Dragon"}
+    )
+
+    destination = dispose(folder, tmp_path, "uploaded", {"modelId": "abc"})
+    payload = json.loads((destination / "metadata.json").read_text(encoding="utf-8"))
+
+    assert payload["result"] == {"modelId": "abc"}
+    assert payload["modelName"] == "Dragon"
+
+
+def test_should_write_a_result_even_when_the_folder_had_no_metadata(tmp_path) -> None:
+    folder = make_folder(tmp_path / "002501-dragon", models=["a.zip"])
+
+    destination = dispose(folder, tmp_path, "failed", {"error": "boom"})
+    payload = json.loads((destination / "metadata.json").read_text(encoding="utf-8"))
+
+    assert payload["result"] == {"error": "boom"}
+
+
+def test_should_remove_a_container_left_with_no_model_folders(tmp_path) -> None:
+    release = tmp_path / "002501-dragon-set"
+    release.mkdir()
+    (release / "metadata.json").write_text(json.dumps({}), encoding="utf-8")
+    make_folder(release / "knight", models=["knight.zip"])
+
+    dispose(release / "knight", tmp_path, "uploaded", {"modelId": "abc"})
+
+    assert not release.exists()
+
+
+def test_should_keep_a_container_that_still_holds_model_folders(tmp_path) -> None:
+    release = tmp_path / "002501-dragon-set"
+    release.mkdir()
+    make_folder(release / "knight", models=["knight.zip"])
+    make_folder(release / "mage", models=["mage.zip"])
+
+    dispose(release / "knight", tmp_path, "uploaded", {"modelId": "abc"})
+
+    assert release.is_dir()
+    assert (release / "mage").is_dir()
+
+
+def test_should_suffix_a_disposal_that_collides_with_an_earlier_one(tmp_path) -> None:
+    (tmp_path / "uploaded" / "dragon").mkdir(parents=True)
+    folder = make_folder(tmp_path / "dragon", models=["a.zip"])
+
+    destination = dispose(folder, tmp_path, "uploaded", {"modelId": "abc"})
+
+    assert destination.name == "dragon-2"
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `uv run pytest tests/test_folder_upload.py -v -k dispose`
+Expected: FAIL — `ImportError: cannot import name 'dispose'`
+
+- [ ] **Step 3: Write the implementation**
+
+Add to the imports of `src/alexandria_telegram_importer/folder_upload.py`:
+
+```python
+import shutil
+
+from .folder_metadata import METADATA_FILENAME, write_metadata
+from .staging import unique_child
+```
+
+Merge with the existing `folder_metadata` import rather than duplicating it.
+
+Append to the same file:
+
+```python
+def dispose(
+    folder: Path, root: Path, destination_dirname: str, result: dict[str, Any]
+) -> Path:
+    """Move one settled model folder under uploaded/ or failed/.
+
+    The path relative to the staging root is preserved, so a release that
+    settles a few folders at a time stays recognizable, and each ancestor's
+    metadata.json is copied so the archived copy still carries its defaults.
+    """
+    relative = folder.relative_to(root)
+    destination_parent = root / destination_dirname / relative.parent
+    destination_parent.mkdir(parents=True, exist_ok=True)
+    destination = unique_child(destination_parent, folder.name)
+
+    payload = read_metadata(folder) or {}
+    payload["result"] = result
+    write_metadata(folder, payload)
+
+    shutil.move(str(folder), str(destination))
+
+    ancestor = folder.parent
+    mirrored = destination_parent
+    while ancestor != root:
+        source_metadata = ancestor / METADATA_FILENAME
+        if source_metadata.is_file() and not (mirrored / METADATA_FILENAME).exists():
+            shutil.copy2(source_metadata, mirrored / METADATA_FILENAME)
+        ancestor = ancestor.parent
+        mirrored = mirrored.parent
+
+    _prune_empty_containers(folder.parent, root)
+    return destination
+
+
+def _prune_empty_containers(directory: Path, root: Path) -> None:
+    """Remove containers that no longer hold any model folder."""
+    while directory != root and directory.is_dir():
+        remaining, ambiguous = discover(directory)
+        if remaining or ambiguous:
+            return
+        shutil.rmtree(directory, ignore_errors=True)
+        directory = directory.parent
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `uv run pytest tests/test_folder_upload.py -v`
+Expected: PASS, 29 tests
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/alexandria_telegram_importer/folder_upload.py tests/test_folder_upload.py
+git commit -m "feat: dispose settled staged folders into uploaded and failed"
+```
+
+---
+
+## Task 8: Upload one folder to Alexandria
+
+**Files:**
+- Modify: `src/alexandria_telegram_importer/folder_upload.py`
+- Test: `tests/test_folder_upload.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_folder_upload.py`, extending the `folder_upload` import with `FolderUploader`.
+
+```python
+class FakeAlexandria:
+    def __init__(self) -> None:
+        self.uploads: list[tuple[str, bool]] = []
+        self.appended: list[str] = []
+        self.commits: list[dict] = []
+        self.session = {"id": "session-1", "status": "ready_for_review"}
+        self.fail_commit = False
+
+    async def upload_file(self, path, upload_name, *, multipart, on_progress=None):
+        self.uploads.append((upload_name, multipart))
+        return f"upload-{len(self.uploads)}"
+
+    async def complete_upload(self, upload_ids, *, multipart):
+        return "session-1"
+
+    async def abort_uploads(self, upload_ids) -> None:
+        return None
+
+    async def get_session(self, session_id):
+        return self.session
+
+    async def wait_for_session(self, session_id, statuses, **kwargs):
+        return {"id": session_id, "status": sorted(statuses)[0], "modelId": "model-1"}
+
+    async def append_files(self, session_id, paths, upload_names):
+        self.appended.extend(upload_names)
+        return self.session
+
+    async def commit(self, session_id, *, model_name, description=None, **extra):
+        if self.fail_commit:
+            raise RuntimeError("commit exploded")
+        self.commits.append(
+            {"modelName": model_name, "description": description, **extra}
+        )
+        return "model-1"
+
+
+async def test_should_upload_a_folder_and_return_its_model_id(tmp_path) -> None:
+    make_folder(
+        tmp_path / "002501-dragon",
+        models=["dragon.7z"],
+        images=["render.jpg"],
+        metadata={"modelName": "Dragon", "artist": "Foo", "tags": ["dragon"]},
+    )
+    alexandria = FakeAlexandria()
+    [folder], _ = discover(tmp_path)
+
+    model_id = await FolderUploader(
+        alexandria=alexandria, work_root=tmp_path / "work"
+    ).upload(folder)
+
+    assert model_id == "model-1"
+    assert alexandria.uploads == [("dragon.7z", False)]
+    assert alexandria.appended == ["render.jpg"]
+    assert alexandria.commits[0]["modelName"] == "Dragon"
+    assert alexandria.commits[0]["batch_metadata"]["artist"] == "Foo"
+    assert alexandria.commits[0]["batch_metadata"]["tags"] == ["dragon"]
+
+
+async def test_should_append_container_images_to_every_model_beneath_it(
+    tmp_path,
+) -> None:
+    release = tmp_path / "002501-dragon-set"
+    release.mkdir()
+    (release / "images").mkdir()
+    (release / "images" / "group.jpg").write_bytes(b"group")
+    make_folder(release / "knight", models=["knight.zip"], images=["knight.jpg"])
+    alexandria = FakeAlexandria()
+    [folder], _ = discover(tmp_path)
+
+    await FolderUploader(alexandria=alexandria, work_root=tmp_path / "work").upload(
+        folder
+    )
+
+    assert sorted(alexandria.appended) == ["group.jpg", "knight.jpg"]
+
+
+async def test_should_prefer_a_models_own_image_over_a_container_duplicate(
+    tmp_path,
+) -> None:
+    release = tmp_path / "002501-dragon-set"
+    release.mkdir()
+    (release / "images").mkdir()
+    (release / "images" / "render.jpg").write_bytes(b"container")
+    make_folder(release / "knight", models=["knight.zip"], images=["render.jpg"])
+    alexandria = FakeAlexandria()
+    [folder], _ = discover(tmp_path)
+
+    uploader = FolderUploader(alexandria=alexandria, work_root=tmp_path / "work")
+    assert [path.read_bytes() for path in uploader.image_paths(folder)] == [b"render.jpg"]
+
+
+async def test_should_upload_a_split_set_as_multipart(tmp_path) -> None:
+    make_folder(
+        tmp_path / "002501-dragon", models=["dragon.part1.rar", "dragon.part2.rar"]
+    )
+    alexandria = FakeAlexandria()
+    [folder], _ = discover(tmp_path)
+
+    await FolderUploader(alexandria=alexandria, work_root=tmp_path / "work").upload(
+        folder
+    )
+
+    assert alexandria.uploads == [
+        ("dragon.part1.rar", True),
+        ("dragon.part2.rar", True),
+    ]
+
+
+async def test_should_move_a_folder_to_failed_when_upload_raises(tmp_path) -> None:
+    make_folder(tmp_path / "002501-dragon", models=["dragon.7z"])
+    alexandria = FakeAlexandria()
+    alexandria.fail_commit = True
+
+    uploader = FolderUploader(alexandria=alexandria, work_root=tmp_path / "work")
+    outcomes = await uploader.run(tmp_path)
+
+    assert outcomes["failed"] == 1
+    assert (tmp_path / "failed" / "002501-dragon").is_dir()
+    payload = json.loads(
+        (tmp_path / "failed" / "002501-dragon" / "metadata.json").read_text(
+            encoding="utf-8"
+        ),
+    )
+    assert "commit exploded" in payload["result"]["error"]
+
+
+async def test_should_move_an_ambiguous_folder_to_failed_without_uploading(
+    tmp_path,
+) -> None:
+    release = make_folder(tmp_path / "002501-dragon-set", models=["leftover.zip"])
+    make_folder(release / "knight", models=["knight.zip"])
+    alexandria = FakeAlexandria()
+
+    outcomes = await FolderUploader(
+        alexandria=alexandria, work_root=tmp_path / "work"
+    ).run(tmp_path)
+
+    assert outcomes["failed"] == 1
+    assert alexandria.uploads == []
+    assert (tmp_path / "failed" / "002501-dragon-set").is_dir()
+
+
+async def test_should_keep_going_after_one_folder_fails(tmp_path) -> None:
+    make_folder(tmp_path / "002501-broken", models=[])
+    make_folder(tmp_path / "002502-good", models=["good.7z"])
+    alexandria = FakeAlexandria()
+
+    outcomes = await FolderUploader(
+        alexandria=alexandria, work_root=tmp_path / "work"
+    ).run(tmp_path)
+
+    assert outcomes == {"completed": 1, "failed": 1}
+    assert (tmp_path / "uploaded" / "002502-good").is_dir()
+    assert (tmp_path / "failed" / "002501-broken").is_dir()
+```
+
+Note: `002501-broken` has no `models/` directory, so `discover` treats it as neither a model folder nor a container and skips it. Change that helper call to `make_folder(tmp_path / "002501-broken", models=[])` producing an empty `models/` — update `make_folder` so `models=[]` still creates the directory:
+
+```python
+def make_folder(path: Path, *, models=None, images=(), metadata=None) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    if models is not None:
+        (path / "models").mkdir(exist_ok=True)
+        for name in models:
+            (path / "models" / name).write_bytes(name.encode())
+    ...
+```
+
+Apply that change to the existing `make_folder` at the top of the file; every existing call passes a non-empty list, so their behavior is unchanged.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `uv run pytest tests/test_folder_upload.py -v -k FolderUploader or uploader`
+Expected: FAIL — `ImportError: cannot import name 'FolderUploader'`
+
+- [ ] **Step 3: Write the implementation**
+
+Add to the imports of `src/alexandria_telegram_importer/folder_upload.py`:
+
+```python
+import asyncio
+import tempfile
+from collections import Counter
+
+from .alexandria import session_filenames
+from .folder_metadata import batch_metadata
+from .progress import (
+    ModelProgress,
+    NullProgress,
+    ProgressReporter,
+    guarded_model,
+    guarded_reporter,
+)
+```
+
+Append to the same file:
+
+```python
+ATTACHMENT_BATCH_SIZE = 100
+
+
+class FolderUploader:
+    """Uploads hand-curated folders. Performs no deduplication by design:
+    the folders are the operator's, and the phases share no state so that
+    folders can be split, merged, renamed, and recompressed freely."""
+
+    def __init__(
+        self,
+        *,
+        alexandria: Any,
+        work_root: Path,
+        concurrency: int = 1,
+        progress: ProgressReporter | None = None,
+    ) -> None:
+        if concurrency < 1:
+            raise ValueError("Upload concurrency must be at least 1")
+        self.alexandria = alexandria
+        self.work_root = work_root
+        self.concurrency = concurrency
+        self.progress: ProgressReporter = progress or NullProgress()
+
+    def image_paths(self, folder: ModelFolder) -> tuple[Path, ...]:
+        """Every image to append, with the model's own file winning a name clash."""
+        by_name: dict[str, Path] = {}
+        for directory in folder.image_dirs:
+            for path in sorted(directory.iterdir()):
+                if path.is_file():
+                    by_name[path.name] = path
+        return tuple(by_name.values())
+
+    async def run(self, root: Path) -> dict[str, int]:
+        found, ambiguous = discover(root)
+        outcomes: Counter[str] = Counter()
+        settled = 0
+        total = len(found) + len(ambiguous)
+
+        for path, reason in ambiguous:
+            log.error("Skipping ambiguous folder %s: %s", path, reason)
+            dispose(path, root, FAILED_DIRNAME, {"error": reason, **_failed_at()})
+            outcomes["failed"] += 1
+            settled += 1
+
+        self.work_root.mkdir(parents=True, exist_ok=True)
+        slots = asyncio.Semaphore(self.concurrency)
+        lock = asyncio.Lock()
+
+        async def settle(folder: ModelFolder) -> None:
+            nonlocal settled
+            async with slots:
+                outcome = await self._upload_and_dispose(folder, root)
+            async with lock:
+                outcomes[outcome] += 1
+                settled += 1
+                self._report(settled, total, outcomes)
+
+        with guarded_reporter(self.progress):
+            self._report(settled, total, outcomes)
+            results = await asyncio.gather(
+                *(settle(folder) for folder in found),
+                return_exceptions=True,
+            )
+        for result in results:
+            if isinstance(result, BaseException):
+                raise result
+        return dict(outcomes)
+
+    def _report(self, done: int, total: int, outcomes: Counter[str]) -> None:
+        try:
+            self.progress.totals(done, total, dict(outcomes))
+        except Exception as error:  # noqa: BLE001 - a display fault is not an upload fault
+            log.debug("Progress reporter could not record totals: %s", error)
+
+    async def _upload_and_dispose(self, folder: ModelFolder, root: Path) -> str:
+        log.info("Uploading %s", folder.path.name)
+        try:
+            with guarded_model(self.progress, folder.path.name, parts=1) as handle:
+                model_id = await self.upload(folder, handle)
+        # One bad folder must not stop the rest of the staging directory.
+        except Exception as error:  # noqa: BLE001
+            log.error("Failed to upload %s: %s", folder.path.name, error)
+            dispose(
+                folder.path, root, FAILED_DIRNAME, {"error": str(error), **_failed_at()}
+            )
+            return "failed"
+        dispose(
+            folder.path,
+            root,
+            UPLOADED_DIRNAME,
+            {"modelId": model_id, **_uploaded_at()},
+        )
+        log.info("Uploaded %s as Alexandria model %s", folder.path.name, model_id)
+        return "completed"
+
+    async def upload(
+        self, folder: ModelFolder, handle: ModelProgress | None = None
+    ) -> str:
+        handle = handle or NullModelProgress()
+        effective = folder.metadata
+        payload = batch_metadata(effective)
+        payload["modelName"] = folder.model_name
+
+        with tempfile.TemporaryDirectory(
+            prefix="alexandria-folder-", dir=self.work_root
+        ) as temp:
+            plan = plan_models_dir(folder.models_dir)
+            if plan.kind == "zip":
+                handle.phase("packaging")
+            paths, multipart = build_upload_paths(plan, Path(temp), payload["modelName"])
+
+            upload_ids: list[str] = []
+            try:
+                for path in paths:
+                    with handle.transfer("upload", path.name) as transfer:
+                        upload_ids.append(
+                            await self.alexandria.upload_file(
+                                path,
+                                path.name,
+                                multipart=multipart,
+                                on_progress=transfer.advance,
+                            ),
+                        )
+                session_id = await self.alexandria.complete_upload(
+                    upload_ids, multipart=multipart
+                )
+            except Exception:
+                await self.alexandria.abort_uploads(upload_ids)
+                raise
+
+            handle.phase("scanning")
+            session = await self.alexandria.wait_for_session(
+                session_id, {"ready_for_review"}
+            )
+            if session["status"] == "error":
+                raise RuntimeError(session.get("error") or "Alexandria ingestion failed")
+
+            await self._append_images(folder, session_id, session, handle)
+
+            handle.phase("committing")
+            await self.alexandria.commit(
+                session_id,
+                model_name=payload.pop("modelName"),
+                description=effective.get("description"),
+                batch_metadata=payload,
+            )
+            committed = await self.alexandria.wait_for_session(
+                session_id, {"committed"}
+            )
+            if committed["status"] == "error":
+                raise RuntimeError(
+                    committed.get("error") or "Alexandria commit failed"
+                )
+            return committed["modelId"]
+
+    async def _append_images(
+        self,
+        folder: ModelFolder,
+        session_id: str,
+        session: dict[str, Any],
+        handle: ModelProgress,
+    ) -> None:
+        present = session_filenames(session)
+        pending = tuple(
+            path for path in self.image_paths(folder) if path.name not in present
+        )
+        if not pending:
+            return
+        handle.phase("attachments")
+        done = 0
+        handle.attachments(done, len(pending))
+        for offset in range(0, len(pending), ATTACHMENT_BATCH_SIZE):
+            batch = pending[offset : offset + ATTACHMENT_BATCH_SIZE]
+            for path in batch:
+                await self.alexandria.append_files(session_id, (path,), (path.name,))
+                done += 1
+                handle.attachments(done, len(pending))
+
+
+def _uploaded_at() -> dict[str, str]:
+    return {"uploadedAt": datetime.now(UTC).isoformat()}
+
+
+def _failed_at() -> dict[str, str]:
+    return {"failedAt": datetime.now(UTC).isoformat()}
+```
+
+Add `from datetime import UTC, datetime` and `NullModelProgress` to the module's imports.
+
+- [ ] **Step 4: Extend AlexandriaClient.commit to carry full batch metadata**
+
+The existing `commit` sends only `modelName` and `description`. Replace `AlexandriaClient.commit` in `src/alexandria_telegram_importer/alexandria.py:261-278` with:
+
+```python
+    async def commit(
+        self,
+        session_id: str,
+        *,
+        model_name: str,
+        description: str | None = None,
+        batch_metadata: dict[str, Any] | None = None,
+    ) -> str:
+        payload: dict[str, Any] = dict(batch_metadata or {})
+        payload["modelName"] = model_name[:255]
+        if description is not None:
+            payload["description"] = description[:2000]
+        response = await self._request(
+            "POST",
+            f"/models/import-sessions/{session_id}/commit",
+            json={"batchMetadata": payload},
+        )
+        return self._data(response)["modelId"]
+```
+
+`ChannelImporter` calls `commit(session_id, model_name=..., description=...)`, which this signature still accepts unchanged.
+
+- [ ] **Step 5: Run the whole suite**
+
+Run: `uv run pytest -v`
+Expected: PASS — every new test plus every pre-existing one, including `tests/test_importer.py`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/alexandria_telegram_importer/folder_upload.py src/alexandria_telegram_importer/alexandria.py tests/test_folder_upload.py
+git commit -m "feat: upload staged folders to Alexandria with inherited metadata"
+```
+
+---
+
+## Task 9: CLI flags and the pause
+
+**Files:**
+- Modify: `src/alexandria_telegram_importer/cli.py`
+- Test: `tests/test_cli.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_cli.py`:
+
+```python
+def test_should_reject_a_staging_flag_without_a_staging_directory() -> None:
+    args = parser().parse_args(["--download-only", "5"])
+
+    with pytest.raises(SystemExit, match="--staging-dir"):
+        validate_staging_args(args)
+
+
+def test_should_reject_a_staging_directory_without_a_staging_flag() -> None:
+    args = parser().parse_args(["--staging-dir", "/tmp/work"])
+
+    with pytest.raises(SystemExit, match="one of"):
+        validate_staging_args(args)
+
+
+def test_should_reject_two_staging_flags_at_once() -> None:
+    with pytest.raises(SystemExit):
+        parser().parse_args(
+            ["--staging-dir", "/tmp/work", "--download-only", "5", "--upload-only"],
+        )
+
+
+def test_should_reject_a_non_positive_download_count() -> None:
+    with pytest.raises(SystemExit):
+        parser().parse_args(["--staging-dir", "/tmp/work", "--download-only", "0"])
+
+
+def test_should_accept_each_staging_mode(tmp_path) -> None:
+    for extra in (["--download-only", "5"], ["--upload-only"], ["--stage", "5"]):
+        args = parser().parse_args(["--staging-dir", str(tmp_path), *extra])
+        validate_staging_args(args)
+
+
+def test_should_treat_a_closed_stdin_as_quitting_the_pause(monkeypatch) -> None:
+    import io
+
+    monkeypatch.setattr("sys.stdin", io.StringIO(""))
+
+    assert confirm_upload("2 folders staged.") is False
+
+
+def test_should_treat_q_as_quitting_and_enter_as_proceeding(monkeypatch) -> None:
+    import io
+
+    monkeypatch.setattr("sys.stdin", io.StringIO("q\n"))
+    assert confirm_upload("2 folders staged.") is False
+
+    monkeypatch.setattr("sys.stdin", io.StringIO("\n"))
+    assert confirm_upload("2 folders staged.") is True
+```
+
+Add to the top of `tests/test_cli.py`:
+
+```python
+import pytest
+
+from alexandria_telegram_importer.cli import confirm_upload, validate_staging_args
+```
+
+`parser` is already imported there; verify with `head -15 tests/test_cli.py`.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `uv run pytest tests/test_cli.py -v`
+Expected: FAIL — `ImportError: cannot import name 'validate_staging_args'`
+
+- [ ] **Step 3: Write the implementation**
+
+In `src/alexandria_telegram_importer/cli.py`, add this helper beside `_concurrency`:
+
+```python
+def _positive(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError(
+            f"count must be an integer, got {value!r}"
+        ) from error
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("count must be at least 1")
+    return parsed
+```
+
+In `parser()`, add before `return result`:
+
+```python
+    result.add_argument(
+        "--staging-dir",
+        type=Path,
+        default=os.getenv("TELEGRAM_STAGING_DIR") or None,
+        help=(
+            "Directory holding staged model folders. Required by --download-only, "
+            "--upload-only, and --stage"
+        ),
+    )
+    staging = result.add_mutually_exclusive_group()
+    staging.add_argument(
+        "--download-only",
+        type=_positive,
+        metavar="N",
+        help="Stage up to N new Telegram bundles as folders, then exit",
+    )
+    staging.add_argument(
+        "--upload-only",
+        action="store_true",
+        help="Upload every model folder already in --staging-dir, then exit",
+    )
+    staging.add_argument(
+        "--stage",
+        type=_positive,
+        metavar="N",
+        help=(
+            "Stage up to N new bundles, pause for reorganization, then upload "
+            "whatever is in --staging-dir"
+        ),
+    )
+```
+
+Add these two functions at module level:
+
+```python
+def validate_staging_args(args: argparse.Namespace) -> None:
+    selected = (
+        args.download_only is not None or args.upload_only or args.stage is not None
+    )
+    if selected and args.staging_dir is None:
+        raise SystemExit(
+            "--staging-dir is required by --download-only, --upload-only, and --stage"
+        )
+    if args.staging_dir is not None and not selected:
+        raise SystemExit(
+            "--staging-dir requires one of --download-only, --upload-only, or --stage"
+        )
+
+
+def confirm_upload(summary: str) -> bool:
+    """Pause between the phases. A non-interactive stdin quits rather than hangs."""
+    print(summary)
+    print(
+        "Reorganize the folders now — split releases, compress, rename, "
+        "edit metadata.json."
+    )
+    print("Press Enter to upload, or q then Enter to quit without uploading.")
+    line = sys.stdin.readline()
+    if not line:
+        print("No input available; leaving the staged folders in place.")
+        return False
+    return line.strip().lower() != "q"
+```
+
+Add `import sys` to the module's imports.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `uv run pytest tests/test_cli.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/alexandria_telegram_importer/cli.py tests/test_cli.py
+git commit -m "feat: add staged import flags and the reorganization pause"
+```
+
+---
+
+## Task 10: Wire the phases into the run loop
+
+**Files:**
+- Modify: `src/alexandria_telegram_importer/cli.py`
+
+- [ ] **Step 1: Write the implementation**
+
+Add to the imports of `cli.py`:
+
+```python
+from .folder_upload import FolderUploader
+from .grouping import build_bundles
+from .staging import BundleStager, bundle_key
+```
+
+Add these two coroutines at module level:
+
+```python
+async def stage_bundles(
+    *,
+    telegram: TelegramSource,
+    tracker: ImportTracker,
+    refs: list,
+    staging_dir: Path,
+    limit: int,
+    progress,
+) -> tuple[int, int]:
+    """Stage up to `limit` not-yet-staged bundles. Returns (staged, failed)."""
+    already = tracker.staged_keys(telegram.channel_id)
+    stager = BundleStager(telegram=telegram, root=staging_dir)
+    staged = 0
+    failed = 0
+    with guarded_reporter(progress):
+        for bundle in build_bundles(telegram.channel_id, refs):
+            if staged >= limit:
+                break
+            key = bundle_key(telegram.channel_id, bundle)
+            if key in already:
+                continue
+            label = bundle.models[0].logical_filename
+            try:
+                with guarded_model(progress, label, parts=1) as handle:
+                    folder = await stager.stage(bundle, handle)
+            # One unreachable Telegram post must not stop the rest of the run.
+            except Exception as error:  # noqa: BLE001
+                log.error("Failed to stage bundle at %s: %s", label, error)
+                failed += 1
+                continue
+            tracker.record_staged(
+                bundle_key=key,
+                source_channel_id=telegram.channel_id,
+                folder_name=folder.name,
+                model_message_ids=tuple(
+                    part.message_id for unit in bundle.models for part in unit.parts
+                ),
+            )
+            staged += 1
+            progress.totals(staged, limit, {"staged": staged, "failed": failed})
+    return staged, failed
+
+
+def _staging_summary(staging_dir: Path, staged: int, failed: int) -> str:
+    total_bytes = sum(
+        path.stat().st_size for path in staging_dir.rglob("*") if path.is_file()
+    )
+    line = f"{staged} folders staged in {staging_dir} ({format_bytes(total_bytes)})."
+    return line + (f" {failed} bundle(s) failed to stage." if failed else "")
+```
+
+Add `format_bytes`, `guarded_model`, and `guarded_reporter` to the `progress` import in `cli.py`, and `log = logging.getLogger(__name__)` at module level.
+
+Replace the body of `run()` between `refs = await telegram.collect_media(...)` and the `finally:` block with:
+
+```python
+        if args.dry_run:
+            print(describe_plan(telegram.channel_id, refs))
+            return 0
+
+        progress = reporter_from_args(
+            no_progress=args.no_progress,
+            dry_run=args.dry_run,
+            verbose=args.verbose,
+        )
+        staged = failed_to_stage = 0
+        if args.download_only is not None or args.stage is not None:
+            tracker = ImportTracker(args.state)
+            staged, failed_to_stage = await stage_bundles(
+                telegram=telegram,
+                tracker=tracker,
+                refs=refs,
+                staging_dir=args.staging_dir,
+                limit=args.download_only or args.stage,
+                progress=progress,
+            )
+            summary = _staging_summary(args.staging_dir, staged, failed_to_stage)
+            if args.download_only is not None:
+                print(summary)
+                return 1 if failed_to_stage else 0
+            if not confirm_upload(summary):
+                return 1 if failed_to_stage else 0
+
+        if args.upload_only or args.stage is not None:
+            email = os.getenv("ALEXANDRIA_EMAIL") or input("Alexandria email: ").strip()
+            password = os.getenv("ALEXANDRIA_PASSWORD") or getpass.getpass(
+                "Alexandria password: "
+            )
+            alexandria = AlexandriaClient(
+                args.alexandria_url,
+                library_id=args.library_id,
+                poll_interval=args.poll_interval,
+                allow_insecure_http=args.allow_insecure_http,
+            )
+            await alexandria.login(email, password)
+            outcomes = await FolderUploader(
+                alexandria=alexandria,
+                work_root=args.state.parent / f"{args.state.name}.work",
+                concurrency=args.concurrency,
+                progress=progress,
+            ).run(args.staging_dir)
+            print(
+                "Upload state: "
+                + ", ".join(
+                    f"{status}={count}" for status, count in sorted(outcomes.items())
+                ),
+            )
+            return 1 if outcomes.get("failed") or failed_to_stage else 0
+
+        email = os.getenv("ALEXANDRIA_EMAIL") or input("Alexandria email: ").strip()
+        password = os.getenv("ALEXANDRIA_PASSWORD") or getpass.getpass(
+            "Alexandria password: "
+        )
+        alexandria = AlexandriaClient(
+            args.alexandria_url,
+            library_id=args.library_id,
+            poll_interval=args.poll_interval,
+            allow_insecure_http=args.allow_insecure_http,
+        )
+        await alexandria.login(email, password)
+        tracker = tracker or ImportTracker(args.state)
+        counts = await ChannelImporter(
+            telegram=telegram,
+            alexandria=alexandria,
+            tracker=tracker,
+            work_root=args.state.parent / f"{args.state.name}.work",
+            concurrency=args.concurrency,
+            progress=progress,
+        ).run(refs)
+        print(
+            "Import state: "
+            + ", ".join(f"{status}={count}" for status, count in sorted(counts.items()))
+        )
+        return (
+            1 if counts.get("failed", 0) or counts.get("completion_uncertain", 0) else 0
+        )
+```
+
+In `main()`, call `validate_staging_args(args)` immediately after `args = parser().parse_args()`.
+
+- [ ] **Step 2: Run the whole suite and lint**
+
+Run: `uv run pytest -v && uv run ruff check .`
+Expected: PASS with no lint findings
+
+- [ ] **Step 3: Smoke-test the flags**
+
+Run: `uv run alexandria-telegram-import --help`
+Expected: `--staging-dir`, `--download-only`, `--upload-only`, and `--stage` appear
+
+Run: `uv run alexandria-telegram-import --download-only 5`
+Expected: exits with `--staging-dir is required by --download-only, --upload-only, and --stage`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/alexandria_telegram_importer/cli.py
+git commit -m "feat: wire the staged download and folder upload phases into the CLI"
+```
+
+---
+
+## Task 11: Document the staged flow
+
+**Files:**
+- Modify: `tools/telegram-importer/README.md`
+
+- [ ] **Step 1: Write the documentation**
+
+Insert a new `## Staged import` section immediately after the existing `## Preview and import` section, before `## Concurrency`. It must cover:
+
+- The three flags with a worked example of each, matching Task 9's help text.
+- The folder layout (`models/`, `images/`, `metadata.json`) with the tree from the spec.
+- The `models/` classification rules — as-is single archive, split set, everything else zipped — and that a hand-made `.7z` is uploaded byte for byte.
+- Discovery: `models/` means model folder, subdirectories mean container, both means ambiguous and moved to `failed/`.
+- Inheritance: scalars nearest-wins, tags merged, `metadata`/`options` merged per key, `modelName` never inherited.
+- Container `images/` appended to every model beneath, with the storage cost stated.
+- Disposal into `uploaded/` and `failed/` with `result` written into `metadata.json`.
+- That the upload phase performs no deduplication, and that re-uploading a folder moved back out of `uploaded/` creates a second model.
+- That `staged_bundles` state makes consecutive `--download-only N` runs walk forward, and that deleting a folder by hand does not re-offer that bundle.
+
+Also add `TELEGRAM_STAGING_DIR` to the `.env` documentation in the Setup section.
+
+- [ ] **Step 2: Verify the documented commands parse**
+
+Run each command shown in the new section with `--help` appended, confirming no argparse error.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: document the Telegram staged import flow"
+```
+
+---
+
+## Task 12: Full verification and PR
+
+- [ ] **Step 1: Run the full suite, lint, and the repo-wide build**
+
+```bash
+uv run pytest -v
+uv run ruff check .
+```
+
+Then from the repository root:
+
+```bash
+npm test
+```
+
+Expected: all pass. The npm suite must be unaffected — this plan changes no TypeScript.
+
+- [ ] **Step 2: Confirm the direct-import path still behaves identically**
+
+Run: `uv run pytest tests/test_importer.py tests/test_concurrency.py tests/test_tracker.py -v`
+Expected: PASS with no changes to their assertions. If any assertion needed changing, the direct path was modified and that is a defect in this plan's execution — stop and report it.
+
+- [ ] **Step 3: Run the reviewer agent**
+
+Per `CLAUDE.md`, run the `reviewer` agent over the diff for architectural drift and convention violations.
+
+- [ ] **Step 4: Open the PR**
+
+```bash
+gh pr create --title "feat: staged Telegram import with an operator reorganization pause" --body "..."
+```
+
+The body must summarize the two phases, the folder contract, and the deliberate no-dedupe decision. Do not merge — leave the PR open for review.
+
+---
+
+## Self-Review Notes
+
+Checked against `docs/superpowers/specs/2026-07-25-telegram-staged-import-design.md`:
+
+- Spec §1 command surface → Tasks 9, 10.
+- Spec §2 staged download (bundle key, `staged_bundles`, layout, naming, failure) → Tasks 2, 3, 4.
+- Spec §3 `metadata.json` → Tasks 1, 4.
+- Spec §4 discovery, inheritance, classification, container images, disposal, no-dedupe → Tasks 5, 6, 7, 8.
+- Spec §5 backend prefill → **not in this plan.** It is an independent subsystem and has its own plan: `docs/superpowers/plans/2026-07-25-alexandria-metadata-json-prefill.md`.
+- Spec §6 module layout → File Structure table.
+- Spec §7 testing → the test steps of Tasks 1–8; the backend bullets belong to the other plan.
+
+Naming consistency verified across tasks: `plan_models_dir`, `build_upload_paths`, `ModelsPlan`, `ModelFolder`, `discover`, `dispose`, `FolderUploader`, `BundleStager`, `bundle_key`, `bundle_folder_name`, `unique_child`, `merge_chain`, `batch_metadata`, `model_name_from_folder`, `record_staged`, `get_staged`, `staged_keys`, `validate_staging_args`, `confirm_upload`.
+
+One cross-task dependency to watch: Task 8 Step 4 changes `AlexandriaClient.commit`'s signature. `ChannelImporter` calls it with `model_name=` and `description=` only, both of which the new signature still accepts, so `tests/test_importer.py` must pass unchanged. Task 12 Step 2 verifies this explicitly.

--- a/docs/superpowers/specs/2026-07-25-telegram-staged-import-design.md
+++ b/docs/superpowers/specs/2026-07-25-telegram-staged-import-design.md
@@ -1,0 +1,380 @@
+# Telegram staged import — design
+
+Date: 2026-07-25
+Components: `tools/telegram-importer`, `apps/backend`, `packages/shared`, `apps/frontend`
+
+## Problem
+
+The importer runs Telegram → Alexandria as one uninterruptible pipeline. Each logical
+model is downloaded, uploaded, and committed with no point at which a human can look at
+what was fetched. Three consequences:
+
+1. **Multi-model releases are mis-grouped.** `build_bundles` turns a bundle of eight
+   archives into eight logical models and gives the bundle's images to the *first* one
+   only; the rest get a "possibly related" note and no attachments. The images usually
+   belong to all eight, and which archives are variants of one model versus genuinely
+   separate models is a judgment the grouping rules cannot make.
+2. **No compression window.** A release of loose STLs uploads as a plain `ZIP_DEFLATED`
+   archive. Getting a well-compressed `.7z` today means importing, downloading the model
+   back out, compressing, and re-uploading.
+3. **No naming or metadata window.** The committed name is mechanically derived from the
+   filename, and the description is assembled from captions. Correcting either means
+   editing the model in Alexandria afterwards.
+
+## Goal
+
+Split the pipeline into a **download phase** that stages Telegram bundles as folders on
+disk and an **upload phase** that ingests folders into Alexandria, with an operator
+intervention window between them. The two phases share no run-time state: what gets
+uploaded is whatever is on disk when the upload phase runs, regardless of what was
+downloaded.
+
+## Non-goals
+
+- Changing the existing direct-import path. `ChannelImporter` keeps its current
+  behaviour, dedupe, and recovery semantics, and is not refactored.
+- Deduplication in the upload phase. See "Deliberate omissions".
+- Automatically splitting multi-model releases. Deciding that eight archives are eight
+  models rather than one model with eight variants is the operator's job; that decision
+  is the entire reason the pause exists.
+
+---
+
+## 1. Command surface
+
+Three new flags on the existing `alexandria-telegram-import` command:
+
+```bash
+# Download 20 bundles and exit
+alexandria-telegram-import --download-only 20 --staging-dir ./work
+
+# Upload everything currently in ./work and exit
+alexandria-telegram-import --upload-only --staging-dir ./work
+
+# Both, with a pause between
+alexandria-telegram-import --stage 20 --staging-dir ./work
+```
+
+`--staging-dir` is required by all three and rejected without one of them. `--download-only`
+and `--stage` take a positive integer. The three flags are mutually exclusive. Passing none
+of them keeps today's direct-import behaviour exactly.
+
+`--stage N` runs the download phase, then prints a summary and blocks:
+
+```
+20 folders staged in ./work (14.2 GB).
+Reorganize them now — split releases, compress, rename, edit metadata.json.
+Press Enter to upload, or q then Enter to quit without uploading.
+```
+
+Quitting leaves the staged folders in place; a later `--upload-only` picks them up. The
+pause reads from stdin and requires a newline rather than raw-mode single-key input, so a
+non-interactive stdin (a pipe, `nohup`) gets EOF and is treated as quit rather than
+hanging forever.
+
+`--concurrency` and `--download-connections` apply to both phases as they do today.
+`--dry-run` combined with `--download-only` or `--stage` prints the bundle plan and exits
+without downloading.
+
+---
+
+## 2. Staged download
+
+### Bundle selection
+
+Bundles come from the existing `grouping.build_bundles` — no grouping changes. Each bundle
+gets a **bundle key**: SHA-256 over the channel ID and every model message ID in the
+bundle, sorted. This is distinct from the per-logical-model `import_key` the direct path
+uses; the two key spaces never mix.
+
+A new `staged_bundles` table in the same SQLite state file records what has been staged:
+
+| Column | Notes |
+|---|---|
+| `bundle_key` | primary key |
+| `source_channel_id` | |
+| `folder_name` | as created, before any rename |
+| `model_message_ids` | JSON array |
+| `status` | `downloaded` |
+| `downloaded_at` | ISO 8601 |
+
+The existing `imports` table is untouched — its `session_id`, `model_id`, and signature
+columns have no meaning for a staged bundle. Table creation follows the tracker's existing
+in-place migration approach (`CREATE TABLE IF NOT EXISTS` at startup), so an existing state
+file gains the table without a manual step.
+
+`N` counts **newly staged** bundles. Any bundle whose key is already present is skipped, so
+consecutive `--download-only 20` runs walk forward through the channel. Bundles are
+considered in ascending message-ID order and the run stops once `N` have been staged or the
+channel is exhausted.
+
+A folder deleted by hand is not re-offered — deleting is recorded as a skip decision by the
+row that remains in `staged_bundles`. Re-staging requires deleting that row.
+
+### Folder layout
+
+Folder name is `{first_message_id:06d}-{slug}`, where the slug comes from
+`model_name_from_filename` on the bundle's first model filename, lowercased, non-alphanumerics
+collapsed to hyphens, truncated to 60 characters. Zero-padding to six digits keeps a normal
+channel sorting correctly in a file browser; a channel past message 999999 sorts slightly out
+of order, which is cosmetic.
+
+```
+work/002501-dragon-set/
+  metadata.json
+  models/     every model medium in the bundle, original filenames, split parts intact
+  images/     every attachment medium in the bundle
+```
+
+Filenames pass through the existing `safe_filename`. A collision within a folder gets a
+`-2`, `-3` suffix before the extension. `models/` and `images/` are always created, even when
+empty, so the layout is predictable.
+
+Downloads reuse `TelegramSource.download` and the existing `ProgressReporter`; a staged
+download only ever reports the `download` phase.
+
+### Failure handling
+
+A bundle that fails mid-download leaves no `staged_bundles` row and its partial folder is
+removed, so the next run retries it. The run continues with the remaining bundles; a summary
+line reports how many staged and how many failed.
+
+---
+
+## 3. metadata.json
+
+Written at the root of every staged folder. The top level mirrors
+`batchUploadMetadataSchema` field for field so the upload phase passes it to the commit
+endpoint with no translation layer.
+
+```json
+{
+  "schemaVersion": 1,
+
+  "modelName": "Dragon Set",
+  "description": "…captions, related-model note, and source line…",
+  "artist": null,
+  "tags": [],
+  "metadata": {},
+  "options": {},
+  "collectionId": null,
+  "newCollectionName": null,
+
+  "source": {
+    "channelId": -1001234567890,
+    "channelUsername": "somechannel",
+    "bundleKey": "9f2a…",
+    "modelMessageIds": [2501, 2502],
+    "attachmentMessageIds": [2499, 2500],
+    "link": "https://t.me/somechannel/2501",
+    "downloadedAt": "2026-07-25T04:12:03Z"
+  },
+
+  "result": null
+}
+```
+
+`description` is exactly what `build_description` composes today — unique captions, the
+possibly-related note, the channel and message IDs, and the `t.me` link — so it is edited
+rather than written from scratch.
+
+`source` is provenance. The upload phase reads none of it; it exists so a folder is
+traceable to its Telegram origin after being renamed and split. `result` is filled on
+disposal with `{"modelId", "sessionId", "uploadedAt"}` or `{"error", "failedAt"}`.
+
+Unknown top-level keys are preserved on rewrite. A file that is absent, unparseable, or not
+a JSON object is treated as "no metadata" — the folder still uploads.
+
+---
+
+## 4. Upload phase
+
+### Discovery
+
+Recursive walk from the staging root, skipping `uploaded/` and `failed/`:
+
+- Directory contains a `models/` subdirectory → **model folder**. Upload it.
+- Otherwise, directory contains subdirectories → **container**. Recurse into it.
+- Directory contains `models/` **and** has a descendant model folder → **ambiguous**.
+  Moved to `failed/` without uploading.
+
+The ambiguous case is the half-finished split: archives moved into child folders but the
+parent's `models/` left in place. Uploading the parent would commit two archives and
+silently drop the six that were moved, so it fails loudly instead.
+
+A staged folder therefore starts life as a model folder. Moving its archives into child
+`models/` directories and removing the now-empty parent `models/` turns it into a
+container. The split itself is the signal — no flag, no rename.
+
+### Inheritance
+
+`metadata.json` files merge from the staging root down to the model folder, at arbitrary
+depth:
+
+- **Scalars** (`description`, `artist`, `collectionId`, `newCollectionName`) — nearest
+  ancestor wins.
+- **`tags`** — merged across all levels, de-duplicated, order preserved from outermost.
+- **`metadata`** — merged key by key, nearest wins per key.
+- **`options`** — merged key by key, nearest wins per key.
+- **`modelName`** — **never inherits.** A model folder uses its own `metadata.json`
+  `modelName`, or failing that its own directory name (leading `NNNNNN-` stripped, hyphens
+  and underscores to spaces). Inheriting it would commit all eight models of a release as
+  "Dragon Set".
+
+This makes the release-level `metadata.json` a defaults file: set the collection, artist,
+and tags once, and each child folder needs at most its own name.
+
+### Per-folder upload
+
+1. Resolve effective metadata by merging the inheritance chain.
+2. Classify `models/`:
+   - `models/` holds **exactly one entry** and it is an archive file
+     (`.zip`, `.rar`, `.7z`, `.tar.gz`, `.tgz`) → upload as-is, byte for byte. No
+     recompression — this is what makes a hand-made `.7z` worth creating.
+   - **Every** entry is a member of one recognized split set (`.partN.rar`,
+     `.zNN` + `.zip`, `.zip.NNN`) → multipart `split` upload, reusing the existing
+     part-role detection in `grouping.py`. A set that is incomplete or mixes two
+     different base names falls through to the zip case rather than being guessed at.
+   - Anything else — several files, loose model files, subdirectories, one archive
+     alongside a stray `readme.txt` → zipped with `ZIP_DEFLATED` into one archive
+     preserving paths relative to `models/`.
+   - Empty or missing → error, folder moves to `failed/`.
+3. Upload → wait for `ready_for_review`.
+4. Append every file in `images/` as attachments, plus every file in each ancestor
+   container's `images/` (see below). Batched at 100 as the direct path does.
+5. Commit with `batchMetadata` built from the effective metadata.
+6. Wait for `committed`.
+
+A failure at any step records the error and moves the folder to `failed/`; the run
+continues with the remaining folders. `--concurrency` applies across model folders.
+
+### Container images
+
+Files in a container's `images/` directory are appended to **every** model folder beneath
+it, in addition to that folder's own images. The case this serves: a release has ten
+renders, three belong to the knight, three to the mage, and four are group shots that
+belong to no single model. Distribute the six, leave the four, and every model gets the
+group renders.
+
+The cost is storage — those four images are stored once per model. The alternative,
+ignoring them, silently discards images the operator deliberately left in place, which is
+the worse failure. Duplicate filenames between a container's `images/` and a model's own
+`images/` resolve in favour of the model's own file.
+
+### Disposal
+
+Per model folder, not per release — six can succeed while two fail.
+
+- Success → moved to `uploaded/`, preserving the path relative to the staging root:
+  `uploaded/002501-dragon-set/dragon-knight/`. `result` is written first.
+- Failure → moved to `failed/` on the same relative path, with `result` recording the error.
+- Each ancestor container's `metadata.json` is **copied** (not moved) alongside, so the
+  archived copy is self-describing and later folders from the same release still see their
+  defaults.
+- A container left with no model folders beneath it is removed from the staging root.
+- A move that collides with an existing path gets a `-2`, `-3` suffix rather than
+  overwriting.
+
+The staging root therefore always shows exactly what is left to do. `uploaded/` is deleted
+by hand once the results have been checked.
+
+### Deliberate omissions
+
+The upload phase performs **no deduplication**. No Telegram media signatures, no SHA-256
+content signatures, no reads or writes to the `imports` table. The folders are
+hand-curated; the phase uploads what it is given.
+
+The consequence is explicit: moving a folder back out of `uploaded/` and re-running
+`--upload-only` creates a second Alexandria model. This follows directly from the phases
+sharing no state, which is what allows folders to be split, merged, renamed, and
+recompressed freely between them.
+
+---
+
+## 5. Backend metadata.json prefill
+
+Independent of the importer and shippable as its own PR.
+
+During import-session scanning, if the uploaded archive contains `metadata.json` at its
+root, parse it and surface it on the session for the review form to prefill.
+
+- Validated leniently against the existing `batchUploadMetadataSchema` shape, with unknown
+  keys (`source`, `result`, `schemaVersion`) stripped rather than rejected.
+- Invalid JSON, a non-object root, or a file over 64 KB → skipped with a debug log. Never
+  fails the scan.
+- Surfaced as a new optional field on the import session's `detected` payload, added to
+  `packages/shared` and documented in `docs/TYPES.md` and `docs/API.md`.
+- The frontend review form prefills empty fields from it and marks them as suggested.
+
+**Prefill only — never auto-applied at commit.** The client always sends the metadata it
+intends. This keeps the web UI honest (the operator sees the values before they are
+applied) and guarantees the change cannot alter the outcome of any existing upload path.
+
+The importer does not rely on this. It sends `batchMetadata` explicitly at commit, which
+is what makes an upload-as-is `.7z` — whose bytes the backend cannot modify — carry its
+metadata.
+
+---
+
+## 6. Module layout
+
+| Module | Responsibility |
+|---|---|
+| `staging.py` (new) | Bundle keys, folder naming and creation, downloading a bundle into a folder, writing `metadata.json` |
+| `folder_upload.py` (new) | Discovery walk, inheritance merge, `models/` classification, upload/commit, disposal |
+| `folder_metadata.py` (new) | `metadata.json` read/write/merge, schema versioning |
+| `tracker.py` | `staged_bundles` table and its accessors |
+| `cli.py` | New flags, mutual exclusion, the pause |
+| `importer.py` | Unchanged |
+| `grouping.py` | `multipart_part_role` and the archive-extension constants reused by the classifier; no behaviour change |
+
+`ChannelImporter` is deliberately not reused. The new phases reuse `TelegramSource`,
+`AlexandriaClient`, `grouping`, and `progress` directly. Sharing `ChannelImporter` would
+mean inheriting its dedupe, session-recovery, and signature-gate semantics, all of which
+the staged flow explicitly does not want.
+
+---
+
+## 7. Testing
+
+**Python — staging**
+- Bundle key is stable across runs and distinct from `import_key` for the same messages.
+- `--download-only N` stages exactly N new bundles and skips already-staged keys.
+- Folder layout, name slugging, padding, and filename collision suffixes.
+- `metadata.json` contents, including that `description` matches `build_description`.
+- A failed bundle leaves no `staged_bundles` row and no partial folder.
+
+**Python — folder upload**
+- Discovery: model folder, container, nested container, ambiguous parent → `failed/`.
+- Inheritance: scalar override, tag merge, per-key `metadata` merge, `modelName` not
+  inheriting, missing child `metadata.json` falling back to the folder name.
+- Classification: single archive uploaded as-is (byte-identical), split set detected as
+  multipart, loose files zipped with relative paths preserved, empty `models/` failing.
+- Container `images/` appended to every descendant; name collision favours the model's own.
+- Disposal: relative path preserved, container `metadata.json` copied, emptied container
+  removed, collision suffixing, `result` written in both directions.
+- A folder with no `metadata.json` uploads with a folder-derived name.
+
+**Backend**
+- `metadata.json` at archive root is detected and surfaced on the session.
+- Invalid JSON, non-object root, oversized file, and a nested (non-root) `metadata.json`
+  are all ignored without failing the scan.
+- Unknown keys are stripped; known keys survive validation.
+- Commit is unaffected when the client sends no `batchMetadata` — detection never applies
+  values on its own.
+
+---
+
+## 8. Decision log
+
+| Decision | Rationale |
+|---|---|
+| One staged folder per bundle, not per logical model | The bundle is what shares images. Per-model staging re-creates the mis-grouping the feature exists to fix. |
+| `models/` and `images/` subfolders | Unambiguous after hand-renaming and recompression; no extension guessing at upload time. |
+| Single archive uploaded as-is | Re-wrapping a hand-made `.7z` in a zip wastes the compression work that motivated the pause. |
+| Phases share no state | Folders will be split, merged, and renamed between them, so any download→upload correspondence would be wrong more often than right. |
+| No dedupe on upload | Follows from the above. Hand-curated input is trusted. |
+| Container metadata inherits, `modelName` does not | Set collection/artist/tags once per release; never commit eight models under one name. |
+| Container `images/` inherit | Silently dropping deliberately-placed images is worse than storing them per model. |
+| Ambiguous folder fails rather than uploads | A half-finished split would otherwise silently drop most of a release. |
+| Backend prefill never auto-applies | Cannot change the outcome of any existing upload path. |

--- a/docs/superpowers/specs/2026-07-25-telegram-staged-import-design.md
+++ b/docs/superpowers/specs/2026-07-25-telegram-staged-import-design.md
@@ -182,8 +182,21 @@ rather than written from scratch.
 traceable to its Telegram origin after being renamed and split. `result` is filled on
 disposal with `{"modelId", "sessionId", "uploadedAt"}` or `{"error", "failedAt"}`.
 
-Unknown top-level keys are preserved on rewrite. A file that is absent, unparseable, or not
-a JSON object is treated as "no metadata" — the folder still uploads.
+Unknown top-level keys are preserved on rewrite. A file that is absent is treated as "no
+metadata" — the folder still uploads, named from its folder.
+
+An **unparseable** file is not the same thing, and is handled differently by level. This file is
+edited by hand, so a JSON syntax error is likely, and silently defaulting would commit a wrongly
+named model while destroying the typed values:
+
+- A **model folder** whose own `metadata.json` will not parse moves to `failed/` without
+  uploading.
+- A **container's** unparseable file is skipped leniently — a container commits nothing.
+- In both cases the unreadable file is never rewritten. Its result goes to a sibling
+  `result.json`, so hand-typed values survive.
+
+*(Revised after review: the original spec said "unparseable → treated as no metadata" at every
+level, which made a typo silently destructive.)*
 
 ---
 
@@ -209,7 +222,8 @@ container. The split itself is the signal — no flag, no rename.
 ### Inheritance
 
 `metadata.json` files merge from the staging root down to the model folder, at arbitrary
-depth:
+depth. The staging root participates as a container itself, so `<staging-dir>/metadata.json`
+and `<staging-dir>/images/` supply channel-wide defaults:
 
 - **Scalars** (`description`, `artist`, `collectionId`, `newCollectionName`) — nearest
   ancestor wins.
@@ -271,7 +285,13 @@ Per model folder, not per release — six can succeed while two fail.
 - Each ancestor container's `metadata.json` is **copied** (not moved) alongside, so the
   archived copy is self-describing and later folders from the same release still see their
   defaults.
-- A container left with no model folders beneath it is removed from the staging root.
+- A container is removed once it holds nothing but its own `metadata.json`. Emptiness is
+  judged by what is on disk, **not** by whether discovery can still find a model folder —
+  a container may hold an unsplit archive, a half-organized subfolder, or shared images, none
+  of which discovery sees and all of which are the operator's work in progress.
+
+  *(Revised after review: the original rule, "a container left with no model folders is
+  removed", deleted exactly that work in progress.)*
 - A move that collides with an existing path gets a `-2`, `-3` suffix rather than
   overwriting.
 
@@ -377,4 +397,7 @@ the staged flow explicitly does not want.
 | Container metadata inherits, `modelName` does not | Set collection/artist/tags once per release; never commit eight models under one name. |
 | Container `images/` inherit | Silently dropping deliberately-placed images is worse than storing them per model. |
 | Ambiguous folder fails rather than uploads | A half-finished split would otherwise silently drop most of a release. |
+| Pruning judges emptiness by disk contents, not by discovery | Discovery only sees model folders, so pruning on it deletes unsplit archives and shared images. |
+| An unparseable model-folder `metadata.json` fails the folder | It is the one file operators edit by hand; defaulting silently commits a wrong name and destroys the typed values. |
+| `--concurrency` applies to both phases | Otherwise moving from the direct path to `--download-only` is a silent throughput regression. |
 | Backend prefill never auto-applies | Cannot change the outcome of any existing upload path. |

--- a/tools/telegram-importer/README.md
+++ b/tools/telegram-importer/README.md
@@ -50,6 +50,8 @@ Set `TELEGRAM_IMPORT_CONCURRENCY` to import several models at the same time; it 
 
 Set `TELEGRAM_DOWNLOAD_CONNECTIONS` to change how many connections fetch one file at once; it defaults to `8` and `--download-connections` overrides it. See [Download speed](#download-speed).
 
+Set `TELEGRAM_STAGING_DIR` to a default directory for staged model folders; `--staging-dir` overrides it. See [Staged import](#staged-import).
+
 By default, the reusable Telegram login session and SQLite import state live under `$XDG_DATA_HOME/alexandria-telegram-importer`, or `~/.local/share/alexandria-telegram-importer` when `XDG_DATA_HOME` is unset. Override them with `TELEGRAM_SESSION_PATH` and `TELEGRAM_IMPORT_STATE_PATH`, or with the `--session` and `--state` command-line options.
 
 ## Preview and import
@@ -84,6 +86,116 @@ uv run alexandria-telegram-import \
 `--from-message-id N` considers only Telegram messages with IDs greater than `N`. `--poll-interval` changes the default two-second Alexandria session polling interval. `--concurrency N` sets how many models are imported at the same time. Run `uv run alexandria-telegram-import --help` for all options.
 
 During a real run, each model is downloaded, scanned by Alexandria, held until `ready_for_review`, given its assigned attachments, committed with a derived name and Telegram-source description, and awaited until `committed`. The commit sets only that name and description; the importer does not assign a collection or map Telegram content into artist, tags, or custom metadata. A failure is recorded and the run continues with the remaining models. The command exits with status 1 when the state database contains failed or completion-uncertain imports after the run.
+
+## Staged import
+
+The default run sends every model straight to Alexandria. A staged import splits that into a download phase and an upload phase with a pause in between, so a release can be reorganized before anything is committed. It exists for three things the direct path cannot do: splitting a release that holds several distinct models, compressing archives yourself rather than downloading and re-uploading later, and correcting names and metadata before commit rather than after.
+
+```bash
+# Stage 20 bundles as folders and exit
+uv run alexandria-telegram-import --download-only 20 --staging-dir ./work
+
+# Upload every model folder currently in ./work and exit
+uv run alexandria-telegram-import --upload-only --staging-dir ./work
+
+# Both, pausing between them
+uv run alexandria-telegram-import --stage 20 --staging-dir ./work
+```
+
+All three require `--staging-dir`, and `--staging-dir` requires one of them. `TELEGRAM_STAGING_DIR` sets the default directory. `--stage` prints a summary and waits for Enter; `q` then Enter quits and leaves the folders for a later `--upload-only`. A non-interactive standard input is treated as quitting rather than hanging.
+
+### Folder layout
+
+One folder per *bundle* — the attachments and the consecutive run of model media that grouping assigns to each other — rather than one per logical model, because the images belong to the whole bundle:
+
+```
+work/002501-dragon-set/
+  metadata.json
+  models/    every model medium, original filenames, split parts intact
+  images/    every attachment medium
+```
+
+The name is the first model message ID zero-padded to six digits, plus a slug of the first model's filename. Both subfolders are always created, even when empty.
+
+### Reorganizing
+
+A folder holding `models/` is a **model folder** and becomes one Alexandria model. A folder holding only subfolders is a **container** and is recursed into. So splitting a release means moving its archives into per-model child folders and removing the now-empty parent `models/` — the split itself is the signal, with no flag to set:
+
+```
+work/002501-dragon-set/
+  metadata.json          <- release defaults
+  images/                <- group renders, inherited by every model below
+  dragon-knight/
+    metadata.json        <- modelName only; everything else inherited
+    models/  images/
+  dragon-mage/
+    models/  images/     <- no metadata.json: name comes from the folder
+```
+
+A folder holding **both** its own `models/` and a descendant model folder is a half-finished split. It is moved to `failed/` without uploading, because committing the leftovers would silently drop everything already moved into the children.
+
+### How models/ is uploaded
+
+- Exactly one entry, and it is an archive (`.zip`, `.rar`, `.7z`, `.tar.gz`, `.tgz`) — uploaded byte for byte, with no recompression. This is what makes a hand-made `.7z` worth creating.
+- Every entry a member of one complete split set (`.partN.rar`, `.zNN` plus `.zip`, `.zip.NNN`) — uploaded through the multipart `split` endpoints. An incomplete set, or one mixing two base names, falls through to the zip case rather than being guessed at.
+- Anything else — several files, loose model files, subfolders, an archive sitting beside a stray `readme.txt` — zipped into one archive preserving paths relative to `models/`.
+- Empty or missing — the folder moves to `failed/`.
+
+Every file in `images/` is appended as an attachment after the scan reaches `ready_for_review`.
+
+### metadata.json
+
+Its top level mirrors Alexandria's commit `batchMetadata` field for field, so it is passed through untranslated:
+
+```json
+{
+  "schemaVersion": 1,
+  "modelName": "Dragon Knight",
+  "description": "…captions, related models, and the t.me source link…",
+  "artist": null, "tags": [], "metadata": {}, "options": {},
+  "collectionId": null, "newCollectionName": null,
+  "source": { "channelId": -100…, "modelMessageIds": [2501], "link": "https://t.me/…" },
+  "result": null
+}
+```
+
+`source` records where the bundle came from; the upload phase ignores it, and it survives renaming and splitting. `result` is filled on disposal. `description` is composed from the bundle's captions and source link, so it is edited rather than written from scratch. A folder with no `metadata.json` still uploads, taking its name from its folder name.
+
+Values merge from the outermost container down to the model folder:
+
+| Field | Rule |
+|---|---|
+| `description`, `artist`, `collectionId`, `newCollectionName` | Nearest level wins |
+| `tags` | Merged across every level, de-duplicated |
+| `metadata`, `options` | Merged key by key, nearest wins per key |
+| `modelName` | **Never inherits** — from the folder's own file, or its folder name |
+
+`modelName` is excluded deliberately: inheriting it would commit all eight models of a release as "Dragon Set". Everything else inheriting means the collection, artist, and tags are set once at the release root.
+
+Files in a container's `images/` are appended to **every** model folder beneath it, so group renders you do not want to file per-model still reach each model. They are stored once per model, and a model's own `images/` wins a filename collision.
+
+### Disposal
+
+Each model folder settles independently — six can succeed while two fail:
+
+```
+work/
+  002503-wizard-set/       <- still pending
+  uploaded/
+    002501-dragon-set/
+      metadata.json        <- copied from the container
+      dragon-knight/       <- result.modelId written into its metadata.json
+  failed/
+    002502-broken/         <- result.error written into its metadata.json
+```
+
+Paths relative to the staging root are preserved, each ancestor container's `metadata.json` is copied alongside, and a container left with no model folders is removed. The staging root therefore always shows exactly what is left to do. Delete `uploaded/` once the results have been checked.
+
+### State and duplicates
+
+Staged bundles are recorded in a `staged_bundles` table in the same SQLite state file, so consecutive `--download-only 20` runs walk forward through the channel rather than re-staging the same bundles. Deleting a folder by hand does not re-offer that bundle — deleting is recorded as a skip decision. Re-staging it means deleting its row.
+
+**The upload phase performs no deduplication.** No Telegram media signatures, no content hashes, no reads or writes to the `imports` table that the direct path uses. The folders are hand-curated and are uploaded as given. The consequence is explicit: moving a folder back out of `uploaded/` and re-running `--upload-only` creates a second Alexandria model. This follows from the two phases sharing no state, which is what lets folders be split, merged, renamed, and recompressed freely between them.
 
 ## Concurrency
 

--- a/tools/telegram-importer/README.md
+++ b/tools/telegram-importer/README.md
@@ -102,7 +102,7 @@ uv run alexandria-telegram-import --upload-only --staging-dir ./work
 uv run alexandria-telegram-import --stage 20 --staging-dir ./work
 ```
 
-All three require `--staging-dir`, and `--staging-dir` requires one of them. `TELEGRAM_STAGING_DIR` sets the default directory. `--stage` prints a summary and waits for Enter; `q` then Enter quits and leaves the folders for a later `--upload-only`. A non-interactive standard input is treated as quitting rather than hanging.
+All three require `--staging-dir`, and `--staging-dir` requires one of them. `TELEGRAM_STAGING_DIR` sets the default directory. `--concurrency` applies to both phases: N bundles stage at once, and N folders upload at once. `--upload-only` is entirely local — it needs no Telegram credentials and opens no Telegram session — and combining it with `--dry-run` prints what would be uploaded without contacting Alexandria. `--stage` prints a summary and waits for Enter; `q` then Enter quits and leaves the folders for a later `--upload-only`. A non-interactive standard input is treated as quitting rather than hanging.
 
 ### Folder layout
 
@@ -161,6 +161,10 @@ Its top level mirrors Alexandria's commit `batchMetadata` field for field, so it
 
 `source` records where the bundle came from; the upload phase ignores it, and it survives renaming and splitting. `result` is filled on disposal. `description` is composed from the bundle's captions and source link, so it is edited rather than written from scratch. A folder with no `metadata.json` still uploads, taking its name from its folder name.
 
+Because you edit this file by hand, a JSON syntax error is treated as an error rather than as "no metadata": a **model folder** whose own `metadata.json` will not parse moves to `failed/` without uploading, and the unreadable file is never rewritten — its result is written to a sibling `result.json` instead, so your hand-typed values survive. Fix the typo and re-run. A **container's** unparseable file is still skipped leniently, since a container commits nothing.
+
+Values merge from the staging root downward, so `<staging-dir>/metadata.json` and `<staging-dir>/images/` supply defaults to every folder in the directory — the natural place for channel-wide artist, tags, or collection.
+
 Values merge from the outermost container down to the model folder:
 
 | Field | Rule |
@@ -169,6 +173,8 @@ Values merge from the outermost container down to the model folder:
 | `tags` | Merged across every level, de-duplicated |
 | `metadata`, `options` | Merged key by key, nearest wins per key |
 | `modelName` | **Never inherits** — from the folder's own file, or its folder name |
+
+A child cannot clear an inherited value by setting it to `null`; omit the field or set a replacement.
 
 `modelName` is excluded deliberately: inheriting it would commit all eight models of a release as "Dragon Set". Everything else inheriting means the collection, artist, and tags are set once at the release root.
 
@@ -189,7 +195,7 @@ work/
     002502-broken/         <- result.error written into its metadata.json
 ```
 
-Paths relative to the staging root are preserved, each ancestor container's `metadata.json` is copied alongside, and a container left with no model folders is removed. The staging root therefore always shows exactly what is left to do. Delete `uploaded/` once the results have been checked.
+Paths relative to the staging root are preserved, each ancestor container's `metadata.json` is copied alongside, and a container is removed once it holds nothing but its own `metadata.json`. A container still holding an unsplit archive, a half-organized subfolder, or shared images is left alone — that is work in progress, not leftovers. The staging root therefore always shows exactly what is left to do. Delete `uploaded/` once the results have been checked.
 
 ### State and duplicates
 

--- a/tools/telegram-importer/src/alexandria_telegram_importer/alexandria.py
+++ b/tools/telegram-importer/src/alexandria_telegram_importer/alexandria.py
@@ -263,17 +263,17 @@ class AlexandriaClient:
         session_id: str,
         *,
         model_name: str,
-        description: str,
+        description: str | None = None,
+        batch_metadata: dict[str, Any] | None = None,
     ) -> str:
+        payload: dict[str, Any] = dict(batch_metadata or {})
+        payload["modelName"] = model_name[:255]
+        if description is not None:
+            payload["description"] = description[:2000]
         response = await self._request(
             "POST",
             f"/models/import-sessions/{session_id}/commit",
-            json={
-                "batchMetadata": {
-                    "modelName": model_name[:255],
-                    "description": description[:2000],
-                },
-            },
+            json={"batchMetadata": payload},
         )
         return self._data(response)["modelId"]
 

--- a/tools/telegram-importer/src/alexandria_telegram_importer/cli.py
+++ b/tools/telegram-importer/src/alexandria_telegram_importer/cli.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from dotenv import load_dotenv
 
 from .alexandria import AlexandriaClient
-from .folder_upload import FolderUploader
+from .folder_upload import FolderUploader, describe_staging
 from .grouping import build_bundles
 from .importer import ChannelImporter, describe_plan
 from .models import MediaRef
@@ -220,28 +220,46 @@ async def stage_bundles(
     staging_dir: Path,
     limit: int,
     progress: ProgressReporter,
-) -> tuple[int, int]:
-    """Stage up to `limit` not-yet-staged bundles. Returns (staged, failed)."""
+    concurrency: int = 1,
+) -> tuple[int, int, int]:
+    """Stage up to `limit` not-yet-staged bundles.
+
+    Returns (staged, failed, bytes). `concurrency` bundles are staged at once,
+    matching what the direct import path does across models.
+    """
     already = tracker.staged_keys(telegram.channel_id)
     stager = BundleStager(telegram=telegram, root=staging_dir)
+    pending = []
+    for bundle in build_bundles(telegram.channel_id, refs):
+        if len(pending) >= limit:
+            break
+        key = bundle_key(telegram.channel_id, bundle)
+        if key not in already:
+            pending.append((key, bundle))
+
     staged = 0
     failed = 0
-    with guarded_reporter(progress):
-        for bundle in build_bundles(telegram.channel_id, refs):
-            if staged >= limit:
-                break
-            key = bundle_key(telegram.channel_id, bundle)
-            if key in already:
-                continue
-            label = bundle.models[0].logical_filename
+    staged_bytes = 0
+    slots = asyncio.Semaphore(concurrency)
+    lock = asyncio.Lock()
+
+    async def stage_one(key: str, bundle) -> None:
+        nonlocal staged, failed, staged_bytes
+        label = bundle.models[0].logical_filename
+        async with slots:
             try:
                 with guarded_model(progress, label, parts=1) as handle:
                     folder = await stager.stage(bundle, handle)
             # One unreachable Telegram post must not stop the rest of the run.
             except Exception as error:  # noqa: BLE001
                 log.error("Failed to stage bundle at %s: %s", label, error)
-                failed += 1
-                continue
+                async with lock:
+                    failed += 1
+                return
+            size = sum(
+                path.stat().st_size for path in folder.rglob("*") if path.is_file()
+            )
+        async with lock:
             tracker.record_staged(
                 bundle_key=key,
                 source_channel_id=telegram.channel_id,
@@ -251,15 +269,34 @@ async def stage_bundles(
                 ),
             )
             staged += 1
-            progress.totals(staged, limit, {"staged": staged, "failed": failed})
-    return staged, failed
+            staged_bytes += size
+            _report_staging(progress, staged, len(pending), failed)
+
+    with guarded_reporter(progress):
+        _report_staging(progress, 0, len(pending), 0)
+        results = await asyncio.gather(
+            *(stage_one(key, bundle) for key, bundle in pending),
+            return_exceptions=True,
+        )
+    for result in results:
+        if isinstance(result, BaseException):
+            raise result
+    return staged, failed, staged_bytes
 
 
-def _staging_summary(staging_dir: Path, staged: int, failed: int) -> str:
-    total_bytes = sum(
-        path.stat().st_size for path in staging_dir.rglob("*") if path.is_file()
-    )
-    line = f"{staged} folders staged in {staging_dir} ({format_bytes(total_bytes)})."
+def _report_staging(
+    progress: ProgressReporter, staged: int, total: int, failed: int
+) -> None:
+    try:
+        progress.totals(staged, total, {"staged": staged, "failed": failed})
+    except Exception as error:  # noqa: BLE001 - a display fault is not a staging fault
+        log.debug("Progress reporter could not record totals: %s", error)
+
+
+def _staging_summary(
+    staging_dir: Path, staged: int, failed: int, staged_bytes: int
+) -> str:
+    line = f"{staged} folders staged in {staging_dir} ({format_bytes(staged_bytes)})."
     return line + (f" {failed} bundle(s) failed to stage." if failed else "")
 
 
@@ -285,6 +322,38 @@ async def _login(args: argparse.Namespace) -> AlexandriaClient:
 
 
 async def run(args: argparse.Namespace) -> int:
+    alexandria: AlexandriaClient | None = None
+    tracker: ImportTracker | None = None
+    progress = reporter_from_args(
+        no_progress=args.no_progress,
+        dry_run=args.dry_run,
+        verbose=args.verbose,
+    )
+    work_root = args.state.parent / f"{args.state.name}.work"
+
+    # Uploading staged folders touches nothing but the staging directory and
+    # Alexandria. It must not need Telegram credentials, open a Telegram
+    # session file, or scan the channel — so it returns before any of that.
+    if args.upload_only:
+        if not args.staging_dir.is_dir():
+            raise SystemExit(f"Staging directory {args.staging_dir} does not exist")
+        if args.dry_run:
+            print(describe_staging(args.staging_dir))
+            return 0
+        try:
+            alexandria = await _login(args)
+            outcomes = await FolderUploader(
+                alexandria=alexandria,
+                work_root=work_root,
+                concurrency=args.concurrency,
+                progress=progress,
+            ).run(args.staging_dir)
+            print(_upload_summary(outcomes))
+            return 1 if outcomes.get("failed") else 0
+        finally:
+            if alexandria:
+                await alexandria.close()
+
     api_id_text = os.getenv("TELEGRAM_API_ID") or os.getenv("API_ID")
     api_hash = os.getenv("TELEGRAM_API_HASH") or os.getenv("API_HASH")
     if not api_id_text or not api_hash:
@@ -301,33 +370,6 @@ async def run(args: argparse.Namespace) -> int:
         phone=os.getenv("TELEGRAM_PHONE") or os.getenv("PHONE") or None,
         download_connections=args.download_connections,
     )
-    alexandria: AlexandriaClient | None = None
-    tracker: ImportTracker | None = None
-    progress = reporter_from_args(
-        no_progress=args.no_progress,
-        dry_run=args.dry_run,
-        verbose=args.verbose,
-    )
-    work_root = args.state.parent / f"{args.state.name}.work"
-
-    # Uploading staged folders is entirely local. Connecting to Telegram and
-    # scanning the channel first would be wasted work on a large channel, and
-    # would make a local-only operation depend on a Telegram session.
-    if args.upload_only:
-        try:
-            alexandria = await _login(args)
-            outcomes = await FolderUploader(
-                alexandria=alexandria,
-                work_root=work_root,
-                concurrency=args.concurrency,
-                progress=progress,
-            ).run(args.staging_dir)
-            print(_upload_summary(outcomes))
-            return 1 if outcomes.get("failed") else 0
-        finally:
-            if alexandria:
-                await alexandria.close()
-            await telegram.close()
 
     try:
         await telegram.connect(_channel(args.channel))
@@ -340,15 +382,18 @@ async def run(args: argparse.Namespace) -> int:
 
         if args.download_only is not None or args.stage is not None:
             tracker = ImportTracker(args.state)
-            staged, failed_to_stage = await stage_bundles(
+            staged, failed_to_stage, staged_bytes = await stage_bundles(
                 telegram=telegram,
                 tracker=tracker,
                 refs=refs,
                 staging_dir=args.staging_dir,
                 limit=args.download_only or args.stage,
                 progress=progress,
+                concurrency=args.concurrency,
             )
-            summary = _staging_summary(args.staging_dir, staged, failed_to_stage)
+            summary = _staging_summary(
+                args.staging_dir, staged, failed_to_stage, staged_bytes
+            )
             if args.download_only is not None:
                 print(summary)
                 return 1 if failed_to_stage else 0

--- a/tools/telegram-importer/src/alexandria_telegram_importer/cli.py
+++ b/tools/telegram-importer/src/alexandria_telegram_importer/cli.py
@@ -11,11 +11,23 @@ from pathlib import Path
 from dotenv import load_dotenv
 
 from .alexandria import AlexandriaClient
+from .folder_upload import FolderUploader
+from .grouping import build_bundles
 from .importer import ChannelImporter, describe_plan
+from .models import MediaRef
 from .parallel_download import DEFAULT_CONNECTIONS, MAX_CONNECTIONS
-from .progress import reporter_from_args
+from .progress import (
+    ProgressReporter,
+    format_bytes,
+    guarded_model,
+    guarded_reporter,
+    reporter_from_args,
+)
+from .staging import BundleStager, bundle_key
 from .telegram_source import TelegramSource
 from .tracker import ImportTracker
+
+log = logging.getLogger(__name__)
 
 
 def _data_dir() -> Path:
@@ -200,6 +212,72 @@ def confirm_upload(summary: str) -> bool:
     return line.strip().lower() != "q"
 
 
+async def stage_bundles(
+    *,
+    telegram: TelegramSource,
+    tracker: ImportTracker,
+    refs: list[MediaRef],
+    staging_dir: Path,
+    limit: int,
+    progress: ProgressReporter,
+) -> tuple[int, int]:
+    """Stage up to `limit` not-yet-staged bundles. Returns (staged, failed)."""
+    already = tracker.staged_keys(telegram.channel_id)
+    stager = BundleStager(telegram=telegram, root=staging_dir)
+    staged = 0
+    failed = 0
+    with guarded_reporter(progress):
+        for bundle in build_bundles(telegram.channel_id, refs):
+            if staged >= limit:
+                break
+            key = bundle_key(telegram.channel_id, bundle)
+            if key in already:
+                continue
+            label = bundle.models[0].logical_filename
+            try:
+                with guarded_model(progress, label, parts=1) as handle:
+                    folder = await stager.stage(bundle, handle)
+            # One unreachable Telegram post must not stop the rest of the run.
+            except Exception as error:  # noqa: BLE001
+                log.error("Failed to stage bundle at %s: %s", label, error)
+                failed += 1
+                continue
+            tracker.record_staged(
+                bundle_key=key,
+                source_channel_id=telegram.channel_id,
+                folder_name=folder.name,
+                model_message_ids=tuple(
+                    part.message_id for unit in bundle.models for part in unit.parts
+                ),
+            )
+            staged += 1
+            progress.totals(staged, limit, {"staged": staged, "failed": failed})
+    return staged, failed
+
+
+def _staging_summary(staging_dir: Path, staged: int, failed: int) -> str:
+    total_bytes = sum(
+        path.stat().st_size for path in staging_dir.rglob("*") if path.is_file()
+    )
+    line = f"{staged} folders staged in {staging_dir} ({format_bytes(total_bytes)})."
+    return line + (f" {failed} bundle(s) failed to stage." if failed else "")
+
+
+async def _login(args: argparse.Namespace) -> AlexandriaClient:
+    email = os.getenv("ALEXANDRIA_EMAIL") or input("Alexandria email: ").strip()
+    password = os.getenv("ALEXANDRIA_PASSWORD") or getpass.getpass(
+        "Alexandria password: "
+    )
+    client = AlexandriaClient(
+        args.alexandria_url,
+        library_id=args.library_id,
+        poll_interval=args.poll_interval,
+        allow_insecure_http=args.allow_insecure_http,
+    )
+    await client.login(email, password)
+    return client
+
+
 async def run(args: argparse.Namespace) -> int:
     api_id_text = os.getenv("TELEGRAM_API_ID") or os.getenv("API_ID")
     api_hash = os.getenv("TELEGRAM_API_HASH") or os.getenv("API_HASH")
@@ -226,29 +304,56 @@ async def run(args: argparse.Namespace) -> int:
             print(describe_plan(telegram.channel_id, refs))
             return 0
 
-        email = os.getenv("ALEXANDRIA_EMAIL") or input("Alexandria email: ").strip()
-        password = os.getenv("ALEXANDRIA_PASSWORD") or getpass.getpass(
-            "Alexandria password: "
+        progress = reporter_from_args(
+            no_progress=args.no_progress,
+            dry_run=args.dry_run,
+            verbose=args.verbose,
         )
-        alexandria = AlexandriaClient(
-            args.alexandria_url,
-            library_id=args.library_id,
-            poll_interval=args.poll_interval,
-            allow_insecure_http=args.allow_insecure_http,
-        )
-        await alexandria.login(email, password)
-        tracker = ImportTracker(args.state)
+        work_root = args.state.parent / f"{args.state.name}.work"
+        failed_to_stage = 0
+
+        if args.download_only is not None or args.stage is not None:
+            tracker = ImportTracker(args.state)
+            staged, failed_to_stage = await stage_bundles(
+                telegram=telegram,
+                tracker=tracker,
+                refs=refs,
+                staging_dir=args.staging_dir,
+                limit=args.download_only or args.stage,
+                progress=progress,
+            )
+            summary = _staging_summary(args.staging_dir, staged, failed_to_stage)
+            if args.download_only is not None:
+                print(summary)
+                return 1 if failed_to_stage else 0
+            if not confirm_upload(summary):
+                return 1 if failed_to_stage else 0
+
+        if args.upload_only or args.stage is not None:
+            alexandria = await _login(args)
+            outcomes = await FolderUploader(
+                alexandria=alexandria,
+                work_root=work_root,
+                concurrency=args.concurrency,
+                progress=progress,
+            ).run(args.staging_dir)
+            print(
+                "Upload state: "
+                + ", ".join(
+                    f"{status}={count}" for status, count in sorted(outcomes.items())
+                ),
+            )
+            return 1 if outcomes.get("failed") or failed_to_stage else 0
+
+        alexandria = await _login(args)
+        tracker = tracker or ImportTracker(args.state)
         counts = await ChannelImporter(
             telegram=telegram,
             alexandria=alexandria,
             tracker=tracker,
-            work_root=args.state.parent / f"{args.state.name}.work",
+            work_root=work_root,
             concurrency=args.concurrency,
-            progress=reporter_from_args(
-                no_progress=args.no_progress,
-                dry_run=args.dry_run,
-                verbose=args.verbose,
-            ),
+            progress=progress,
         ).run(refs)
         print(
             "Import state: "
@@ -268,6 +373,7 @@ async def run(args: argparse.Namespace) -> int:
 def main() -> None:
     load_dotenv()
     args = parser().parse_args()
+    validate_staging_args(args)
     logging.basicConfig(
         level=logging.DEBUG if args.verbose else logging.INFO,
         format="%(asctime)s %(levelname)s %(message)s",

--- a/tools/telegram-importer/src/alexandria_telegram_importer/cli.py
+++ b/tools/telegram-importer/src/alexandria_telegram_importer/cli.py
@@ -5,6 +5,7 @@ import asyncio
 import getpass
 import logging
 import os
+import sys
 from pathlib import Path
 
 from dotenv import load_dotenv
@@ -32,6 +33,18 @@ def _concurrency(value: str) -> int:
         ) from error
     if parsed < 1:
         raise argparse.ArgumentTypeError("concurrency must be at least 1")
+    return parsed
+
+
+def _positive(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError(
+            f"count must be an integer, got {value!r}"
+        ) from error
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("count must be at least 1")
     return parsed
 
 
@@ -123,7 +136,68 @@ def parser() -> argparse.ArgumentParser:
         help=("Disable the progress display entirely and log as earlier versions did"),
     )
     result.add_argument("--verbose", action="store_true")
+    result.add_argument(
+        "--staging-dir",
+        type=Path,
+        default=(
+            Path(staging) if (staging := os.getenv("TELEGRAM_STAGING_DIR")) else None
+        ),
+        help=(
+            "Directory holding staged model folders. Required by --download-only, "
+            "--upload-only, and --stage"
+        ),
+    )
+    staging_mode = result.add_mutually_exclusive_group()
+    staging_mode.add_argument(
+        "--download-only",
+        type=_positive,
+        metavar="N",
+        help="Stage up to N new Telegram bundles as folders, then exit",
+    )
+    staging_mode.add_argument(
+        "--upload-only",
+        action="store_true",
+        help="Upload every model folder already in --staging-dir, then exit",
+    )
+    staging_mode.add_argument(
+        "--stage",
+        type=_positive,
+        metavar="N",
+        help=(
+            "Stage up to N new bundles, pause for reorganization, then upload "
+            "whatever is in --staging-dir"
+        ),
+    )
     return result
+
+
+def validate_staging_args(args: argparse.Namespace) -> None:
+    selected = (
+        args.download_only is not None or args.upload_only or args.stage is not None
+    )
+    if selected and args.staging_dir is None:
+        raise SystemExit(
+            "--staging-dir is required by --download-only, --upload-only, and --stage"
+        )
+    if args.staging_dir is not None and not selected:
+        raise SystemExit(
+            "--staging-dir requires one of --download-only, --upload-only, or --stage"
+        )
+
+
+def confirm_upload(summary: str) -> bool:
+    """Pause between the phases. A non-interactive stdin quits rather than hangs."""
+    print(summary)
+    print(
+        "Reorganize the folders now — split releases, compress, rename, "
+        "edit metadata.json."
+    )
+    print("Press Enter to upload, or q then Enter to quit without uploading.")
+    line = sys.stdin.readline()
+    if not line:
+        print("No input available; leaving the staged folders in place.")
+        return False
+    return line.strip().lower() != "q"
 
 
 async def run(args: argparse.Namespace) -> int:

--- a/tools/telegram-importer/src/alexandria_telegram_importer/cli.py
+++ b/tools/telegram-importer/src/alexandria_telegram_importer/cli.py
@@ -263,6 +263,12 @@ def _staging_summary(staging_dir: Path, staged: int, failed: int) -> str:
     return line + (f" {failed} bundle(s) failed to stage." if failed else "")
 
 
+def _upload_summary(outcomes: dict[str, int]) -> str:
+    return "Upload state: " + ", ".join(
+        f"{status}={count}" for status, count in sorted(outcomes.items())
+    )
+
+
 async def _login(args: argparse.Namespace) -> AlexandriaClient:
     email = os.getenv("ALEXANDRIA_EMAIL") or input("Alexandria email: ").strip()
     password = os.getenv("ALEXANDRIA_PASSWORD") or getpass.getpass(
@@ -297,6 +303,32 @@ async def run(args: argparse.Namespace) -> int:
     )
     alexandria: AlexandriaClient | None = None
     tracker: ImportTracker | None = None
+    progress = reporter_from_args(
+        no_progress=args.no_progress,
+        dry_run=args.dry_run,
+        verbose=args.verbose,
+    )
+    work_root = args.state.parent / f"{args.state.name}.work"
+
+    # Uploading staged folders is entirely local. Connecting to Telegram and
+    # scanning the channel first would be wasted work on a large channel, and
+    # would make a local-only operation depend on a Telegram session.
+    if args.upload_only:
+        try:
+            alexandria = await _login(args)
+            outcomes = await FolderUploader(
+                alexandria=alexandria,
+                work_root=work_root,
+                concurrency=args.concurrency,
+                progress=progress,
+            ).run(args.staging_dir)
+            print(_upload_summary(outcomes))
+            return 1 if outcomes.get("failed") else 0
+        finally:
+            if alexandria:
+                await alexandria.close()
+            await telegram.close()
+
     try:
         await telegram.connect(_channel(args.channel))
         refs = await telegram.collect_media(min_message_id=args.from_message_id)
@@ -304,12 +336,6 @@ async def run(args: argparse.Namespace) -> int:
             print(describe_plan(telegram.channel_id, refs))
             return 0
 
-        progress = reporter_from_args(
-            no_progress=args.no_progress,
-            dry_run=args.dry_run,
-            verbose=args.verbose,
-        )
-        work_root = args.state.parent / f"{args.state.name}.work"
         failed_to_stage = 0
 
         if args.download_only is not None or args.stage is not None:
@@ -329,7 +355,7 @@ async def run(args: argparse.Namespace) -> int:
             if not confirm_upload(summary):
                 return 1 if failed_to_stage else 0
 
-        if args.upload_only or args.stage is not None:
+        if args.stage is not None:
             alexandria = await _login(args)
             outcomes = await FolderUploader(
                 alexandria=alexandria,
@@ -337,12 +363,7 @@ async def run(args: argparse.Namespace) -> int:
                 concurrency=args.concurrency,
                 progress=progress,
             ).run(args.staging_dir)
-            print(
-                "Upload state: "
-                + ", ".join(
-                    f"{status}={count}" for status, count in sorted(outcomes.items())
-                ),
-            )
+            print(_upload_summary(outcomes))
             return 1 if outcomes.get("failed") or failed_to_stage else 0
 
         alexandria = await _login(args)

--- a/tools/telegram-importer/src/alexandria_telegram_importer/folder_metadata.py
+++ b/tools/telegram-importer/src/alexandria_telegram_importer/folder_metadata.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import json
+import logging
+import re
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+SCHEMA_VERSION = 1
+METADATA_FILENAME = "metadata.json"
+
+# Fields the commit endpoint accepts. Kept in sync with
+# packages/shared/src/validation/upload.ts batchUploadMetadataSchema.
+COMMIT_FIELDS = (
+    "modelName",
+    "description",
+    "collectionId",
+    "newCollectionName",
+    "artist",
+    "tags",
+    "metadata",
+    "options",
+)
+_INHERITED_SCALARS = ("description", "collectionId", "newCollectionName", "artist")
+_INHERITED_MAPPINGS = ("metadata", "options")
+
+_FOLDER_PREFIX_RE = re.compile(r"^\d{4,}-")
+
+
+def read_metadata(folder: Path) -> dict[str, Any] | None:
+    """Read one folder's metadata.json, or None when it is absent or unusable."""
+    path = folder / METADATA_FILENAME
+    if not path.is_file():
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as error:
+        log.warning("Ignoring unreadable %s: %s", path, error)
+        return None
+    if not isinstance(payload, dict):
+        log.warning("Ignoring %s: expected a JSON object", path)
+        return None
+    return payload
+
+
+def write_metadata(folder: Path, payload: dict[str, Any]) -> None:
+    folder.mkdir(parents=True, exist_ok=True)
+    document = {"schemaVersion": SCHEMA_VERSION, **payload}
+    (folder / METADATA_FILENAME).write_text(
+        json.dumps(document, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+
+def merge_chain(chain: Sequence[dict[str, Any]]) -> dict[str, Any]:
+    """Merge metadata from outermost container to model folder.
+
+    modelName deliberately does not inherit: a release-level name would
+    otherwise commit every model in the release under one title.
+    """
+    merged: dict[str, Any] = {}
+    tags: list[str] = []
+    for level, payload in enumerate(chain):
+        for key in _INHERITED_SCALARS:
+            if payload.get(key) is not None:
+                merged[key] = payload[key]
+        for key in _INHERITED_MAPPINGS:
+            value = payload.get(key)
+            if isinstance(value, dict):
+                merged.setdefault(key, {}).update(value)
+        for tag in payload.get("tags") or []:
+            if tag not in tags:
+                tags.append(tag)
+        if level == len(chain) - 1 and payload.get("modelName"):
+            merged["modelName"] = payload["modelName"]
+    if tags:
+        merged["tags"] = tags
+    return merged
+
+
+def batch_metadata(effective: dict[str, Any]) -> dict[str, Any]:
+    """Reduce merged metadata to the fields the commit endpoint accepts."""
+    return {key: effective[key] for key in COMMIT_FIELDS if effective.get(key) is not None}
+
+
+def model_name_from_folder(name: str) -> str:
+    stripped = _FOLDER_PREFIX_RE.sub("", name)
+    cleaned = stripped.replace("_", " ").replace("-", " ").strip()
+    return cleaned or name

--- a/tools/telegram-importer/src/alexandria_telegram_importer/folder_metadata.py
+++ b/tools/telegram-importer/src/alexandria_telegram_importer/folder_metadata.py
@@ -30,20 +30,37 @@ _INHERITED_MAPPINGS = ("metadata", "options")
 _FOLDER_PREFIX_RE = re.compile(r"^\d{4,}-")
 
 
-def read_metadata(folder: Path) -> dict[str, Any] | None:
-    """Read one folder's metadata.json, or None when it is absent or unusable."""
+def _load(folder: Path) -> tuple[dict[str, Any] | None, str | None]:
+    """Return (payload, error).
+
+    `error` is set only when the file exists but cannot be used, which is
+    distinct from it being absent. Callers that are about to overwrite or
+    commit on the strength of this file need to tell those two apart: a
+    typo in a hand-edited file must never be treated as "no metadata".
+    """
     path = folder / METADATA_FILENAME
     if not path.is_file():
-        return None
+        return None, None
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, ValueError) as error:
-        log.warning("Ignoring unreadable %s: %s", path, error)
-        return None
+        return None, f"{METADATA_FILENAME} could not be read: {error}"
     if not isinstance(payload, dict):
-        log.warning("Ignoring %s: expected a JSON object", path)
-        return None
+        return None, f"{METADATA_FILENAME} must contain a JSON object"
+    return payload, None
+
+
+def read_metadata(folder: Path) -> dict[str, Any] | None:
+    """Read one folder's metadata.json, or None when it is absent or unusable."""
+    payload, error = _load(folder)
+    if error:
+        log.warning("Ignoring %s: %s", folder / METADATA_FILENAME, error)
     return payload
+
+
+def metadata_error(folder: Path) -> str | None:
+    """A message when this folder's metadata.json exists but is unusable."""
+    return _load(folder)[1]
 
 
 def write_metadata(folder: Path, payload: dict[str, Any]) -> None:

--- a/tools/telegram-importer/src/alexandria_telegram_importer/folder_metadata.py
+++ b/tools/telegram-importer/src/alexandria_telegram_importer/folder_metadata.py
@@ -27,7 +27,9 @@ COMMIT_FIELDS = (
 _INHERITED_SCALARS = ("description", "collectionId", "newCollectionName", "artist")
 _INHERITED_MAPPINGS = ("metadata", "options")
 
-_FOLDER_PREFIX_RE = re.compile(r"^\d{4,}-")
+# Matches only the six-digit prefix bundle_folder_name writes, so a real
+# name like "2001-a-space-odyssey" keeps its leading number.
+_FOLDER_PREFIX_RE = re.compile(r"^\d{6}-")
 
 
 def _load(folder: Path) -> tuple[dict[str, Any] | None, str | None]:

--- a/tools/telegram-importer/src/alexandria_telegram_importer/folder_upload.py
+++ b/tools/telegram-importer/src/alexandria_telegram_importer/folder_upload.py
@@ -1,14 +1,20 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 import shutil
+import tempfile
 import zipfile
+from collections import Counter
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from .alexandria import session_filenames
 from .folder_metadata import (
     METADATA_FILENAME,
+    batch_metadata,
     merge_chain,
     model_name_from_folder,
     read_metadata,
@@ -22,6 +28,14 @@ from .grouping import (
     validate_logical_model,
 )
 from .models import MediaKind, MediaRef
+from .progress import (
+    ModelProgress,
+    NullModelProgress,
+    NullProgress,
+    ProgressReporter,
+    guarded_model,
+    guarded_reporter,
+)
 from .staging import unique_child
 
 log = logging.getLogger(__name__)
@@ -97,13 +111,11 @@ def _visit(
         for child in subdirectories:
             _visit(child, chain, image_dirs, nested, nested_ambiguous)
         if nested or nested_ambiguous:
-            ambiguous.append(
-                (
-                    directory,
-                    f"holds its own {MODELS_DIRNAME}/ and model folders beneath it; "
-                    f"finish the split by emptying {MODELS_DIRNAME}/",
-                ),
+            reason = (
+                f"holds its own {MODELS_DIRNAME}/ and model folders beneath it; "
+                f"finish the split by emptying {MODELS_DIRNAME}/"
             )
+            ambiguous.append((directory, reason))
             return
         found.append(
             ModelFolder(path=directory, chain=chain, container_image_dirs=image_dirs),
@@ -241,3 +253,191 @@ def _prune_empty_containers(directory: Path, root: Path) -> None:
             return
         shutil.rmtree(directory, ignore_errors=True)
         directory = directory.parent
+
+
+ATTACHMENT_BATCH_SIZE = 100
+
+
+def _uploaded_at() -> dict[str, str]:
+    return {"uploadedAt": datetime.now(UTC).isoformat()}
+
+
+def _failed_at() -> dict[str, str]:
+    return {"failedAt": datetime.now(UTC).isoformat()}
+
+
+class FolderUploader:
+    """Uploads hand-curated folders.
+
+    Performs no deduplication by design: the folders are the operator's, and
+    the phases share no state so that folders can be split, merged, renamed,
+    and recompressed freely between them.
+    """
+
+    def __init__(
+        self,
+        *,
+        alexandria: Any,
+        work_root: Path,
+        concurrency: int = 1,
+        progress: ProgressReporter | None = None,
+    ) -> None:
+        if concurrency < 1:
+            raise ValueError("Upload concurrency must be at least 1")
+        self.alexandria = alexandria
+        self.work_root = work_root
+        self.concurrency = concurrency
+        self.progress: ProgressReporter = progress or NullProgress()
+
+    def image_paths(self, folder: ModelFolder) -> tuple[Path, ...]:
+        """Every image to append, with the model's own file winning a name clash."""
+        by_name: dict[str, Path] = {}
+        for directory in folder.image_dirs:
+            for path in sorted(directory.iterdir()):
+                if path.is_file():
+                    by_name[path.name] = path
+        return tuple(by_name.values())
+
+    async def run(self, root: Path) -> dict[str, int]:
+        found, ambiguous = discover(root)
+        outcomes: Counter[str] = Counter()
+        settled = 0
+        total = len(found) + len(ambiguous)
+
+        for path, reason in ambiguous:
+            log.error("Skipping ambiguous folder %s: %s", path, reason)
+            dispose(path, root, FAILED_DIRNAME, {"error": reason, **_failed_at()})
+            outcomes["failed"] += 1
+            settled += 1
+
+        self.work_root.mkdir(parents=True, exist_ok=True)
+        slots = asyncio.Semaphore(self.concurrency)
+        lock = asyncio.Lock()
+
+        async def settle(folder: ModelFolder) -> None:
+            nonlocal settled
+            async with slots:
+                outcome = await self._upload_and_dispose(folder, root)
+            async with lock:
+                outcomes[outcome] += 1
+                settled += 1
+                self._report(settled, total, outcomes)
+
+        with guarded_reporter(self.progress):
+            self._report(settled, total, outcomes)
+            results = await asyncio.gather(
+                *(settle(folder) for folder in found),
+                return_exceptions=True,
+            )
+        for result in results:
+            if isinstance(result, BaseException):
+                raise result
+        return dict(outcomes)
+
+    def _report(self, done: int, total: int, outcomes: Counter[str]) -> None:
+        try:
+            self.progress.totals(done, total, dict(outcomes))
+        except Exception as error:  # noqa: BLE001 - a display fault is not an upload fault
+            log.debug("Progress reporter could not record totals: %s", error)
+
+    async def _upload_and_dispose(self, folder: ModelFolder, root: Path) -> str:
+        log.info("Uploading %s", folder.path.name)
+        try:
+            with guarded_model(self.progress, folder.path.name, parts=1) as handle:
+                model_id = await self.upload(folder, handle)
+        # One bad folder must not stop the rest of the staging directory.
+        except Exception as error:  # noqa: BLE001
+            log.error("Failed to upload %s: %s", folder.path.name, error)
+            dispose(
+                folder.path, root, FAILED_DIRNAME, {"error": str(error), **_failed_at()}
+            )
+            return "failed"
+        dispose(
+            folder.path, root, UPLOADED_DIRNAME, {"modelId": model_id, **_uploaded_at()}
+        )
+        log.info("Uploaded %s as Alexandria model %s", folder.path.name, model_id)
+        return "completed"
+
+    async def upload(
+        self, folder: ModelFolder, handle: ModelProgress | None = None
+    ) -> str:
+        handle = handle or NullModelProgress()
+        effective = folder.metadata
+        payload = batch_metadata(effective)
+        payload["modelName"] = folder.model_name
+
+        # upload() is public and callable without run(), so it owns creating
+        # the work root rather than relying on the caller having done so.
+        self.work_root.mkdir(parents=True, exist_ok=True)
+        with tempfile.TemporaryDirectory(
+            prefix="alexandria-folder-", dir=self.work_root
+        ) as temp:
+            plan = plan_models_dir(folder.models_dir)
+            if plan.kind == "zip":
+                handle.phase("packaging")
+            paths, multipart = build_upload_paths(
+                plan, Path(temp), payload["modelName"]
+            )
+
+            upload_ids: list[str] = []
+            try:
+                for path in paths:
+                    with handle.transfer("upload", path.name) as transfer:
+                        upload_ids.append(
+                            await self.alexandria.upload_file(
+                                path,
+                                path.name,
+                                multipart=multipart,
+                                on_progress=transfer.advance,
+                            ),
+                        )
+                session_id = await self.alexandria.complete_upload(
+                    upload_ids, multipart=multipart
+                )
+            except Exception:
+                await self.alexandria.abort_uploads(upload_ids)
+                raise
+
+            handle.phase("scanning")
+            session = await self.alexandria.wait_for_session(
+                session_id, {"ready_for_review"}
+            )
+            if session["status"] == "error":
+                raise RuntimeError(session.get("error") or "Alexandria ingestion failed")
+
+            await self._append_images(folder, session_id, session, handle)
+
+            handle.phase("committing")
+            await self.alexandria.commit(
+                session_id,
+                model_name=payload.pop("modelName"),
+                description=effective.get("description"),
+                batch_metadata=payload,
+            )
+            committed = await self.alexandria.wait_for_session(session_id, {"committed"})
+            if committed["status"] == "error":
+                raise RuntimeError(committed.get("error") or "Alexandria commit failed")
+            return committed["modelId"]
+
+    async def _append_images(
+        self,
+        folder: ModelFolder,
+        session_id: str,
+        session: dict[str, Any],
+        handle: ModelProgress,
+    ) -> None:
+        present = session_filenames(session)
+        pending = tuple(
+            path for path in self.image_paths(folder) if path.name not in present
+        )
+        if not pending:
+            return
+        handle.phase("attachments")
+        done = 0
+        handle.attachments(done, len(pending))
+        for offset in range(0, len(pending), ATTACHMENT_BATCH_SIZE):
+            batch = pending[offset : offset + ATTACHMENT_BATCH_SIZE]
+            for path in batch:
+                await self.alexandria.append_files(session_id, (path,), (path.name,))
+                done += 1
+                handle.attachments(done, len(pending))

--- a/tools/telegram-importer/src/alexandria_telegram_importer/folder_upload.py
+++ b/tools/telegram-importer/src/alexandria_telegram_importer/folder_upload.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .folder_metadata import merge_chain, model_name_from_folder, read_metadata
+
+log = logging.getLogger(__name__)
+
+MODELS_DIRNAME = "models"
+IMAGES_DIRNAME = "images"
+UPLOADED_DIRNAME = "uploaded"
+FAILED_DIRNAME = "failed"
+RESERVED_DIRNAMES = frozenset({UPLOADED_DIRNAME, FAILED_DIRNAME})
+
+
+@dataclass(frozen=True, slots=True)
+class ModelFolder:
+    path: Path
+    chain: tuple[dict[str, Any], ...]
+    container_image_dirs: tuple[Path, ...]
+
+    @property
+    def metadata(self) -> dict[str, Any]:
+        return merge_chain(self.chain)
+
+    @property
+    def model_name(self) -> str:
+        return self.metadata.get("modelName") or model_name_from_folder(self.path.name)
+
+    @property
+    def models_dir(self) -> Path:
+        return self.path / MODELS_DIRNAME
+
+    @property
+    def image_dirs(self) -> tuple[Path, ...]:
+        own = self.path / IMAGES_DIRNAME
+        return (*self.container_image_dirs, *((own,) if own.is_dir() else ()))
+
+
+def discover(root: Path) -> tuple[list[ModelFolder], list[tuple[Path, str]]]:
+    """Walk the staging root, returning model folders and ambiguous folders.
+
+    A directory holding `models/` is a model folder. A directory holding only
+    subdirectories is a container and is recursed into. A directory holding
+    both is a half-finished split: uploading it would commit the leftovers
+    and silently drop everything already moved into the children, so it is
+    reported instead.
+    """
+    found: list[ModelFolder] = []
+    ambiguous: list[tuple[Path, str]] = []
+    if not root.is_dir():
+        return found, ambiguous
+    for child in sorted(root.iterdir()):
+        if child.is_dir() and child.name not in RESERVED_DIRNAMES:
+            _visit(child, (), (), found, ambiguous)
+    return found, ambiguous
+
+
+def _visit(
+    directory: Path,
+    chain: tuple[dict[str, Any], ...],
+    image_dirs: tuple[Path, ...],
+    found: list[ModelFolder],
+    ambiguous: list[tuple[Path, str]],
+) -> None:
+    chain = (*chain, read_metadata(directory) or {})
+    has_models = (directory / MODELS_DIRNAME).is_dir()
+    subdirectories = [
+        child
+        for child in sorted(directory.iterdir())
+        if child.is_dir() and child.name not in {MODELS_DIRNAME, IMAGES_DIRNAME}
+    ]
+
+    if has_models:
+        nested: list[ModelFolder] = []
+        nested_ambiguous: list[tuple[Path, str]] = []
+        for child in subdirectories:
+            _visit(child, chain, image_dirs, nested, nested_ambiguous)
+        if nested or nested_ambiguous:
+            ambiguous.append(
+                (
+                    directory,
+                    f"holds its own {MODELS_DIRNAME}/ and model folders beneath it; "
+                    f"finish the split by emptying {MODELS_DIRNAME}/",
+                ),
+            )
+            return
+        found.append(
+            ModelFolder(path=directory, chain=chain, container_image_dirs=image_dirs),
+        )
+        return
+
+    own_images = directory / IMAGES_DIRNAME
+    if own_images.is_dir():
+        image_dirs = (*image_dirs, own_images)
+    for child in subdirectories:
+        _visit(child, chain, image_dirs, found, ambiguous)

--- a/tools/telegram-importer/src/alexandria_telegram_importer/folder_upload.py
+++ b/tools/telegram-importer/src/alexandria_telegram_importer/folder_upload.py
@@ -166,10 +166,12 @@ def _is_split_member(filename: str) -> bool:
 
 
 def _split_order(entries: list[Path]) -> tuple[Path, ...] | None:
-    """Order entries as one split set, or None when they are not one.
+    """Return the entries when they form one complete split set, else None.
 
     Reuses grouping's part detection and validation so the importer and the
-    staged flow agree on what a complete set is.
+    staged flow agree on what a complete set is. Order is not meaningful:
+    FileProcessingService.processSplitArchive reassembles by filename, not by
+    upload order, so the entries are returned as given.
     """
     if len(entries) < 2 or not all(entry.is_file() for entry in entries):
         return None
@@ -187,8 +189,7 @@ def _split_order(entries: list[Path]) -> tuple[Path, ...] | None:
     except ValueError as error:
         log.info("Not treating %s as a split set: %s", entries[0].parent, error)
         return None
-    order = {part.filename: index for index, part in enumerate(units[0].parts)}
-    return tuple(sorted(entries, key=lambda entry: order[entry.name]))
+    return tuple(entries)
 
 
 def plan_models_dir(models_dir: Path) -> ModelsPlan:
@@ -387,14 +388,18 @@ class FolderUploader:
 
     async def _upload_and_dispose(self, folder: ModelFolder, root: Path) -> str:
         log.info("Uploading %s", folder.path.name)
+        session_out: dict[str, str] = {}
         try:
             with guarded_model(self.progress, folder.path.name, parts=1) as handle:
-                model_id = await self.upload(folder, handle)
+                model_id = await self.upload(folder, handle, session_out)
         # One bad folder must not stop the rest of the staging directory.
         except Exception as error:  # noqa: BLE001
             log.error("Failed to upload %s: %s", folder.path.name, error)
             dispose(
-                folder.path, root, FAILED_DIRNAME, {"error": str(error), **_failed_at()}
+                folder.path,
+                root,
+                FAILED_DIRNAME,
+                {"error": str(error), **session_out, **_failed_at()},
             )
             return "failed"
         dispose(
@@ -404,7 +409,10 @@ class FolderUploader:
         return "completed"
 
     async def upload(
-        self, folder: ModelFolder, handle: ModelProgress | None = None
+        self,
+        folder: ModelFolder,
+        handle: ModelProgress | None = None,
+        session_out: dict[str, str] | None = None,
     ) -> str:
         handle = handle or NullModelProgress()
         effective = folder.metadata
@@ -420,8 +428,10 @@ class FolderUploader:
             plan = plan_models_dir(folder.models_dir)
             if plan.kind == "zip":
                 handle.phase("packaging")
-            paths, multipart = build_upload_paths(
-                plan, Path(temp), payload["modelName"]
+            # Zipping an arbitrary tree can take minutes; off-thread so it does
+            # not stall sibling transfers and their progress at --concurrency > 1.
+            paths, multipart = await asyncio.to_thread(
+                build_upload_paths, plan, Path(temp), payload["modelName"]
             )
 
             upload_ids: list[str] = []
@@ -443,6 +453,8 @@ class FolderUploader:
                 await self.alexandria.abort_uploads(upload_ids)
                 raise
 
+            if session_out is not None:
+                session_out["sessionId"] = session_id
             handle.phase("scanning")
             session = await self.alexandria.wait_for_session(
                 session_id, {"ready_for_review"}
@@ -482,7 +494,36 @@ class FolderUploader:
         handle.attachments(done, len(pending))
         for offset in range(0, len(pending), ATTACHMENT_BATCH_SIZE):
             batch = pending[offset : offset + ATTACHMENT_BATCH_SIZE]
-            for path in batch:
-                await self.alexandria.append_files(session_id, (path,), (path.name,))
-                done += 1
-                handle.attachments(done, len(pending))
+            await self.alexandria.append_files(
+                session_id, batch, tuple(path.name for path in batch)
+            )
+            done += len(batch)
+            handle.attachments(done, len(pending))
+
+
+def describe_staging(root: Path) -> str:
+    """Dry-run report for the upload phase: what would be uploaded, and how."""
+    found, ambiguous = discover(root)
+    lines: list[str] = []
+    for folder in found:
+        try:
+            kind = plan_models_dir(folder.models_dir).kind
+        except ValueError as error:
+            lines.append(f"  SKIP  {folder.path.relative_to(root)}: {error}")
+            continue
+        images = sum(
+            1 for directory in folder.image_dirs for item in directory.iterdir()
+            if item.is_file()
+        )
+        lines.append(
+            f"  {kind:<6} {folder.path.relative_to(root)} "
+            f"-> {folder.model_name!r} ({images} image(s))"
+        )
+    for path, reason in ambiguous:
+        lines.append(f"  FAIL   {path.relative_to(root)}: {reason}")
+    if not lines:
+        return f"No model folders found in {root}."
+    header = f"{len(found)} model folder(s) would be uploaded from {root}"
+    if ambiguous:
+        header += f"; {len(ambiguous)} would be moved to {FAILED_DIRNAME}/"
+    return header + ":\n" + "\n".join(lines)

--- a/tools/telegram-importer/src/alexandria_telegram_importer/folder_upload.py
+++ b/tools/telegram-importer/src/alexandria_telegram_importer/folder_upload.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import shutil
 import tempfile
@@ -16,6 +17,7 @@ from .folder_metadata import (
     METADATA_FILENAME,
     batch_metadata,
     merge_chain,
+    metadata_error,
     model_name_from_folder,
     read_metadata,
     write_metadata,
@@ -45,6 +47,7 @@ IMAGES_DIRNAME = "images"
 UPLOADED_DIRNAME = "uploaded"
 FAILED_DIRNAME = "failed"
 RESERVED_DIRNAMES = frozenset({UPLOADED_DIRNAME, FAILED_DIRNAME})
+RESULT_FILENAME = "result.json"
 
 
 @dataclass(frozen=True, slots=True)
@@ -84,10 +87,27 @@ def discover(root: Path) -> tuple[list[ModelFolder], list[tuple[Path, str]]]:
     ambiguous: list[tuple[Path, str]] = []
     if not root.is_dir():
         return found, ambiguous
-    for child in sorted(root.iterdir()):
-        if child.is_dir() and child.name not in RESERVED_DIRNAMES:
-            _visit(child, (), (), found, ambiguous)
+
+    # The staging root participates in the chain like any container, so it is
+    # the natural place for channel-wide defaults.
+    root_chain: tuple[dict[str, Any], ...] = (read_metadata(root) or {},)
+    root_images = root / IMAGES_DIRNAME
+    root_image_dirs = (root_images,) if root_images.is_dir() else ()
+
+    for child in _child_directories(root):
+        _visit(child, root_chain, root_image_dirs, found, ambiguous)
     return found, ambiguous
+
+
+def _child_directories(directory: Path) -> list[Path]:
+    """Subdirectories that can hold model folders, at any depth."""
+    return [
+        child
+        for child in sorted(directory.iterdir())
+        if child.is_dir()
+        and child.name not in RESERVED_DIRNAMES
+        and child.name not in {MODELS_DIRNAME, IMAGES_DIRNAME}
+    ]
 
 
 def _visit(
@@ -99,13 +119,15 @@ def _visit(
 ) -> None:
     chain = (*chain, read_metadata(directory) or {})
     has_models = (directory / MODELS_DIRNAME).is_dir()
-    subdirectories = [
-        child
-        for child in sorted(directory.iterdir())
-        if child.is_dir() and child.name not in {MODELS_DIRNAME, IMAGES_DIRNAME}
-    ]
+    subdirectories = _child_directories(directory)
 
     if has_models:
+        # A model folder commits on the strength of its own metadata.json, so a
+        # typo in one must not quietly produce a wrongly-named model. Container
+        # files stay lenient: the operator never edited those.
+        if error := metadata_error(directory):
+            ambiguous.append((directory, error))
+            return
         nested: list[ModelFolder] = []
         nested_ambiguous: list[tuple[Path, str]] = []
         for child in subdirectories:
@@ -226,9 +248,17 @@ def dispose(
     destination_parent.mkdir(parents=True, exist_ok=True)
     destination = unique_child(destination_parent, folder.name)
 
-    payload = read_metadata(folder) or {}
-    payload["result"] = result
-    write_metadata(folder, payload)
+    # Never rewrite a file we could not parse — it holds hand-typed values that
+    # exist nowhere else, and `or {}` would replace them with the result alone.
+    if metadata_error(folder):
+        (folder / RESULT_FILENAME).write_text(
+            json.dumps(result, indent=2, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+    else:
+        payload = read_metadata(folder) or {}
+        payload["result"] = result
+        write_metadata(folder, payload)
 
     shutil.move(str(folder), str(destination))
 
@@ -246,12 +276,27 @@ def dispose(
 
 
 def _prune_empty_containers(directory: Path, root: Path) -> None:
-    """Remove containers that no longer hold any model folder."""
+    """Remove containers that hold nothing but their own metadata.json.
+
+    Emptiness is judged by what is actually on disk, not by whether `discover`
+    can still find a model folder. A container may hold an unsplit archive, a
+    half-organized subfolder, or shared images — none of which `discover` sees,
+    and all of which are the operator's work in progress.
+    """
     while directory != root and directory.is_dir():
-        remaining, ambiguous = discover(directory)
-        if remaining or ambiguous:
+        leftovers = [
+            child
+            for child in directory.iterdir()
+            if child.name not in {METADATA_FILENAME, RESULT_FILENAME}
+        ]
+        if leftovers:
             return
-        shutil.rmtree(directory, ignore_errors=True)
+        try:
+            shutil.rmtree(directory)
+            log.info("Removed emptied container %s", directory)
+        except OSError as error:
+            log.warning("Could not remove emptied container %s: %s", directory, error)
+            return
         directory = directory.parent
 
 

--- a/tools/telegram-importer/src/alexandria_telegram_importer/folder_upload.py
+++ b/tools/telegram-importer/src/alexandria_telegram_importer/folder_upload.py
@@ -1,11 +1,20 @@
 from __future__ import annotations
 
 import logging
+import zipfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 from .folder_metadata import merge_chain, model_name_from_folder, read_metadata
+from .grouping import (
+    ARCHIVE_EXTENSIONS,
+    multipart_part_role,
+    partition_logical_models,
+    safe_filename,
+    validate_logical_model,
+)
+from .models import MediaKind, MediaRef
 
 log = logging.getLogger(__name__)
 
@@ -98,3 +107,86 @@ def _visit(
         image_dirs = (*image_dirs, own_images)
     for child in subdirectories:
         _visit(child, chain, image_dirs, found, ambiguous)
+
+
+@dataclass(frozen=True, slots=True)
+class ModelsPlan:
+    kind: str  # "as_is" | "split" | "zip"
+    paths: tuple[Path, ...]
+
+
+def _is_split_member(filename: str) -> bool:
+    try:
+        multipart_part_role(filename)
+    except ValueError:
+        return False
+    return True
+
+
+def _split_order(entries: list[Path]) -> tuple[Path, ...] | None:
+    """Order entries as one split set, or None when they are not one.
+
+    Reuses grouping's part detection and validation so the importer and the
+    staged flow agree on what a complete set is.
+    """
+    if len(entries) < 2 or not all(entry.is_file() for entry in entries):
+        return None
+    if not all(_is_split_member(entry.name) for entry in entries):
+        return None
+    refs = [
+        MediaRef(message_id=index, filename=entry.name, kind=MediaKind.MODEL)
+        for index, entry in enumerate(entries)
+    ]
+    units = partition_logical_models(0, refs)
+    if len(units) != 1 or not units[0].multipart:
+        return None
+    try:
+        validate_logical_model(units[0])
+    except ValueError as error:
+        log.info("Not treating %s as a split set: %s", entries[0].parent, error)
+        return None
+    order = {part.filename: index for index, part in enumerate(units[0].parts)}
+    return tuple(sorted(entries, key=lambda entry: order[entry.name]))
+
+
+def plan_models_dir(models_dir: Path) -> ModelsPlan:
+    if not models_dir.is_dir():
+        raise ValueError(f"{models_dir} is missing")
+    entries = sorted(models_dir.iterdir())
+    if not entries:
+        raise ValueError(f"{models_dir} is empty")
+
+    only = entries[0]
+    if (
+        len(entries) == 1
+        and only.is_file()
+        and only.name.lower().endswith(ARCHIVE_EXTENSIONS)
+    ):
+        return ModelsPlan(kind="as_is", paths=(only,))
+
+    if ordered := _split_order(entries):
+        return ModelsPlan(kind="split", paths=ordered)
+
+    return ModelsPlan(kind="zip", paths=tuple(entries))
+
+
+def build_upload_paths(
+    plan: ModelsPlan, work_dir: Path, model_name: str
+) -> tuple[tuple[Path, ...], bool]:
+    """Resolve a plan into paths to upload and whether they are a split set.
+
+    An `as_is` or `split` plan uploads the operator's own files untouched —
+    that is what makes hand-made compression worth doing.
+    """
+    if plan.kind == "as_is":
+        return plan.paths, False
+    if plan.kind == "split":
+        return plan.paths, True
+
+    models_dir = plan.paths[0].parent
+    archive_path = work_dir / f"{safe_filename(model_name, 'model')}.zip"
+    with zipfile.ZipFile(archive_path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        for path in sorted(models_dir.rglob("*")):
+            if path.is_file():
+                archive.write(path, arcname=str(path.relative_to(models_dir)))
+    return (archive_path,), False

--- a/tools/telegram-importer/src/alexandria_telegram_importer/folder_upload.py
+++ b/tools/telegram-importer/src/alexandria_telegram_importer/folder_upload.py
@@ -1,12 +1,19 @@
 from __future__ import annotations
 
 import logging
+import shutil
 import zipfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from .folder_metadata import merge_chain, model_name_from_folder, read_metadata
+from .folder_metadata import (
+    METADATA_FILENAME,
+    merge_chain,
+    model_name_from_folder,
+    read_metadata,
+    write_metadata,
+)
 from .grouping import (
     ARCHIVE_EXTENSIONS,
     multipart_part_role,
@@ -15,6 +22,7 @@ from .grouping import (
     validate_logical_model,
 )
 from .models import MediaKind, MediaRef
+from .staging import unique_child
 
 log = logging.getLogger(__name__)
 
@@ -190,3 +198,46 @@ def build_upload_paths(
             if path.is_file():
                 archive.write(path, arcname=str(path.relative_to(models_dir)))
     return (archive_path,), False
+
+
+def dispose(
+    folder: Path, root: Path, destination_dirname: str, result: dict[str, Any]
+) -> Path:
+    """Move one settled model folder under uploaded/ or failed/.
+
+    The path relative to the staging root is preserved, so a release that
+    settles a few folders at a time stays recognizable, and each ancestor's
+    metadata.json is copied so the archived copy still carries its defaults.
+    """
+    relative = folder.relative_to(root)
+    destination_parent = root / destination_dirname / relative.parent
+    destination_parent.mkdir(parents=True, exist_ok=True)
+    destination = unique_child(destination_parent, folder.name)
+
+    payload = read_metadata(folder) or {}
+    payload["result"] = result
+    write_metadata(folder, payload)
+
+    shutil.move(str(folder), str(destination))
+
+    ancestor = folder.parent
+    mirrored = destination_parent
+    while ancestor != root:
+        source_metadata = ancestor / METADATA_FILENAME
+        if source_metadata.is_file() and not (mirrored / METADATA_FILENAME).exists():
+            shutil.copy2(source_metadata, mirrored / METADATA_FILENAME)
+        ancestor = ancestor.parent
+        mirrored = mirrored.parent
+
+    _prune_empty_containers(folder.parent, root)
+    return destination
+
+
+def _prune_empty_containers(directory: Path, root: Path) -> None:
+    """Remove containers that no longer hold any model folder."""
+    while directory != root and directory.is_dir():
+        remaining, ambiguous = discover(directory)
+        if remaining or ambiguous:
+            return
+        shutil.rmtree(directory, ignore_errors=True)
+        directory = directory.parent

--- a/tools/telegram-importer/src/alexandria_telegram_importer/staging.py
+++ b/tools/telegram-importer/src/alexandria_telegram_importer/staging.py
@@ -1,12 +1,22 @@
 from __future__ import annotations
 
 import hashlib
+import logging
 import re
+import shutil
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Protocol
 
-from .grouping import model_name_from_filename
-from .models import ImportBundle
+from .folder_metadata import write_metadata
+from .grouping import model_name_from_filename, safe_filename
+from .models import ImportBundle, MediaRef
+from .progress import ModelProgress, NullModelProgress
+
+log = logging.getLogger(__name__)
 
 MAX_SLUG_LENGTH = 60
+MAX_DESCRIPTION_LENGTH = 2000
 
 _SLUG_STRIP_RE = re.compile(r"[^a-z0-9]+")
 
@@ -36,3 +46,135 @@ def bundle_folder_name(bundle: ImportBundle) -> str:
     first_message_id = min(unit.first_message_id for unit in bundle.models)
     name = slug(model_name_from_filename(bundle.models[0].logical_filename))
     return f"{first_message_id:06d}-{name}" if name else f"{first_message_id:06d}"
+
+
+class MediaDownloader(Protocol):
+    channel_id: int
+
+    async def download(
+        self, ref: MediaRef, directory: Path, *, on_progress: Any = None
+    ) -> Path: ...
+
+    def message_link(self, message_id: int) -> str | None: ...
+
+
+def unique_child(parent: Path, name: str) -> Path:
+    """A path under parent that does not exist yet, suffixing -2, -3 on collision."""
+    candidate = parent / name
+    index = 2
+    while candidate.exists():
+        candidate = parent / f"{name}-{index}"
+        index += 1
+    return candidate
+
+
+def _unique_filename(directory: Path, filename: str) -> Path:
+    stem, dot, extension = filename.partition(".")
+    candidate = directory / filename
+    index = 2
+    while candidate.exists():
+        candidate = directory / f"{stem}-{index}{dot}{extension}"
+        index += 1
+    return candidate
+
+
+def bundle_description(source: MediaDownloader, bundle: ImportBundle) -> str:
+    """Compose one description for a whole bundle.
+
+    Mirrors importer.build_description, but scoped to every model in the
+    bundle rather than one logical model, since a staged folder is a bundle.
+    """
+    sections: list[str] = []
+    seen: set[str] = set()
+    parts = [part for unit in bundle.models for part in unit.parts]
+    for ref in (*bundle.attachments, *parts):
+        if ref.caption and ref.caption not in seen:
+            sections.append(ref.caption)
+            seen.add(ref.caption)
+
+    ids = ", ".join(str(message_id) for message_id in bundle_message_ids(bundle))
+    source_line = (
+        f"Imported from Telegram channel {source.channel_id}; model message(s): {ids}."
+    )
+    first = min(unit.first_message_id for unit in bundle.models)
+    if link := source.message_link(first):
+        source_line += f" Source: {link}"
+    sections.append(source_line)
+    description = "\n\n".join(sections)
+    if len(description) > MAX_DESCRIPTION_LENGTH:
+        return description[: MAX_DESCRIPTION_LENGTH - 1] + "…"
+    return description
+
+
+class BundleStager:
+    def __init__(self, *, telegram: MediaDownloader, root: Path) -> None:
+        self.telegram = telegram
+        self.root = root
+
+    async def stage(
+        self, bundle: ImportBundle, handle: ModelProgress | None = None
+    ) -> Path:
+        """Download one bundle into its own folder, or leave nothing behind."""
+        handle = handle or NullModelProgress()
+        self.root.mkdir(parents=True, exist_ok=True)
+        folder = unique_child(self.root, bundle_folder_name(bundle))
+        folder.mkdir()
+        try:
+            models_dir = folder / "models"
+            images_dir = folder / "images"
+            models_dir.mkdir()
+            images_dir.mkdir()
+
+            parts = [part for unit in bundle.models for part in unit.parts]
+            for ref in parts:
+                await self._fetch(ref, models_dir, handle)
+            for ref in bundle.attachments:
+                await self._fetch(ref, images_dir, handle)
+
+            write_metadata(
+                folder,
+                {
+                    "modelName": model_name_from_filename(
+                        bundle.models[0].logical_filename
+                    ),
+                    "description": bundle_description(self.telegram, bundle),
+                    "artist": None,
+                    "tags": [],
+                    "metadata": {},
+                    "options": {},
+                    "collectionId": None,
+                    "newCollectionName": None,
+                    "source": {
+                        "channelId": self.telegram.channel_id,
+                        "channelUsername": getattr(
+                            self.telegram, "channel_username", None
+                        ),
+                        "bundleKey": bundle_key(self.telegram.channel_id, bundle),
+                        "modelMessageIds": list(bundle_message_ids(bundle)),
+                        "attachmentMessageIds": [
+                            ref.message_id for ref in bundle.attachments
+                        ],
+                        "link": self.telegram.message_link(
+                            min(unit.first_message_id for unit in bundle.models)
+                        ),
+                        "downloadedAt": datetime.now(UTC).isoformat(),
+                    },
+                    "result": None,
+                },
+            )
+        except BaseException:
+            # A half-staged folder would upload as an incomplete model, so the
+            # bundle is left entirely unstaged and retried on the next run.
+            shutil.rmtree(folder, ignore_errors=True)
+            raise
+        return folder
+
+    async def _fetch(
+        self, ref: MediaRef, directory: Path, handle: ModelProgress
+    ) -> None:
+        with handle.transfer("download", ref.filename) as transfer:
+            downloaded = await self.telegram.download(
+                ref, directory, on_progress=transfer.advance
+            )
+        target = _unique_filename(directory, safe_filename(ref.filename, "media"))
+        downloaded.rename(target)

--- a/tools/telegram-importer/src/alexandria_telegram_importer/staging.py
+++ b/tools/telegram-importer/src/alexandria_telegram_importer/staging.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import hashlib
+import re
+
+from .grouping import model_name_from_filename
+from .models import ImportBundle
+
+MAX_SLUG_LENGTH = 60
+
+_SLUG_STRIP_RE = re.compile(r"[^a-z0-9]+")
+
+
+def bundle_message_ids(bundle: ImportBundle) -> tuple[int, ...]:
+    return tuple(
+        sorted(part.message_id for unit in bundle.models for part in unit.parts)
+    )
+
+
+def bundle_key(channel_id: int, bundle: ImportBundle) -> str:
+    """Key one staged bundle.
+
+    The `staged:` prefix keeps this key space disjoint from grouping's
+    per-logical-model `import_key`, which hashes the same message IDs.
+    """
+    ids = ",".join(str(message_id) for message_id in bundle_message_ids(bundle))
+    return hashlib.sha256(f"staged:{channel_id}:{ids}".encode()).hexdigest()[:24]
+
+
+def slug(value: str) -> str:
+    return _SLUG_STRIP_RE.sub("-", value.lower()).strip("-")[:MAX_SLUG_LENGTH].strip("-")
+
+
+def bundle_folder_name(bundle: ImportBundle) -> str:
+    # partition_logical_models sorts by first_message_id, so models[0] is earliest.
+    first_message_id = min(unit.first_message_id for unit in bundle.models)
+    name = slug(model_name_from_filename(bundle.models[0].logical_filename))
+    return f"{first_message_id:06d}-{name}" if name else f"{first_message_id:06d}"

--- a/tools/telegram-importer/src/alexandria_telegram_importer/tracker.py
+++ b/tools/telegram-importer/src/alexandria_telegram_importer/tracker.py
@@ -26,6 +26,16 @@ class ImportRecord:
     duplicate_of_import_key: str | None = None
 
 
+@dataclass(frozen=True, slots=True)
+class StagedBundle:
+    bundle_key: str
+    source_channel_id: int
+    folder_name: str
+    model_message_ids: tuple[int, ...]
+    status: str
+    downloaded_at: str
+
+
 class ImportTracker:
     def __init__(self, path: Path) -> None:
         path.parent.mkdir(parents=True, exist_ok=True)
@@ -81,6 +91,22 @@ class ImportTracker:
         self._connection.execute(
             "CREATE INDEX IF NOT EXISTS imports_content_signature_idx "
             "ON imports (content_signature, status)",
+        )
+        self._connection.execute(
+            """
+            CREATE TABLE IF NOT EXISTS staged_bundles (
+                bundle_key TEXT PRIMARY KEY,
+                source_channel_id INTEGER NOT NULL,
+                folder_name TEXT NOT NULL,
+                model_message_ids TEXT NOT NULL,
+                status TEXT NOT NULL,
+                downloaded_at TEXT NOT NULL
+            )
+            """,
+        )
+        self._connection.execute(
+            "CREATE INDEX IF NOT EXISTS staged_bundles_channel_idx "
+            "ON staged_bundles (source_channel_id)",
         )
         self._connection.commit()
 
@@ -266,6 +292,59 @@ class ImportTracker:
         if record is None:
             raise KeyError(import_key)
         return record
+
+    def record_staged(
+        self,
+        *,
+        bundle_key: str,
+        source_channel_id: int,
+        folder_name: str,
+        model_message_ids: tuple[int, ...],
+    ) -> StagedBundle:
+        now = datetime.now(UTC).isoformat()
+        with self._connection:
+            self._connection.execute(
+                """
+                INSERT INTO staged_bundles (
+                    bundle_key, source_channel_id, folder_name,
+                    model_message_ids, status, downloaded_at
+                ) VALUES (?, ?, ?, ?, 'downloaded', ?)
+                ON CONFLICT(bundle_key) DO NOTHING
+                """,
+                (
+                    bundle_key,
+                    source_channel_id,
+                    folder_name,
+                    json.dumps(model_message_ids),
+                    now,
+                ),
+            )
+        staged = self.get_staged(bundle_key)
+        assert staged is not None
+        return staged
+
+    def get_staged(self, bundle_key: str) -> StagedBundle | None:
+        row = self._connection.execute(
+            "SELECT * FROM staged_bundles WHERE bundle_key = ?",
+            (bundle_key,),
+        ).fetchone()
+        if row is None:
+            return None
+        return StagedBundle(
+            bundle_key=row["bundle_key"],
+            source_channel_id=row["source_channel_id"],
+            folder_name=row["folder_name"],
+            model_message_ids=tuple(json.loads(row["model_message_ids"])),
+            status=row["status"],
+            downloaded_at=row["downloaded_at"],
+        )
+
+    def staged_keys(self, source_channel_id: int) -> set[str]:
+        rows = self._connection.execute(
+            "SELECT bundle_key FROM staged_bundles WHERE source_channel_id = ?",
+            (source_channel_id,),
+        ).fetchall()
+        return {row["bundle_key"] for row in rows}
 
     def counts(self) -> dict[str, int]:
         rows = self._connection.execute(

--- a/tools/telegram-importer/src/alexandria_telegram_importer/tracker.py
+++ b/tools/telegram-importer/src/alexandria_telegram_importer/tracker.py
@@ -320,7 +320,8 @@ class ImportTracker:
                 ),
             )
         staged = self.get_staged(bundle_key)
-        assert staged is not None
+        if staged is None:
+            raise KeyError(bundle_key)
         return staged
 
     def get_staged(self, bundle_key: str) -> StagedBundle | None:

--- a/tools/telegram-importer/tests/test_cli.py
+++ b/tools/telegram-importer/tests/test_cli.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 import pytest
 
-from alexandria_telegram_importer.cli import parser
+from alexandria_telegram_importer.cli import (
+    confirm_upload,
+    parser,
+    validate_staging_args,
+)
 from alexandria_telegram_importer.parallel_download import (
     DEFAULT_CONNECTIONS,
     MAX_CONNECTIONS,
@@ -105,3 +109,53 @@ def test_should_keep_progress_for_falsey_environment_values(monkeypatch, value) 
     monkeypatch.setenv("TELEGRAM_IMPORT_NO_PROGRESS", value)
 
     assert parser().parse_args([]).no_progress is False
+
+
+def test_should_reject_a_staging_flag_without_a_staging_directory() -> None:
+    args = parser().parse_args(["--download-only", "5"])
+
+    with pytest.raises(SystemExit, match="--staging-dir"):
+        validate_staging_args(args)
+
+
+def test_should_reject_a_staging_directory_without_a_staging_flag() -> None:
+    args = parser().parse_args(["--staging-dir", "/tmp/work"])
+
+    with pytest.raises(SystemExit, match="one of"):
+        validate_staging_args(args)
+
+
+def test_should_reject_two_staging_flags_at_once() -> None:
+    with pytest.raises(SystemExit):
+        parser().parse_args(
+            ["--staging-dir", "/tmp/work", "--download-only", "5", "--upload-only"],
+        )
+
+
+def test_should_reject_a_non_positive_download_count() -> None:
+    with pytest.raises(SystemExit):
+        parser().parse_args(["--staging-dir", "/tmp/work", "--download-only", "0"])
+
+
+def test_should_accept_each_staging_mode(tmp_path) -> None:
+    for extra in (["--download-only", "5"], ["--upload-only"], ["--stage", "5"]):
+        args = parser().parse_args(["--staging-dir", str(tmp_path), *extra])
+        validate_staging_args(args)
+
+
+def test_should_treat_a_closed_stdin_as_quitting_the_pause(monkeypatch) -> None:
+    import io
+
+    monkeypatch.setattr("sys.stdin", io.StringIO(""))
+
+    assert confirm_upload("2 folders staged.") is False
+
+
+def test_should_treat_q_as_quitting_and_enter_as_proceeding(monkeypatch) -> None:
+    import io
+
+    monkeypatch.setattr("sys.stdin", io.StringIO("q\n"))
+    assert confirm_upload("2 folders staged.") is False
+
+    monkeypatch.setattr("sys.stdin", io.StringIO("\n"))
+    assert confirm_upload("2 folders staged.") is True

--- a/tools/telegram-importer/tests/test_cli.py
+++ b/tools/telegram-importer/tests/test_cli.py
@@ -206,3 +206,84 @@ async def test_should_upload_without_touching_telegram(monkeypatch, tmp_path) ->
 
 async def _ready(value):
     return value
+
+
+async def test_should_not_upload_anything_on_a_dry_run(monkeypatch, tmp_path) -> None:
+    from alexandria_telegram_importer import cli
+
+    uploaded: list[str] = []
+
+    class FakeUploader:
+        def __init__(self, **kwargs) -> None:
+            pass
+
+        async def run(self, root):
+            uploaded.append("ran")
+            return {"completed": 1}
+
+    (tmp_path / "002501-dragon" / "models").mkdir(parents=True)
+    (tmp_path / "002501-dragon" / "models" / "a.7z").write_bytes(b"a")
+
+    monkeypatch.setattr(cli, "FolderUploader", FakeUploader)
+    monkeypatch.setattr(
+        cli, "_login", lambda args: _fail("must not log in during a dry run")
+    )
+
+    args = parser().parse_args(
+        ["--upload-only", "--dry-run", "--staging-dir", str(tmp_path)],
+    )
+
+    assert await cli.run(args) == 0
+    assert uploaded == []
+    assert (tmp_path / "002501-dragon").is_dir()
+
+
+async def test_should_not_require_telegram_credentials_for_upload_only(
+    monkeypatch, tmp_path
+) -> None:
+    from alexandria_telegram_importer import cli
+
+    class FakeUploader:
+        def __init__(self, **kwargs) -> None:
+            pass
+
+        async def run(self, root):
+            return {"completed": 1}
+
+    class FakeClient:
+        async def close(self) -> None:
+            return None
+
+    monkeypatch.delenv("TELEGRAM_API_ID", raising=False)
+    monkeypatch.delenv("TELEGRAM_API_HASH", raising=False)
+    monkeypatch.delenv("API_ID", raising=False)
+    monkeypatch.delenv("API_HASH", raising=False)
+    monkeypatch.setattr(cli, "TelegramSource", _forbidden_telegram)
+    monkeypatch.setattr(cli, "FolderUploader", FakeUploader)
+    monkeypatch.setattr(cli, "_login", lambda args: _ready(FakeClient()))
+
+    args = parser().parse_args(["--upload-only", "--staging-dir", str(tmp_path)])
+
+    assert await cli.run(args) == 0
+
+
+async def test_should_report_a_staging_directory_that_does_not_exist(
+    monkeypatch, tmp_path
+) -> None:
+    from alexandria_telegram_importer import cli
+
+    monkeypatch.setattr(cli, "TelegramSource", _forbidden_telegram)
+    args = parser().parse_args(
+        ["--upload-only", "--staging-dir", str(tmp_path / "typo")],
+    )
+
+    with pytest.raises(SystemExit, match="does not exist"):
+        await cli.run(args)
+
+
+def _forbidden_telegram(**kwargs):
+    raise AssertionError("TelegramSource must not be constructed for --upload-only")
+
+
+async def _fail(message: str):
+    raise AssertionError(message)

--- a/tools/telegram-importer/tests/test_cli.py
+++ b/tools/telegram-importer/tests/test_cli.py
@@ -159,3 +159,50 @@ def test_should_treat_q_as_quitting_and_enter_as_proceeding(monkeypatch) -> None
 
     monkeypatch.setattr("sys.stdin", io.StringIO("\n"))
     assert confirm_upload("2 folders staged.") is True
+
+
+async def test_should_upload_without_touching_telegram(monkeypatch, tmp_path) -> None:
+    """--upload-only is local; connecting to Telegram would be wasted work."""
+    from alexandria_telegram_importer import cli
+
+    connected: list[str] = []
+
+    class FakeTelegram:
+        def __init__(self, **kwargs) -> None:
+            pass
+
+        async def connect(self, channel) -> None:
+            connected.append("connect")
+
+        async def collect_media(self, *, min_message_id=0):
+            connected.append("collect")
+            return []
+
+        async def close(self) -> None:
+            return None
+
+    class FakeUploader:
+        def __init__(self, **kwargs) -> None:
+            pass
+
+        async def run(self, root):
+            return {"completed": 2}
+
+    class FakeClient:
+        async def close(self) -> None:
+            return None
+
+    monkeypatch.setenv("TELEGRAM_API_ID", "1")
+    monkeypatch.setenv("TELEGRAM_API_HASH", "hash")
+    monkeypatch.setattr(cli, "TelegramSource", FakeTelegram)
+    monkeypatch.setattr(cli, "FolderUploader", FakeUploader)
+    monkeypatch.setattr(cli, "_login", lambda args: _ready(FakeClient()))
+
+    args = parser().parse_args(["--upload-only", "--staging-dir", str(tmp_path)])
+
+    assert await cli.run(args) == 0
+    assert connected == []
+
+
+async def _ready(value):
+    return value

--- a/tools/telegram-importer/tests/test_folder_metadata.py
+++ b/tools/telegram-importer/tests/test_folder_metadata.py
@@ -107,3 +107,20 @@ def test_should_strip_non_commit_keys_from_batch_metadata() -> None:
     )
 
     assert payload == {"modelName": "Dragon", "tags": ["a"]}
+
+
+def test_should_report_an_error_for_an_unparseable_metadata_file(tmp_path) -> None:
+    from alexandria_telegram_importer.folder_metadata import metadata_error
+
+    assert metadata_error(tmp_path) is None
+
+    (tmp_path / "metadata.json").write_text('{"a": 1,}', encoding="utf-8")
+    error = metadata_error(tmp_path)
+    assert error is not None
+    assert "metadata.json" in error
+
+    (tmp_path / "metadata.json").write_text("[1, 2]", encoding="utf-8")
+    assert "JSON object" in (metadata_error(tmp_path) or "")
+
+    (tmp_path / "metadata.json").write_text('{"a": 1}', encoding="utf-8")
+    assert metadata_error(tmp_path) is None

--- a/tools/telegram-importer/tests/test_folder_metadata.py
+++ b/tools/telegram-importer/tests/test_folder_metadata.py
@@ -124,3 +124,9 @@ def test_should_report_an_error_for_an_unparseable_metadata_file(tmp_path) -> No
 
     (tmp_path / "metadata.json").write_text('{"a": 1}', encoding="utf-8")
     assert metadata_error(tmp_path) is None
+
+
+def test_should_only_strip_the_six_digit_staging_prefix() -> None:
+    assert model_name_from_folder("002501-dragon-knight") == "dragon knight"
+    assert model_name_from_folder("2001-a-space-odyssey") == "2001 a space odyssey"
+    assert model_name_from_folder("12345678-thing") == "12345678 thing"

--- a/tools/telegram-importer/tests/test_folder_metadata.py
+++ b/tools/telegram-importer/tests/test_folder_metadata.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import json
+
+from alexandria_telegram_importer.folder_metadata import (
+    SCHEMA_VERSION,
+    batch_metadata,
+    merge_chain,
+    model_name_from_folder,
+    read_metadata,
+    write_metadata,
+)
+
+
+def test_should_return_none_for_a_folder_without_metadata(tmp_path) -> None:
+    assert read_metadata(tmp_path) is None
+
+
+def test_should_return_none_for_unparseable_or_non_object_metadata(tmp_path) -> None:
+    (tmp_path / "metadata.json").write_text("{not json", encoding="utf-8")
+    assert read_metadata(tmp_path) is None
+
+    (tmp_path / "metadata.json").write_text("[1, 2]", encoding="utf-8")
+    assert read_metadata(tmp_path) is None
+
+
+def test_should_round_trip_metadata_preserving_unknown_keys(tmp_path) -> None:
+    write_metadata(tmp_path, {"modelName": "Dragon", "somethingNew": {"a": 1}})
+
+    loaded = read_metadata(tmp_path)
+
+    assert loaded["modelName"] == "Dragon"
+    assert loaded["somethingNew"] == {"a": 1}
+    assert loaded["schemaVersion"] == SCHEMA_VERSION
+    assert json.loads((tmp_path / "metadata.json").read_text(encoding="utf-8"))
+
+
+def test_should_let_the_nearest_level_win_for_scalars() -> None:
+    merged = merge_chain(
+        [
+            {"artist": "Release Studios", "description": "release blurb"},
+            {"artist": "Child Studios"},
+        ],
+    )
+
+    assert merged["artist"] == "Child Studios"
+    assert merged["description"] == "release blurb"
+
+
+def test_should_merge_tags_across_levels_without_duplicates() -> None:
+    merged = merge_chain(
+        [{"tags": ["dragon", "fantasy"]}, {"tags": ["knight", "dragon"]}],
+    )
+
+    assert merged["tags"] == ["dragon", "fantasy", "knight"]
+
+
+def test_should_merge_metadata_and_options_key_by_key() -> None:
+    merged = merge_chain(
+        [
+            {
+                "metadata": {"scale": "32mm", "license": "personal"},
+                "options": {"markNsfw": True},
+            },
+            {"metadata": {"license": "commercial"}},
+        ],
+    )
+
+    assert merged["metadata"] == {"scale": "32mm", "license": "commercial"}
+    assert merged["options"] == {"markNsfw": True}
+
+
+def test_should_never_inherit_model_name_from_a_container() -> None:
+    merged = merge_chain([{"modelName": "Dragon Set"}, {"artist": "Foo"}])
+
+    assert "modelName" not in merged
+
+
+def test_should_take_model_name_from_the_leaf_level_only() -> None:
+    merged = merge_chain([{"modelName": "Dragon Set"}, {"modelName": "Dragon Knight"}])
+
+    assert merged["modelName"] == "Dragon Knight"
+
+
+def test_should_ignore_null_values_when_merging() -> None:
+    merged = merge_chain([{"artist": "Foo"}, {"artist": None}])
+
+    assert merged["artist"] == "Foo"
+
+
+def test_should_derive_a_model_name_from_a_staged_folder_name() -> None:
+    assert model_name_from_folder("002501-dragon-knight") == "dragon knight"
+    assert model_name_from_folder("dragon_knight") == "dragon knight"
+    assert model_name_from_folder("123-abc") == "123 abc"
+
+
+def test_should_strip_non_commit_keys_from_batch_metadata() -> None:
+    payload = batch_metadata(
+        {
+            "modelName": "Dragon",
+            "tags": ["a"],
+            "schemaVersion": 1,
+            "source": {"channelId": -100},
+            "result": None,
+            "artist": None,
+        },
+    )
+
+    assert payload == {"modelName": "Dragon", "tags": ["a"]}

--- a/tools/telegram-importer/tests/test_folder_upload.py
+++ b/tools/telegram-importer/tests/test_folder_upload.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 
 from alexandria_telegram_importer.folder_upload import (
+    FolderUploader,
     build_upload_paths,
     discover,
     dispose,
@@ -349,3 +350,162 @@ def test_should_suffix_a_disposal_that_collides_with_an_earlier_one(tmp_path) ->
     destination = dispose(folder, tmp_path, "uploaded", {"modelId": "abc"})
 
     assert destination.name == "dragon-2"
+
+
+class FakeAlexandria:
+    def __init__(self) -> None:
+        self.uploads: list[tuple[str, bool]] = []
+        self.appended: list[str] = []
+        self.commits: list[dict] = []
+        self.session = {"id": "session-1", "status": "ready_for_review"}
+        self.fail_commit = False
+
+    async def upload_file(self, path, upload_name, *, multipart, on_progress=None):
+        self.uploads.append((upload_name, multipart))
+        return f"upload-{len(self.uploads)}"
+
+    async def complete_upload(self, upload_ids, *, multipart):
+        return "session-1"
+
+    async def abort_uploads(self, upload_ids) -> None:
+        return None
+
+    async def get_session(self, session_id):
+        return self.session
+
+    async def wait_for_session(self, session_id, statuses, **kwargs):
+        return {"id": session_id, "status": min(statuses), "modelId": "model-1"}
+
+    async def append_files(self, session_id, paths, upload_names):
+        self.appended.extend(upload_names)
+        return self.session
+
+    async def commit(self, session_id, *, model_name, description=None, **extra):
+        if self.fail_commit:
+            raise RuntimeError("commit exploded")
+        self.commits.append(
+            {"modelName": model_name, "description": description, **extra}
+        )
+        return "model-1"
+
+
+async def test_should_upload_a_folder_and_return_its_model_id(tmp_path) -> None:
+    make_folder(
+        tmp_path / "002501-dragon",
+        models=["dragon.7z"],
+        images=["render.jpg"],
+        metadata={"modelName": "Dragon", "artist": "Foo", "tags": ["dragon"]},
+    )
+    alexandria = FakeAlexandria()
+    [folder], _ = discover(tmp_path)
+
+    model_id = await FolderUploader(
+        alexandria=alexandria, work_root=tmp_path / "work"
+    ).upload(folder)
+
+    assert model_id == "model-1"
+    assert alexandria.uploads == [("dragon.7z", False)]
+    assert alexandria.appended == ["render.jpg"]
+    assert alexandria.commits[0]["modelName"] == "Dragon"
+    assert alexandria.commits[0]["batch_metadata"]["artist"] == "Foo"
+    assert alexandria.commits[0]["batch_metadata"]["tags"] == ["dragon"]
+
+
+async def test_should_append_container_images_to_every_model_beneath_it(
+    tmp_path,
+) -> None:
+    release = tmp_path / "002501-dragon-set"
+    release.mkdir()
+    (release / "images").mkdir()
+    (release / "images" / "group.jpg").write_bytes(b"group")
+    make_folder(release / "knight", models=["knight.zip"], images=["knight.jpg"])
+    alexandria = FakeAlexandria()
+    [folder], _ = discover(tmp_path)
+
+    await FolderUploader(alexandria=alexandria, work_root=tmp_path / "work").upload(
+        folder
+    )
+
+    assert sorted(alexandria.appended) == ["group.jpg", "knight.jpg"]
+
+
+async def test_should_prefer_a_models_own_image_over_a_container_duplicate(
+    tmp_path,
+) -> None:
+    release = tmp_path / "002501-dragon-set"
+    release.mkdir()
+    (release / "images").mkdir()
+    (release / "images" / "render.jpg").write_bytes(b"container")
+    make_folder(release / "knight", models=["knight.zip"], images=["render.jpg"])
+    alexandria = FakeAlexandria()
+    [folder], _ = discover(tmp_path)
+
+    uploader = FolderUploader(alexandria=alexandria, work_root=tmp_path / "work")
+    assert [path.read_bytes() for path in uploader.image_paths(folder)] == [
+        b"render.jpg"
+    ]
+
+
+async def test_should_upload_a_split_set_as_multipart(tmp_path) -> None:
+    make_folder(
+        tmp_path / "002501-dragon", models=["dragon.part1.rar", "dragon.part2.rar"]
+    )
+    alexandria = FakeAlexandria()
+    [folder], _ = discover(tmp_path)
+
+    await FolderUploader(alexandria=alexandria, work_root=tmp_path / "work").upload(
+        folder
+    )
+
+    assert alexandria.uploads == [
+        ("dragon.part1.rar", True),
+        ("dragon.part2.rar", True),
+    ]
+
+
+async def test_should_move_a_folder_to_failed_when_upload_raises(tmp_path) -> None:
+    make_folder(tmp_path / "002501-dragon", models=["dragon.7z"])
+    alexandria = FakeAlexandria()
+    alexandria.fail_commit = True
+
+    uploader = FolderUploader(alexandria=alexandria, work_root=tmp_path / "work")
+    outcomes = await uploader.run(tmp_path)
+
+    assert outcomes["failed"] == 1
+    assert (tmp_path / "failed" / "002501-dragon").is_dir()
+    payload = json.loads(
+        (tmp_path / "failed" / "002501-dragon" / "metadata.json").read_text(
+            encoding="utf-8"
+        ),
+    )
+    assert "commit exploded" in payload["result"]["error"]
+
+
+async def test_should_move_an_ambiguous_folder_to_failed_without_uploading(
+    tmp_path,
+) -> None:
+    release = make_folder(tmp_path / "002501-dragon-set", models=["leftover.zip"])
+    make_folder(release / "knight", models=["knight.zip"])
+    alexandria = FakeAlexandria()
+
+    outcomes = await FolderUploader(
+        alexandria=alexandria, work_root=tmp_path / "work"
+    ).run(tmp_path)
+
+    assert outcomes["failed"] == 1
+    assert alexandria.uploads == []
+    assert (tmp_path / "failed" / "002501-dragon-set").is_dir()
+
+
+async def test_should_keep_going_after_one_folder_fails(tmp_path) -> None:
+    make_folder(tmp_path / "002501-broken", models=[])
+    make_folder(tmp_path / "002502-good", models=["good.7z"])
+    alexandria = FakeAlexandria()
+
+    outcomes = await FolderUploader(
+        alexandria=alexandria, work_root=tmp_path / "work"
+    ).run(tmp_path)
+
+    assert outcomes == {"completed": 1, "failed": 1}
+    assert (tmp_path / "uploaded" / "002502-good").is_dir()
+    assert (tmp_path / "failed" / "002501-broken").is_dir()

--- a/tools/telegram-importer/tests/test_folder_upload.py
+++ b/tools/telegram-importer/tests/test_folder_upload.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from alexandria_telegram_importer.folder_upload import discover
+
+
+def make_folder(path: Path, *, models=None, images=(), metadata=None) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    if models is not None:
+        (path / "models").mkdir(exist_ok=True)
+        for name in models:
+            (path / "models" / name).write_bytes(name.encode())
+    if images:
+        (path / "images").mkdir(exist_ok=True)
+        for name in images:
+            (path / "images" / name).write_bytes(name.encode())
+    if metadata is not None:
+        (path / "metadata.json").write_text(json.dumps(metadata), encoding="utf-8")
+    return path
+
+
+def test_should_discover_a_single_model_folder(tmp_path) -> None:
+    make_folder(tmp_path / "002501-dragon", models=["dragon.zip"])
+
+    found, ambiguous = discover(tmp_path)
+
+    assert [folder.path.name for folder in found] == ["002501-dragon"]
+    assert ambiguous == []
+
+
+def test_should_recurse_into_a_container_of_model_folders(tmp_path) -> None:
+    release = tmp_path / "002501-dragon-set"
+    release.mkdir()
+    make_folder(release / "knight", models=["knight.zip"])
+    make_folder(release / "mage", models=["mage.zip"])
+
+    found, ambiguous = discover(tmp_path)
+
+    assert sorted(folder.path.name for folder in found) == ["knight", "mage"]
+    assert ambiguous == []
+
+
+def test_should_flag_a_parent_that_has_both_models_and_child_model_folders(
+    tmp_path,
+) -> None:
+    release = make_folder(tmp_path / "002501-dragon-set", models=["leftover.zip"])
+    make_folder(release / "knight", models=["knight.zip"])
+
+    found, ambiguous = discover(tmp_path)
+
+    assert found == []
+    assert [path.name for path, _ in ambiguous] == ["002501-dragon-set"]
+    assert "models/" in ambiguous[0][1]
+
+
+def test_should_skip_the_uploaded_and_failed_directories(tmp_path) -> None:
+    make_folder(tmp_path / "pending", models=["a.zip"])
+    make_folder(tmp_path / "uploaded" / "done", models=["b.zip"])
+    make_folder(tmp_path / "failed" / "broken", models=["c.zip"])
+
+    found, ambiguous = discover(tmp_path)
+
+    assert [folder.path.name for folder in found] == ["pending"]
+    assert ambiguous == []
+
+
+def test_should_build_the_inheritance_chain_from_root_to_leaf(tmp_path) -> None:
+    release = tmp_path / "002501-dragon-set"
+    release.mkdir()
+    (release / "metadata.json").write_text(
+        json.dumps({"artist": "Foo Studios", "tags": ["dragon"]}), encoding="utf-8"
+    )
+    make_folder(
+        release / "knight", models=["knight.zip"], metadata={"modelName": "Knight"}
+    )
+
+    [folder], _ = discover(tmp_path)
+
+    assert folder.chain[0]["artist"] == "Foo Studios"
+    assert folder.chain[-1]["modelName"] == "Knight"
+    assert folder.metadata["artist"] == "Foo Studios"
+    assert folder.metadata["tags"] == ["dragon"]
+    assert folder.metadata["modelName"] == "Knight"
+
+
+def test_should_collect_container_image_directories(tmp_path) -> None:
+    release = tmp_path / "002501-dragon-set"
+    release.mkdir()
+    (release / "images").mkdir()
+    (release / "images" / "group.jpg").write_bytes(b"group")
+    make_folder(release / "knight", models=["knight.zip"], images=["knight.jpg"])
+
+    [folder], _ = discover(tmp_path)
+
+    assert [path.name for path in folder.container_image_dirs] == ["images"]
+    assert folder.container_image_dirs[0].parent.name == "002501-dragon-set"
+
+
+def test_should_name_a_model_from_its_folder_when_metadata_is_absent(tmp_path) -> None:
+    make_folder(tmp_path / "002501-dragon-knight", models=["a.zip"])
+
+    [folder], _ = discover(tmp_path)
+
+    assert folder.model_name == "dragon knight"
+
+
+def test_should_prefer_an_explicit_model_name_over_the_folder_name(tmp_path) -> None:
+    make_folder(
+        tmp_path / "002501-dragon", models=["a.zip"], metadata={"modelName": "Real Name"}
+    )
+
+    [folder], _ = discover(tmp_path)
+
+    assert folder.model_name == "Real Name"
+
+
+def test_should_ignore_a_directory_with_neither_models_nor_subfolders(tmp_path) -> None:
+    (tmp_path / "empty").mkdir()
+    (tmp_path / "empty" / "notes.txt").write_text("hello", encoding="utf-8")
+
+    found, ambiguous = discover(tmp_path)
+
+    assert found == []
+    assert ambiguous == []

--- a/tools/telegram-importer/tests/test_folder_upload.py
+++ b/tools/telegram-importer/tests/test_folder_upload.py
@@ -87,7 +87,8 @@ def test_should_build_the_inheritance_chain_from_root_to_leaf(tmp_path) -> None:
 
     [folder], _ = discover(tmp_path)
 
-    assert folder.chain[0]["artist"] == "Foo Studios"
+    # chain[0] is the staging root itself; the release folder follows it.
+    assert [level.get("artist") for level in folder.chain] == [None, "Foo Studios", None]
     assert folder.chain[-1]["modelName"] == "Knight"
     assert folder.metadata["artist"] == "Foo Studios"
     assert folder.metadata["tags"] == ["dragon"]
@@ -509,3 +510,94 @@ async def test_should_keep_going_after_one_folder_fails(tmp_path) -> None:
     assert outcomes == {"completed": 1, "failed": 1}
     assert (tmp_path / "uploaded" / "002502-good").is_dir()
     assert (tmp_path / "failed" / "002501-broken").is_dir()
+
+
+# --- Data-loss regressions ------------------------------------------------
+
+
+def test_should_not_prune_a_container_that_still_holds_unsplit_files(tmp_path) -> None:
+    """The half-finished split is the whole point of the pause; pruning it is data loss."""
+    release = tmp_path / "002501-release"
+    make_folder(release / "knight", models=["knight.7z"])
+    (release / "mage").mkdir()
+    (release / "mage" / "mage.part1.rar").write_bytes(b"unfinished split")
+    (release / "images").mkdir()
+    (release / "images" / "group.png").write_bytes(b"group render")
+
+    dispose(release / "knight", tmp_path, "uploaded", {"modelId": "m1"})
+
+    assert (release / "mage" / "mage.part1.rar").is_file()
+    assert (release / "images" / "group.png").is_file()
+
+
+def test_should_not_prune_a_container_holding_a_loose_archive(tmp_path) -> None:
+    release = tmp_path / "002501-release"
+    make_folder(release / "knight", models=["knight.7z"])
+    (release / "leftover.7z").write_bytes(b"loose archive")
+
+    dispose(release / "knight", tmp_path, "uploaded", {"modelId": "m1"})
+
+    assert (release / "leftover.7z").is_file()
+
+
+def test_should_still_prune_a_genuinely_empty_container(tmp_path) -> None:
+    release = tmp_path / "002501-release"
+    release.mkdir()
+    (release / "metadata.json").write_text("{}", encoding="utf-8")
+    make_folder(release / "knight", models=["knight.7z"])
+
+    dispose(release / "knight", tmp_path, "uploaded", {"modelId": "m1"})
+
+    assert not release.exists()
+
+
+def test_should_never_overwrite_a_metadata_file_it_could_not_parse(tmp_path) -> None:
+    folder = make_folder(tmp_path / "002501-dragon", models=["a.zip"])
+    original = '{"modelName": "Hand Typed", "artist": "Me",}'
+    (folder / "metadata.json").write_text(original, encoding="utf-8")
+
+    destination = dispose(folder, tmp_path, "failed", {"error": "bad json"})
+
+    assert (destination / "metadata.json").read_text(encoding="utf-8") == original
+    assert json.loads((destination / "result.json").read_text(encoding="utf-8")) == {
+        "error": "bad json",
+    }
+
+
+def test_should_fail_a_model_folder_whose_own_metadata_is_unparseable(tmp_path) -> None:
+    folder = make_folder(tmp_path / "002501-dragon", models=["a.zip"])
+    (folder / "metadata.json").write_text('{"modelName": "X",}', encoding="utf-8")
+
+    found, ambiguous = discover(tmp_path)
+
+    assert found == []
+    assert [path.name for path, _ in ambiguous] == ["002501-dragon"]
+    assert "metadata.json" in ambiguous[0][1]
+
+
+def test_should_merge_metadata_from_the_staging_root_downward(tmp_path) -> None:
+    (tmp_path / "metadata.json").write_text(
+        json.dumps({"artist": "Channel Artist", "tags": ["channel"]}), encoding="utf-8"
+    )
+    (tmp_path / "images").mkdir()
+    (tmp_path / "images" / "banner.png").write_bytes(b"banner")
+    make_folder(tmp_path / "002501-dragon", models=["a.zip"], images=["own.png"])
+
+    [folder], ambiguous = discover(tmp_path)
+
+    assert ambiguous == []
+    assert folder.metadata["artist"] == "Channel Artist"
+    assert folder.metadata["tags"] == ["channel"]
+    assert sorted(p.name for p in folder.image_dirs[0].iterdir()) == ["banner.png"]
+
+
+def test_should_not_walk_a_nested_directory_named_failed_or_uploaded(tmp_path) -> None:
+    release = tmp_path / "002501-release"
+    release.mkdir()
+    make_folder(release / "knight", models=["knight.7z"])
+    make_folder(release / "failed" / "old", models=["old.7z"])
+    make_folder(release / "uploaded" / "done", models=["done.7z"])
+
+    found, _ = discover(tmp_path)
+
+    assert [folder.path.name for folder in found] == ["knight"]

--- a/tools/telegram-importer/tests/test_folder_upload.py
+++ b/tools/telegram-importer/tests/test_folder_upload.py
@@ -1,9 +1,16 @@
 from __future__ import annotations
 
 import json
+import zipfile
 from pathlib import Path
 
-from alexandria_telegram_importer.folder_upload import discover
+import pytest
+
+from alexandria_telegram_importer.folder_upload import (
+    build_upload_paths,
+    discover,
+    plan_models_dir,
+)
 
 
 def make_folder(path: Path, *, models=None, images=(), metadata=None) -> Path:
@@ -124,3 +131,133 @@ def test_should_ignore_a_directory_with_neither_models_nor_subfolders(tmp_path) 
 
     assert found == []
     assert ambiguous == []
+
+
+def models_dir(tmp_path: Path, names, subdir_files=()) -> Path:
+    target = tmp_path / "models"
+    target.mkdir(parents=True, exist_ok=True)
+    for name in names:
+        (target / name).write_bytes(name.encode())
+    for relative in subdir_files:
+        path = target / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(relative.encode())
+    return target
+
+
+def test_should_upload_a_lone_archive_as_is(tmp_path) -> None:
+    plan = plan_models_dir(models_dir(tmp_path, ["dragon.7z"]))
+
+    assert plan.kind == "as_is"
+    assert [path.name for path in plan.paths] == ["dragon.7z"]
+
+
+def test_should_detect_a_rar_split_set_in_part_order(tmp_path) -> None:
+    plan = plan_models_dir(
+        models_dir(tmp_path, ["dragon.part2.rar", "dragon.part1.rar"]),
+    )
+
+    assert plan.kind == "split"
+    assert [path.name for path in plan.paths] == [
+        "dragon.part1.rar",
+        "dragon.part2.rar",
+    ]
+
+
+def test_should_detect_a_classic_zip_split_set(tmp_path) -> None:
+    plan = plan_models_dir(models_dir(tmp_path, ["dragon.z01", "dragon.zip"]))
+
+    assert plan.kind == "split"
+    assert [path.name for path in plan.paths] == ["dragon.z01", "dragon.zip"]
+
+
+def test_should_detect_a_numbered_zip_split_set(tmp_path) -> None:
+    plan = plan_models_dir(
+        models_dir(tmp_path, ["dragon.zip.001", "dragon.zip.002"]),
+    )
+
+    assert plan.kind == "split"
+
+
+def test_should_zip_an_incomplete_split_set_rather_than_guessing(tmp_path) -> None:
+    plan = plan_models_dir(
+        models_dir(tmp_path, ["dragon.part1.rar", "dragon.part3.rar"]),
+    )
+
+    assert plan.kind == "zip"
+
+
+def test_should_zip_a_set_that_mixes_two_base_names(tmp_path) -> None:
+    plan = plan_models_dir(
+        models_dir(tmp_path, ["dragon.part1.rar", "wizard.part2.rar"]),
+    )
+
+    assert plan.kind == "zip"
+
+
+def test_should_zip_an_archive_that_sits_beside_another_file(tmp_path) -> None:
+    plan = plan_models_dir(models_dir(tmp_path, ["dragon.7z", "readme.txt"]))
+
+    assert plan.kind == "zip"
+
+
+def test_should_zip_loose_model_files(tmp_path) -> None:
+    plan = plan_models_dir(models_dir(tmp_path, ["knight.stl", "base.stl"]))
+
+    assert plan.kind == "zip"
+
+
+def test_should_zip_a_lone_subdirectory(tmp_path) -> None:
+    plan = plan_models_dir(models_dir(tmp_path, [], subdir_files=["parts/knight.stl"]))
+
+    assert plan.kind == "zip"
+
+
+def test_should_reject_an_empty_or_missing_models_directory(tmp_path) -> None:
+    with pytest.raises(ValueError, match="empty"):
+        plan_models_dir(models_dir(tmp_path, []))
+
+    with pytest.raises(ValueError, match="missing"):
+        plan_models_dir(tmp_path / "absent")
+
+
+def test_should_build_a_zip_preserving_paths_relative_to_models(tmp_path) -> None:
+    source = models_dir(tmp_path, ["knight.stl"], subdir_files=["parts/base.stl"])
+    work = tmp_path / "work"
+    work.mkdir()
+
+    paths, multipart = build_upload_paths(
+        plan_models_dir(source), work, "Dragon Knight"
+    )
+
+    assert multipart is False
+    assert len(paths) == 1
+    assert paths[0].name == "Dragon Knight.zip"
+    with zipfile.ZipFile(paths[0]) as archive:
+        assert sorted(archive.namelist()) == ["knight.stl", "parts/base.stl"]
+
+
+def test_should_pass_an_as_is_archive_through_without_repacking(tmp_path) -> None:
+    source = models_dir(tmp_path, ["dragon.7z"])
+    work = tmp_path / "work"
+    work.mkdir()
+
+    paths, multipart = build_upload_paths(plan_models_dir(source), work, "Dragon")
+
+    assert multipart is False
+    assert paths == (source / "dragon.7z",)
+    assert paths[0].read_bytes() == b"dragon.7z"
+
+
+def test_should_report_a_split_set_as_multipart(tmp_path) -> None:
+    source = models_dir(tmp_path, ["dragon.part1.rar", "dragon.part2.rar"])
+    work = tmp_path / "work"
+    work.mkdir()
+
+    paths, multipart = build_upload_paths(plan_models_dir(source), work, "Dragon")
+
+    assert multipart is True
+    assert [path.name for path in paths] == [
+        "dragon.part1.rar",
+        "dragon.part2.rar",
+    ]

--- a/tools/telegram-importer/tests/test_folder_upload.py
+++ b/tools/telegram-importer/tests/test_folder_upload.py
@@ -9,6 +9,7 @@ import pytest
 from alexandria_telegram_importer.folder_upload import (
     build_upload_paths,
     discover,
+    dispose,
     plan_models_dir,
 )
 
@@ -261,3 +262,90 @@ def test_should_report_a_split_set_as_multipart(tmp_path) -> None:
         "dragon.part1.rar",
         "dragon.part2.rar",
     ]
+
+
+def test_should_move_a_successful_folder_under_uploaded_preserving_its_path(
+    tmp_path,
+) -> None:
+    release = tmp_path / "002501-dragon-set"
+    release.mkdir()
+    (release / "metadata.json").write_text(
+        json.dumps({"artist": "Foo"}), encoding="utf-8"
+    )
+    folder = make_folder(release / "knight", models=["knight.zip"])
+
+    destination = dispose(folder, tmp_path, "uploaded", {"modelId": "abc"})
+
+    assert destination == tmp_path / "uploaded" / "002501-dragon-set" / "knight"
+    assert (destination / "models" / "knight.zip").is_file()
+    assert not folder.exists()
+
+
+def test_should_copy_container_metadata_alongside_a_disposed_folder(tmp_path) -> None:
+    release = tmp_path / "002501-dragon-set"
+    release.mkdir()
+    (release / "metadata.json").write_text(
+        json.dumps({"artist": "Foo"}), encoding="utf-8"
+    )
+    make_folder(release / "knight", models=["knight.zip"])
+    make_folder(release / "mage", models=["mage.zip"])
+
+    dispose(release / "knight", tmp_path, "uploaded", {"modelId": "abc"})
+
+    copied = tmp_path / "uploaded" / "002501-dragon-set" / "metadata.json"
+    assert json.loads(copied.read_text(encoding="utf-8"))["artist"] == "Foo"
+    assert (release / "metadata.json").is_file()
+    assert (release / "mage").is_dir()
+
+
+def test_should_write_the_result_into_the_disposed_metadata(tmp_path) -> None:
+    folder = make_folder(
+        tmp_path / "002501-dragon", models=["a.zip"], metadata={"modelName": "Dragon"}
+    )
+
+    destination = dispose(folder, tmp_path, "uploaded", {"modelId": "abc"})
+    payload = json.loads((destination / "metadata.json").read_text(encoding="utf-8"))
+
+    assert payload["result"] == {"modelId": "abc"}
+    assert payload["modelName"] == "Dragon"
+
+
+def test_should_write_a_result_even_when_the_folder_had_no_metadata(tmp_path) -> None:
+    folder = make_folder(tmp_path / "002501-dragon", models=["a.zip"])
+
+    destination = dispose(folder, tmp_path, "failed", {"error": "boom"})
+    payload = json.loads((destination / "metadata.json").read_text(encoding="utf-8"))
+
+    assert payload["result"] == {"error": "boom"}
+
+
+def test_should_remove_a_container_left_with_no_model_folders(tmp_path) -> None:
+    release = tmp_path / "002501-dragon-set"
+    release.mkdir()
+    (release / "metadata.json").write_text(json.dumps({}), encoding="utf-8")
+    make_folder(release / "knight", models=["knight.zip"])
+
+    dispose(release / "knight", tmp_path, "uploaded", {"modelId": "abc"})
+
+    assert not release.exists()
+
+
+def test_should_keep_a_container_that_still_holds_model_folders(tmp_path) -> None:
+    release = tmp_path / "002501-dragon-set"
+    release.mkdir()
+    make_folder(release / "knight", models=["knight.zip"])
+    make_folder(release / "mage", models=["mage.zip"])
+
+    dispose(release / "knight", tmp_path, "uploaded", {"modelId": "abc"})
+
+    assert release.is_dir()
+    assert (release / "mage").is_dir()
+
+
+def test_should_suffix_a_disposal_that_collides_with_an_earlier_one(tmp_path) -> None:
+    (tmp_path / "uploaded" / "dragon").mkdir(parents=True)
+    folder = make_folder(tmp_path / "dragon", models=["a.zip"])
+
+    destination = dispose(folder, tmp_path, "uploaded", {"modelId": "abc"})
+
+    assert destination.name == "dragon-2"

--- a/tools/telegram-importer/tests/test_folder_upload.py
+++ b/tools/telegram-importer/tests/test_folder_upload.py
@@ -601,3 +601,40 @@ def test_should_not_walk_a_nested_directory_named_failed_or_uploaded(tmp_path) -
     found, _ = discover(tmp_path)
 
     assert [folder.path.name for folder in found] == ["knight"]
+
+
+async def test_should_append_images_in_one_batched_request(tmp_path) -> None:
+    make_folder(
+        tmp_path / "002501-dragon",
+        models=["a.7z"],
+        images=["one.jpg", "two.jpg", "three.jpg"],
+    )
+    alexandria = FakeAlexandria()
+    calls: list[int] = []
+    original = alexandria.append_files
+
+    async def counting(session_id, paths, upload_names):
+        calls.append(len(paths))
+        return await original(session_id, paths, upload_names)
+
+    alexandria.append_files = counting
+    [folder], _ = discover(tmp_path)
+
+    await FolderUploader(alexandria=alexandria, work_root=tmp_path / "w").upload(folder)
+
+    assert calls == [3]
+    assert sorted(alexandria.appended) == ["one.jpg", "three.jpg", "two.jpg"]
+
+
+def test_should_describe_what_a_dry_run_would_upload(tmp_path) -> None:
+    from alexandria_telegram_importer.folder_upload import describe_staging
+
+    make_folder(tmp_path / "002501-dragon", models=["dragon.7z"], images=["a.jpg"])
+    release = make_folder(tmp_path / "002502-broken", models=["x.zip"])
+    make_folder(release / "child", models=["y.zip"])
+
+    report = describe_staging(tmp_path)
+
+    assert "as_is  002501-dragon -> 'dragon' (1 image(s))" in report
+    assert "FAIL   002502-broken" in report
+    assert "1 model folder(s) would be uploaded" in report

--- a/tools/telegram-importer/tests/test_staging.py
+++ b/tools/telegram-importer/tests/test_staging.py
@@ -1,8 +1,19 @@
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
+import pytest
+
 from alexandria_telegram_importer.grouping import build_bundles
 from alexandria_telegram_importer.models import MediaKind
-from alexandria_telegram_importer.staging import bundle_folder_name, bundle_key
+from alexandria_telegram_importer.staging import (
+    BundleStager,
+    bundle_description,
+    bundle_folder_name,
+    bundle_key,
+    unique_child,
+)
 
 
 def test_should_produce_a_stable_bundle_key_regardless_of_discovery_order(
@@ -65,3 +76,144 @@ def test_should_fall_back_to_the_message_id_when_a_name_slugs_to_nothing(
     [bundle] = build_bundles(-100987654, [media_ref(7, "!!!.zip")])
 
     assert bundle_folder_name(bundle) == "000007"
+
+
+class FakeTelegram:
+    """Stands in for TelegramSource: writes a file named after the ref."""
+
+    def __init__(self, channel_id: int = -100987654, username: str | None = "chan"):
+        self.channel_id = channel_id
+        self.channel_username = username
+        self.downloaded: list[str] = []
+        self.fail_on: set[str] = set()
+
+    async def download(self, ref, directory, *, on_progress=None) -> Path:
+        if ref.filename in self.fail_on:
+            raise RuntimeError(f"boom: {ref.filename}")
+        directory.mkdir(parents=True, exist_ok=True)
+        target = directory / f"{ref.message_id}_{ref.filename}"
+        target.write_bytes(ref.filename.encode())
+        self.downloaded.append(ref.filename)
+        return target
+
+    def message_link(self, message_id: int) -> str | None:
+        if self.channel_username:
+            return f"https://t.me/{self.channel_username}/{message_id}"
+        return None
+
+
+def test_should_suffix_a_colliding_folder_name(tmp_path) -> None:
+    (tmp_path / "dragon").mkdir()
+    (tmp_path / "dragon-2").mkdir()
+
+    assert unique_child(tmp_path, "dragon").name == "dragon-3"
+    assert unique_child(tmp_path, "wizard").name == "wizard"
+
+
+async def test_should_stage_models_and_images_into_their_subfolders(
+    tmp_path, media_ref
+) -> None:
+    [bundle] = build_bundles(
+        -100987654,
+        [
+            media_ref(2499, "render.jpg", kind=MediaKind.ATTACHMENT),
+            media_ref(2501, "dragon-knight.zip"),
+            media_ref(2502, "dragon-mage.zip"),
+        ],
+    )
+    telegram = FakeTelegram()
+
+    folder = await BundleStager(telegram=telegram, root=tmp_path).stage(bundle)
+
+    assert folder.name == "002501-dragon-knight"
+    assert sorted(p.name for p in (folder / "models").iterdir()) == [
+        "dragon-knight.zip",
+        "dragon-mage.zip",
+    ]
+    assert [p.name for p in (folder / "images").iterdir()] == ["render.jpg"]
+    assert (folder / "models" / "dragon-knight.zip").read_bytes() == b"dragon-knight.zip"
+
+
+async def test_should_always_create_both_subfolders_even_when_empty(
+    tmp_path, media_ref
+) -> None:
+    [bundle] = build_bundles(-100987654, [media_ref(2501, "dragon.zip")])
+
+    folder = await BundleStager(telegram=FakeTelegram(), root=tmp_path).stage(bundle)
+
+    assert (folder / "models").is_dir()
+    assert (folder / "images").is_dir()
+
+
+async def test_should_write_metadata_with_source_provenance(tmp_path, media_ref) -> None:
+    [bundle] = build_bundles(
+        -100987654,
+        [
+            media_ref(2499, "render.jpg", kind=MediaKind.ATTACHMENT, caption="Dragons!"),
+            media_ref(2501, "dragon-knight.zip"),
+            media_ref(2502, "dragon-mage.zip"),
+        ],
+    )
+
+    folder = await BundleStager(telegram=FakeTelegram(), root=tmp_path).stage(bundle)
+    payload = json.loads((folder / "metadata.json").read_text(encoding="utf-8"))
+
+    assert payload["schemaVersion"] == 1
+    assert payload["modelName"] == "dragon knight"
+    assert "Dragons!" in payload["description"]
+    assert "https://t.me/chan/2501" in payload["description"]
+    assert payload["result"] is None
+    assert payload["source"]["channelId"] == -100987654
+    assert payload["source"]["modelMessageIds"] == [2501, 2502]
+    assert payload["source"]["attachmentMessageIds"] == [2499]
+    assert payload["source"]["bundleKey"] == bundle_key(-100987654, bundle)
+
+
+async def test_should_suffix_colliding_filenames_within_a_folder(
+    tmp_path, media_ref
+) -> None:
+    [bundle] = build_bundles(
+        -100987654,
+        [media_ref(2501, "dragon.zip"), media_ref(2502, "dragon.zip")],
+    )
+
+    folder = await BundleStager(telegram=FakeTelegram(), root=tmp_path).stage(bundle)
+
+    assert sorted(p.name for p in (folder / "models").iterdir()) == [
+        "dragon-2.zip",
+        "dragon.zip",
+    ]
+
+
+async def test_should_remove_the_partial_folder_when_staging_fails(
+    tmp_path, media_ref
+) -> None:
+    [bundle] = build_bundles(
+        -100987654,
+        [media_ref(2501, "dragon-knight.zip"), media_ref(2502, "dragon-mage.zip")],
+    )
+    telegram = FakeTelegram()
+    telegram.fail_on = {"dragon-mage.zip"}
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await BundleStager(telegram=telegram, root=tmp_path).stage(bundle)
+
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_should_compose_a_bundle_description_from_every_caption(media_ref) -> None:
+    [bundle] = build_bundles(
+        -100987654,
+        [
+            media_ref(2499, "a.jpg", kind=MediaKind.ATTACHMENT, caption="First"),
+            media_ref(2500, "b.jpg", kind=MediaKind.ATTACHMENT, caption="First"),
+            media_ref(2501, "dragon.zip", caption="Second"),
+        ],
+    )
+
+    description = bundle_description(FakeTelegram(), bundle)
+
+    assert description.count("First") == 1
+    assert "Second" in description
+    assert "model message(s): 2501" in description
+    assert description.endswith("https://t.me/chan/2501")

--- a/tools/telegram-importer/tests/test_staging.py
+++ b/tools/telegram-importer/tests/test_staging.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from alexandria_telegram_importer.grouping import build_bundles
+from alexandria_telegram_importer.models import MediaKind
+from alexandria_telegram_importer.staging import bundle_folder_name, bundle_key
+
+
+def test_should_produce_a_stable_bundle_key_regardless_of_discovery_order(
+    media_ref,
+) -> None:
+    forward = list(
+        build_bundles(
+            -100987654,
+            [media_ref(2501, "dragon-knight.zip"), media_ref(2502, "dragon-mage.zip")],
+        ),
+    )
+    reverse = list(
+        build_bundles(
+            -100987654,
+            [media_ref(2502, "dragon-mage.zip"), media_ref(2501, "dragon-knight.zip")],
+        ),
+    )
+
+    assert bundle_key(-100987654, forward[0]) == bundle_key(-100987654, reverse[0])
+
+
+def test_should_produce_different_bundle_keys_for_different_channels(media_ref) -> None:
+    [bundle] = build_bundles(-100987654, [media_ref(2501, "dragon.zip")])
+
+    assert bundle_key(-100987654, bundle) != bundle_key(-100111111, bundle)
+
+
+def test_should_not_collide_with_the_logical_model_key_for_the_same_messages(
+    media_ref,
+) -> None:
+    [bundle] = build_bundles(-100987654, [media_ref(2501, "dragon.zip")])
+
+    assert bundle_key(-100987654, bundle) != bundle.models[0].key
+
+
+def test_should_name_a_folder_from_the_first_message_id_and_first_model(
+    media_ref,
+) -> None:
+    [bundle] = build_bundles(
+        -100987654,
+        [
+            media_ref(2499, "render.jpg", kind=MediaKind.ATTACHMENT),
+            media_ref(2501, "Dragon_Knight Set.zip"),
+            media_ref(2502, "dragon-mage.zip"),
+        ],
+    )
+
+    assert bundle_folder_name(bundle) == "002501-dragon-knight-set"
+
+
+def test_should_slug_awkward_model_names_into_a_safe_folder_name(media_ref) -> None:
+    [bundle] = build_bundles(-100987654, [media_ref(7, "Dragon!!! (v2) [final].zip")])
+
+    assert bundle_folder_name(bundle) == "000007-dragon-v2-final"
+
+
+def test_should_fall_back_to_the_message_id_when_a_name_slugs_to_nothing(
+    media_ref,
+) -> None:
+    [bundle] = build_bundles(-100987654, [media_ref(7, "!!!.zip")])
+
+    assert bundle_folder_name(bundle) == "000007"

--- a/tools/telegram-importer/tests/test_tracker.py
+++ b/tools/telegram-importer/tests/test_tracker.py
@@ -294,3 +294,98 @@ def test_should_reject_duplicate_source_without_model(tmp_path) -> None:
             tracker.mark_duplicate("duplicate", invalid_original)
     finally:
         tracker.close()
+
+
+def test_should_record_and_read_back_a_staged_bundle(tmp_path) -> None:
+    tracker = ImportTracker(tmp_path / "state.sqlite3")
+    try:
+        tracker.record_staged(
+            bundle_key="abc123",
+            source_channel_id=-100987654,
+            folder_name="002501-dragon-set",
+            model_message_ids=(2501, 2502),
+        )
+
+        staged = tracker.get_staged("abc123")
+
+        assert staged is not None
+        assert staged.folder_name == "002501-dragon-set"
+        assert staged.model_message_ids == (2501, 2502)
+        assert staged.status == "downloaded"
+        assert staged.downloaded_at
+    finally:
+        tracker.close()
+
+
+def test_should_report_staged_keys_for_one_channel_only(tmp_path) -> None:
+    tracker = ImportTracker(tmp_path / "state.sqlite3")
+    try:
+        tracker.record_staged(
+            bundle_key="mine",
+            source_channel_id=-100987654,
+            folder_name="a",
+            model_message_ids=(1,),
+        )
+        tracker.record_staged(
+            bundle_key="theirs",
+            source_channel_id=-100111111,
+            folder_name="b",
+            model_message_ids=(2,),
+        )
+
+        assert tracker.staged_keys(-100987654) == {"mine"}
+    finally:
+        tracker.close()
+
+
+def test_should_treat_recording_the_same_bundle_twice_as_idempotent(tmp_path) -> None:
+    tracker = ImportTracker(tmp_path / "state.sqlite3")
+    try:
+        tracker.record_staged(
+            bundle_key="abc123",
+            source_channel_id=-100987654,
+            folder_name="first",
+            model_message_ids=(1,),
+        )
+        tracker.record_staged(
+            bundle_key="abc123",
+            source_channel_id=-100987654,
+            folder_name="second",
+            model_message_ids=(1,),
+        )
+
+        staged = tracker.get_staged("abc123")
+
+        assert staged is not None
+        assert staged.folder_name == "first"
+        assert tracker.staged_keys(-100987654) == {"abc123"}
+    finally:
+        tracker.close()
+
+
+def test_should_add_the_staged_bundles_table_to_an_existing_state_file(tmp_path) -> None:
+    path = tmp_path / "state.sqlite3"
+    legacy = sqlite3.connect(path)
+    legacy.execute(
+        "CREATE TABLE imports ("
+        "import_key TEXT PRIMARY KEY, source_channel_id INTEGER NOT NULL, "
+        "logical_filename TEXT NOT NULL, upload_filename TEXT NOT NULL, "
+        "model_message_ids TEXT NOT NULL, attachment_message_ids TEXT NOT NULL, "
+        "status TEXT NOT NULL, session_id TEXT, model_id TEXT, error TEXT, "
+        "created_at TEXT NOT NULL, updated_at TEXT NOT NULL)",
+    )
+    legacy.commit()
+    legacy.close()
+
+    tracker = ImportTracker(path)
+    try:
+        tracker.record_staged(
+            bundle_key="abc123",
+            source_channel_id=-100987654,
+            folder_name="002501-dragon-set",
+            model_message_ids=(2501,),
+        )
+
+        assert tracker.get_staged("abc123") is not None
+    finally:
+        tracker.close()


### PR DESCRIPTION
Splits the Telegram importer into a **download phase** that stages bundles as folders on disk and an **upload phase** that ingests folders into Alexandria, with an operator intervention window between them.

Addresses three things the direct path can't do: splitting a release that holds several distinct models, compressing archives yourself instead of download→compress→re-upload, and correcting names and metadata before commit rather than after.

## Commands

```bash
alexandria-telegram-import --download-only 20 --staging-dir ./work   # stage and exit
alexandria-telegram-import --upload-only --staging-dir ./work        # upload and exit
alexandria-telegram-import --stage 20 --staging-dir ./work           # both, pausing between
```

## Folder contract

One folder per *bundle*, since the images belong to the whole bundle rather than to the first model:

```
work/002501-dragon-set/
  metadata.json
  models/    every model medium, split parts intact
  images/    every attachment medium
```

A folder holding `models/` is a model folder; a folder holding only subfolders is a container and is recursed into. Splitting a release therefore just means moving archives into child folders and removing the empty parent `models/` — the split itself is the signal. A folder holding **both** is a half-finished split and is moved to `failed/` rather than silently committing the leftovers and dropping the rest.

`metadata.json` mirrors the commit endpoint's `batchMetadata` field for field. Values inherit from the outermost container down — set collection, artist, and tags once per release — except `modelName`, which never inherits, so eight models don't all commit as "Dragon Set". Container `images/` are appended to every model beneath, so ungrouped group renders still reach each model.

`models/` upload rules: one archive → uploaded byte for byte with no recompression (this is what makes a hand-made `.7z` worth creating); a complete split set → multipart `split`; anything else → zipped preserving relative paths.

Each model folder settles independently into `uploaded/` or `failed/`, preserving its path relative to the staging root, with the outcome written into its `metadata.json`.

## Deliberate: no deduplication on upload

The upload phase writes nothing to the `imports` table and computes no Telegram or content signatures. The folders are hand-curated and are uploaded as given.

The consequence is explicit: moving a folder back out of `uploaded/` and re-running `--upload-only` creates a second model. This follows directly from the phases sharing no state, which is what allows folders to be split, merged, renamed, and recompressed freely between them.

## Scope

`importer.py` / `ChannelImporter` are **not** modified — the direct-import path keeps its dedupe, session-recovery, and signature-gate semantics. `test_importer.py`, `test_concurrency.py`, and `test_alexandria.py` have zero diff against `main`, including across the one signature change (`AlexandriaClient.commit` now accepts optional `batch_metadata`; its existing callers are unaffected).

New modules: `folder_metadata.py`, `staging.py`, `folder_upload.py`. 232 Python tests pass.

Spec: `docs/superpowers/specs/2026-07-25-telegram-staged-import-design.md`
Plan: `docs/superpowers/plans/2026-07-25-telegram-staged-import.md`

## Not included

The backend `metadata.json` prefill (spec §5) is independently shippable and has its own plan at `docs/superpowers/plans/2026-07-25-alexandria-metadata-json-prefill.md`. The importer doesn't depend on it — it sends `batchMetadata` explicitly at commit, which is what lets an upload-as-is `.7z` carry its metadata.

## Note

`apps/frontend` has one failing test (`FileTree > explains the limit when more than 500 files are selected`). It fails on `main` too and is unrelated — this PR changes zero TypeScript.

🤖 Generated with [Claude Code](https://claude.com/claude-code)