### PR TITLE
fix: zip complete staged Telegram folders

### DIFF
--- a/docs/superpowers/specs/2026-07-25-telegram-staged-import-design.md
+++ b/docs/superpowers/specs/2026-07-25-telegram-staged-import-design.md
@@ -241,21 +241,13 @@ and tags once, and each child folder needs at most its own name.
 ### Per-folder upload
 
 1. Resolve effective metadata by merging the inheritance chain.
-2. Classify `models/`:
-   - `models/` holds **exactly one entry** and it is an archive file
-     (`.zip`, `.rar`, `.7z`, `.tar.gz`, `.tgz`) → upload as-is, byte for byte. No
-     recompression — this is what makes a hand-made `.7z` worth creating.
-   - **Every** entry is a member of one recognized split set (`.partN.rar`,
-     `.zNN` + `.zip`, `.zip.NNN`) → multipart `split` upload, reusing the existing
-     part-role detection in `grouping.py`. A set that is incomplete or mixes two
-     different base names falls through to the zip case rather than being guessed at.
-   - Anything else — several files, loose model files, subdirectories, one archive
-     alongside a stray `readme.txt` → zipped with `ZIP_DEFLATED` into one archive
-     preserving paths relative to `models/`.
-   - Empty or missing → error, folder moves to `failed/`.
-3. Upload → wait for `ready_for_review`.
-4. Append every file in `images/` as attachments, plus every file in each ancestor
-   container's `images/` (see below). Batched at 100 as the direct path does.
+2. Require a non-empty `models/` directory; an empty or missing one moves the folder to
+   `failed/`.
+3. Compress the entire model folder with `ZIP_DEFLATED`, preserving the model-folder
+   directory and all of its contents, including `models/`, `images/`, and
+   `metadata.json` when present. Inherited container images are included under the
+   model folder's `images/` directory.
+4. Upload the ZIP → wait for `ready_for_review`.
 5. Commit with `batchMetadata` built from the effective metadata.
 6. Wait for `committed`.
 
@@ -264,8 +256,9 @@ continues with the remaining folders. `--concurrency` applies across model folde
 
 ### Container images
 
-Files in a container's `images/` directory are appended to **every** model folder beneath
-it, in addition to that folder's own images. The case this serves: a release has ten
+Files in a container's `images/` directory are included in the ZIP for **every** model
+folder beneath it, under that model folder's `images/` directory in addition to its own
+images. The case this serves: a release has ten
 renders, three belong to the knight, three to the mage, and four are group shots that
 belong to no single model. Distribute the six, leave the four, and every model gets the
 group renders.
@@ -368,9 +361,10 @@ the staged flow explicitly does not want.
 - Discovery: model folder, container, nested container, ambiguous parent → `failed/`.
 - Inheritance: scalar override, tag merge, per-key `metadata` merge, `modelName` not
   inheriting, missing child `metadata.json` falling back to the folder name.
-- Classification: single archive uploaded as-is (byte-identical), split set detected as
-  multipart, loose files zipped with relative paths preserved, empty `models/` failing.
-- Container `images/` appended to every descendant; name collision favours the model's own.
+- Complete model-folder ZIP: `models/`, `images/`, and folder metadata are all present;
+  empty `models/` fails.
+- Container `images/` are included in every descendant ZIP; name collision favours the
+  model's own.
 - Disposal: relative path preserved, container `metadata.json` copied, emptied container
   removed, collision suffixing, `result` written in both directions.
 - A folder with no `metadata.json` uploads with a folder-derived name.
@@ -391,7 +385,7 @@ the staged flow explicitly does not want.
 |---|---|
 | One staged folder per bundle, not per logical model | The bundle is what shares images. Per-model staging re-creates the mis-grouping the feature exists to fix. |
 | `models/` and `images/` subfolders | Unambiguous after hand-renaming and recompression; no extension guessing at upload time. |
-| Single archive uploaded as-is | Re-wrapping a hand-made `.7z` in a zip wastes the compression work that motivated the pause. |
+| Complete model folder uploaded as one ZIP | Alexandria receives the curated `models/` and `images/` structure together, rather than a model-only archive plus separate attachments. |
 | Phases share no state | Folders will be split, merged, and renamed between them, so any download→upload correspondence would be wrong more often than right. |
 | No dedupe on upload | Follows from the above. Hand-curated input is trusted. |
 | Container metadata inherits, `modelName` does not | Set collection/artist/tags once per release; never commit eight models under one name. |

--- a/docs/superpowers/specs/2026-07-25-telegram-staged-import-design.md
+++ b/docs/superpowers/specs/2026-07-25-telegram-staged-import-design.md
@@ -243,10 +243,10 @@ and tags once, and each child folder needs at most its own name.
 1. Resolve effective metadata by merging the inheritance chain.
 2. Require a non-empty `models/` directory; an empty or missing one moves the folder to
    `failed/`.
-3. Compress the entire model folder with `ZIP_DEFLATED`, preserving the model-folder
-   directory and all of its contents, including `models/`, `images/`, and
-   `metadata.json` when present. Inherited container images are included under the
-   model folder's `images/` directory.
+3. Compress the entire model folder with `ZIP_DEFLATED`, preserving its `models/`,
+   `images/`, and `metadata.json` contents at the archive root. This lets Alexandria
+   detect `metadata.json` and prefill the pending review session. Inherited container
+   images are included under the model folder's `images/` directory.
 4. Upload the ZIP → wait for `ready_for_review`.
 5. Commit with `batchMetadata` built from the effective metadata.
 6. Wait for `committed`.

--- a/tools/telegram-importer/README.md
+++ b/tools/telegram-importer/README.md
@@ -136,11 +136,12 @@ A folder holding **both** its own `models/` and a descendant model folder is a h
 
 ### How a staged folder is uploaded
 
-Each model folder is compressed into one ZIP before upload. The ZIP preserves the model
-folder itself and its contents — including `models/`, `images/`, and `metadata.json` when
-present — rather than uploading only the model archive and appending images afterward.
-Container images inherited by a child model are included under that child's `images/`
-directory. Empty or missing `models/` directories move the folder to `failed/`.
+Each model folder is compressed into one ZIP before upload. The ZIP preserves its
+`models/`, `images/`, and `metadata.json` contents at the archive root, rather than
+uploading only the model archive and appending images afterward. This lets Alexandria read
+`metadata.json` during scanning and prefill the pending review session. Container images
+inherited by a child model are included under that child's `images/` directory. Empty or
+missing `models/` directories move the folder to `failed/`.
 
 ### metadata.json
 

--- a/tools/telegram-importer/README.md
+++ b/tools/telegram-importer/README.md
@@ -134,14 +134,13 @@ work/002501-dragon-set/
 
 A folder holding **both** its own `models/` and a descendant model folder is a half-finished split. It is moved to `failed/` without uploading, because committing the leftovers would silently drop everything already moved into the children.
 
-### How models/ is uploaded
+### How a staged folder is uploaded
 
-- Exactly one entry, and it is an archive (`.zip`, `.rar`, `.7z`, `.tar.gz`, `.tgz`) — uploaded byte for byte, with no recompression. This is what makes a hand-made `.7z` worth creating.
-- Every entry a member of one complete split set (`.partN.rar`, `.zNN` plus `.zip`, `.zip.NNN`) — uploaded through the multipart `split` endpoints. An incomplete set, or one mixing two base names, falls through to the zip case rather than being guessed at.
-- Anything else — several files, loose model files, subfolders, an archive sitting beside a stray `readme.txt` — zipped into one archive preserving paths relative to `models/`.
-- Empty or missing — the folder moves to `failed/`.
-
-Every file in `images/` is appended as an attachment after the scan reaches `ready_for_review`.
+Each model folder is compressed into one ZIP before upload. The ZIP preserves the model
+folder itself and its contents — including `models/`, `images/`, and `metadata.json` when
+present — rather than uploading only the model archive and appending images afterward.
+Container images inherited by a child model are included under that child's `images/`
+directory. Empty or missing `models/` directories move the folder to `failed/`.
 
 ### metadata.json
 

--- a/tools/telegram-importer/src/alexandria_telegram_importer/folder_upload.py
+++ b/tools/telegram-importer/src/alexandria_telegram_importer/folder_upload.py
@@ -151,10 +151,11 @@ def build_folder_archive(
 ) -> Path:
     """Create one ZIP of the complete staged model folder.
 
-    Alexandria receives the operator's curated folder as one archive, rather
-    than a models-only upload followed by separate image attachments. Inherited
-    container images are placed under the model folder's `images/` directory,
-    preserving the staged flow's existing image inheritance behavior.
+    Alexandria receives the operator's curated folder contents as one archive,
+    rather than a models-only upload followed by separate image attachments.
+    Keeping metadata.json at the archive root lets Alexandria prefill the
+    pending review session. Inherited container images are placed under the
+    model folder's `images/` directory, preserving existing image inheritance.
     """
     if not folder.models_dir.is_dir():
         raise ValueError(f"{folder.models_dir} is missing")
@@ -163,12 +164,12 @@ def build_folder_archive(
 
     archive_path = work_dir / f"{safe_filename(model_name, 'model')}.zip"
     members = {
-        str(path.relative_to(folder.path.parent)): path
+        str(path.relative_to(folder.path)): path
         for path in sorted(folder.path.rglob("*"))
         if path.is_file()
     }
     for image in images:
-        members[str(Path(folder.path.name) / IMAGES_DIRNAME / image.name)] = image
+        members[str(Path(IMAGES_DIRNAME) / image.name)] = image
 
     with zipfile.ZipFile(archive_path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
         for name, path in sorted(members.items()):

--- a/tools/telegram-importer/src/alexandria_telegram_importer/folder_upload.py
+++ b/tools/telegram-importer/src/alexandria_telegram_importer/folder_upload.py
@@ -12,7 +12,6 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-from .alexandria import session_filenames
 from .folder_metadata import (
     METADATA_FILENAME,
     batch_metadata,
@@ -22,14 +21,7 @@ from .folder_metadata import (
     read_metadata,
     write_metadata,
 )
-from .grouping import (
-    ARCHIVE_EXTENSIONS,
-    multipart_part_role,
-    partition_logical_models,
-    safe_filename,
-    validate_logical_model,
-)
-from .models import MediaKind, MediaRef
+from .grouping import safe_filename
 from .progress import (
     ModelProgress,
     NullModelProgress,
@@ -151,88 +143,37 @@ def _visit(
         _visit(child, chain, image_dirs, found, ambiguous)
 
 
-@dataclass(frozen=True, slots=True)
-class ModelsPlan:
-    kind: str  # "as_is" | "split" | "zip"
-    paths: tuple[Path, ...]
+def build_folder_archive(
+    folder: ModelFolder,
+    images: tuple[Path, ...],
+    work_dir: Path,
+    model_name: str,
+) -> Path:
+    """Create one ZIP of the complete staged model folder.
 
-
-def _is_split_member(filename: str) -> bool:
-    try:
-        multipart_part_role(filename)
-    except ValueError:
-        return False
-    return True
-
-
-def _split_order(entries: list[Path]) -> tuple[Path, ...] | None:
-    """Return the entries when they form one complete split set, else None.
-
-    Reuses grouping's part detection and validation so the importer and the
-    staged flow agree on what a complete set is. Order is not meaningful:
-    FileProcessingService.processSplitArchive reassembles by filename, not by
-    upload order, so the entries are returned as given.
+    Alexandria receives the operator's curated folder as one archive, rather
+    than a models-only upload followed by separate image attachments. Inherited
+    container images are placed under the model folder's `images/` directory,
+    preserving the staged flow's existing image inheritance behavior.
     """
-    if len(entries) < 2 or not all(entry.is_file() for entry in entries):
-        return None
-    if not all(_is_split_member(entry.name) for entry in entries):
-        return None
-    refs = [
-        MediaRef(message_id=index, filename=entry.name, kind=MediaKind.MODEL)
-        for index, entry in enumerate(entries)
-    ]
-    units = partition_logical_models(0, refs)
-    if len(units) != 1 or not units[0].multipart:
-        return None
-    try:
-        validate_logical_model(units[0])
-    except ValueError as error:
-        log.info("Not treating %s as a split set: %s", entries[0].parent, error)
-        return None
-    return tuple(entries)
+    if not folder.models_dir.is_dir():
+        raise ValueError(f"{folder.models_dir} is missing")
+    if not any(folder.models_dir.iterdir()):
+        raise ValueError(f"{folder.models_dir} is empty")
 
-
-def plan_models_dir(models_dir: Path) -> ModelsPlan:
-    if not models_dir.is_dir():
-        raise ValueError(f"{models_dir} is missing")
-    entries = sorted(models_dir.iterdir())
-    if not entries:
-        raise ValueError(f"{models_dir} is empty")
-
-    only = entries[0]
-    if (
-        len(entries) == 1
-        and only.is_file()
-        and only.name.lower().endswith(ARCHIVE_EXTENSIONS)
-    ):
-        return ModelsPlan(kind="as_is", paths=(only,))
-
-    if ordered := _split_order(entries):
-        return ModelsPlan(kind="split", paths=ordered)
-
-    return ModelsPlan(kind="zip", paths=tuple(entries))
-
-
-def build_upload_paths(
-    plan: ModelsPlan, work_dir: Path, model_name: str
-) -> tuple[tuple[Path, ...], bool]:
-    """Resolve a plan into paths to upload and whether they are a split set.
-
-    An `as_is` or `split` plan uploads the operator's own files untouched —
-    that is what makes hand-made compression worth doing.
-    """
-    if plan.kind == "as_is":
-        return plan.paths, False
-    if plan.kind == "split":
-        return plan.paths, True
-
-    models_dir = plan.paths[0].parent
     archive_path = work_dir / f"{safe_filename(model_name, 'model')}.zip"
+    members = {
+        str(path.relative_to(folder.path.parent)): path
+        for path in sorted(folder.path.rglob("*"))
+        if path.is_file()
+    }
+    for image in images:
+        members[str(Path(folder.path.name) / IMAGES_DIRNAME / image.name)] = image
+
     with zipfile.ZipFile(archive_path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
-        for path in sorted(models_dir.rglob("*")):
-            if path.is_file():
-                archive.write(path, arcname=str(path.relative_to(models_dir)))
-    return (archive_path,), False
+        for name, path in sorted(members.items()):
+            archive.write(path, arcname=name)
+    return archive_path
 
 
 def dispose(
@@ -299,9 +240,6 @@ def _prune_empty_containers(directory: Path, root: Path) -> None:
             log.warning("Could not remove emptied container %s: %s", directory, error)
             return
         directory = directory.parent
-
-
-ATTACHMENT_BATCH_SIZE = 100
 
 
 def _uploaded_at() -> dict[str, str]:
@@ -425,30 +363,29 @@ class FolderUploader:
         with tempfile.TemporaryDirectory(
             prefix="alexandria-folder-", dir=self.work_root
         ) as temp:
-            plan = plan_models_dir(folder.models_dir)
-            if plan.kind == "zip":
-                handle.phase("packaging")
+            handle.phase("packaging")
             # Zipping an arbitrary tree can take minutes; off-thread so it does
             # not stall sibling transfers and their progress at --concurrency > 1.
-            paths, multipart = await asyncio.to_thread(
-                build_upload_paths, plan, Path(temp), payload["modelName"]
+            archive_path = await asyncio.to_thread(
+                build_folder_archive,
+                folder,
+                self.image_paths(folder),
+                Path(temp),
+                payload["modelName"],
             )
 
             upload_ids: list[str] = []
             try:
-                for path in paths:
-                    with handle.transfer("upload", path.name) as transfer:
-                        upload_ids.append(
-                            await self.alexandria.upload_file(
-                                path,
-                                path.name,
-                                multipart=multipart,
-                                on_progress=transfer.advance,
-                            ),
-                        )
-                session_id = await self.alexandria.complete_upload(
-                    upload_ids, multipart=multipart
-                )
+                with handle.transfer("upload", archive_path.name) as transfer:
+                    upload_ids.append(
+                        await self.alexandria.upload_file(
+                            archive_path,
+                            archive_path.name,
+                            multipart=False,
+                            on_progress=transfer.advance,
+                        ),
+                    )
+                session_id = await self.alexandria.complete_upload(upload_ids, multipart=False)
             except Exception:
                 await self.alexandria.abort_uploads(upload_ids)
                 raise
@@ -462,8 +399,6 @@ class FolderUploader:
             if session["status"] == "error":
                 raise RuntimeError(session.get("error") or "Alexandria ingestion failed")
 
-            await self._append_images(folder, session_id, session, handle)
-
             handle.phase("committing")
             await self.alexandria.commit(
                 session_id,
@@ -476,30 +411,6 @@ class FolderUploader:
                 raise RuntimeError(committed.get("error") or "Alexandria commit failed")
             return committed["modelId"]
 
-    async def _append_images(
-        self,
-        folder: ModelFolder,
-        session_id: str,
-        session: dict[str, Any],
-        handle: ModelProgress,
-    ) -> None:
-        present = session_filenames(session)
-        pending = tuple(
-            path for path in self.image_paths(folder) if path.name not in present
-        )
-        if not pending:
-            return
-        handle.phase("attachments")
-        done = 0
-        handle.attachments(done, len(pending))
-        for offset in range(0, len(pending), ATTACHMENT_BATCH_SIZE):
-            batch = pending[offset : offset + ATTACHMENT_BATCH_SIZE]
-            await self.alexandria.append_files(
-                session_id, batch, tuple(path.name for path in batch)
-            )
-            done += len(batch)
-            handle.attachments(done, len(pending))
-
 
 def describe_staging(root: Path) -> str:
     """Dry-run report for the upload phase: what would be uploaded, and how."""
@@ -507,7 +418,10 @@ def describe_staging(root: Path) -> str:
     lines: list[str] = []
     for folder in found:
         try:
-            kind = plan_models_dir(folder.models_dir).kind
+            if not folder.models_dir.is_dir():
+                raise ValueError(f"{folder.models_dir} is missing")
+            if not any(folder.models_dir.iterdir()):
+                raise ValueError(f"{folder.models_dir} is empty")
         except ValueError as error:
             lines.append(f"  SKIP  {folder.path.relative_to(root)}: {error}")
             continue
@@ -516,7 +430,7 @@ def describe_staging(root: Path) -> str:
             if item.is_file()
         )
         lines.append(
-            f"  {kind:<6} {folder.path.relative_to(root)} "
+            f"  zip    {folder.path.relative_to(root)} "
             f"-> {folder.model_name!r} ({images} image(s))"
         )
     for path, reason in ambiguous:

--- a/tools/telegram-importer/tests/test_folder_upload.py
+++ b/tools/telegram-importer/tests/test_folder_upload.py
@@ -154,10 +154,10 @@ def test_should_build_a_zip_of_the_complete_model_folder(tmp_path) -> None:
     assert archive_path.name == "Dragon.zip"
     with zipfile.ZipFile(archive_path) as archive:
         assert sorted(archive.namelist()) == [
-            "002501-dragon/images/render.jpg",
-            "002501-dragon/metadata.json",
-            "002501-dragon/models/dragon.7z",
-            "002501-dragon/models/parts/base.stl",
+            "images/render.jpg",
+            "metadata.json",
+            "models/dragon.7z",
+            "models/parts/base.stl",
         ]
 
 
@@ -176,9 +176,9 @@ def test_should_add_inherited_images_to_the_model_folder_archive(tmp_path) -> No
 
     with zipfile.ZipFile(archive_path) as archive:
         assert sorted(archive.namelist()) == [
-            "knight/images/group.jpg",
-            "knight/images/knight.jpg",
-            "knight/models/knight.7z",
+            "images/group.jpg",
+            "images/knight.jpg",
+            "models/knight.7z",
         ]
 
 
@@ -342,9 +342,9 @@ async def test_should_upload_a_folder_and_return_its_model_id(tmp_path) -> None:
         (
             "Dragon.zip",
             [
-                "002501-dragon/images/render.jpg",
-                "002501-dragon/metadata.json",
-                "002501-dragon/models/dragon.7z",
+                "images/render.jpg",
+                "metadata.json",
+                "models/dragon.7z",
             ],
         ),
     ]
@@ -373,9 +373,9 @@ async def test_should_include_container_images_in_every_descendant_folder_archiv
         (
             "knight.zip",
             [
-                "knight/images/group.jpg",
-                "knight/images/knight.jpg",
-                "knight/models/knight.zip",
+                "images/group.jpg",
+                "images/knight.jpg",
+                "models/knight.zip",
             ],
         ),
     ]
@@ -414,8 +414,8 @@ async def test_should_zip_split_archives_with_the_rest_of_the_folder(tmp_path) -
         (
             "dragon.zip",
             [
-                "002501-dragon/models/dragon.part1.rar",
-                "002501-dragon/models/dragon.part2.rar",
+                "models/dragon.part1.rar",
+                "models/dragon.part2.rar",
             ],
         ),
     ]

--- a/tools/telegram-importer/tests/test_folder_upload.py
+++ b/tools/telegram-importer/tests/test_folder_upload.py
@@ -8,10 +8,10 @@ import pytest
 
 from alexandria_telegram_importer.folder_upload import (
     FolderUploader,
-    build_upload_paths,
+    ModelFolder,
+    build_folder_archive,
     discover,
     dispose,
-    plan_models_dir,
 )
 
 
@@ -136,134 +136,63 @@ def test_should_ignore_a_directory_with_neither_models_nor_subfolders(tmp_path) 
     assert ambiguous == []
 
 
-def models_dir(tmp_path: Path, names, subdir_files=()) -> Path:
-    target = tmp_path / "models"
-    target.mkdir(parents=True, exist_ok=True)
-    for name in names:
-        (target / name).write_bytes(name.encode())
-    for relative in subdir_files:
-        path = target / relative
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_bytes(relative.encode())
-    return target
+def test_should_build_a_zip_of_the_complete_model_folder(tmp_path) -> None:
+    folder_path = make_folder(
+        tmp_path / "002501-dragon",
+        models=["dragon.7z"],
+        images=["render.jpg"],
+        metadata={"modelName": "Dragon"},
+    )
+    (folder_path / "models" / "parts").mkdir()
+    (folder_path / "models" / "parts" / "base.stl").write_bytes(b"base")
+    [folder], _ = discover(tmp_path)
+    work = tmp_path / "work"
+    work.mkdir()
+
+    archive_path = build_folder_archive(folder, (), work, "Dragon")
+
+    assert archive_path.name == "Dragon.zip"
+    with zipfile.ZipFile(archive_path) as archive:
+        assert sorted(archive.namelist()) == [
+            "002501-dragon/images/render.jpg",
+            "002501-dragon/metadata.json",
+            "002501-dragon/models/dragon.7z",
+            "002501-dragon/models/parts/base.stl",
+        ]
 
 
-def test_should_upload_a_lone_archive_as_is(tmp_path) -> None:
-    plan = plan_models_dir(models_dir(tmp_path, ["dragon.7z"]))
+def test_should_add_inherited_images_to_the_model_folder_archive(tmp_path) -> None:
+    release = tmp_path / "release"
+    (release / "images").mkdir(parents=True)
+    (release / "images" / "group.jpg").write_bytes(b"group")
+    make_folder(release / "knight", models=["knight.7z"], images=["knight.jpg"])
+    [folder], _ = discover(tmp_path)
+    uploader = FolderUploader(alexandria=None, work_root=tmp_path / "work")
+    (tmp_path / "work").mkdir()
 
-    assert plan.kind == "as_is"
-    assert [path.name for path in plan.paths] == ["dragon.7z"]
-
-
-def test_should_detect_a_rar_split_set_in_part_order(tmp_path) -> None:
-    plan = plan_models_dir(
-        models_dir(tmp_path, ["dragon.part2.rar", "dragon.part1.rar"]),
+    archive_path = build_folder_archive(
+        folder, uploader.image_paths(folder), tmp_path / "work", "Knight"
     )
 
-    assert plan.kind == "split"
-    assert [path.name for path in plan.paths] == [
-        "dragon.part1.rar",
-        "dragon.part2.rar",
-    ]
-
-
-def test_should_detect_a_classic_zip_split_set(tmp_path) -> None:
-    plan = plan_models_dir(models_dir(tmp_path, ["dragon.z01", "dragon.zip"]))
-
-    assert plan.kind == "split"
-    assert [path.name for path in plan.paths] == ["dragon.z01", "dragon.zip"]
-
-
-def test_should_detect_a_numbered_zip_split_set(tmp_path) -> None:
-    plan = plan_models_dir(
-        models_dir(tmp_path, ["dragon.zip.001", "dragon.zip.002"]),
-    )
-
-    assert plan.kind == "split"
-
-
-def test_should_zip_an_incomplete_split_set_rather_than_guessing(tmp_path) -> None:
-    plan = plan_models_dir(
-        models_dir(tmp_path, ["dragon.part1.rar", "dragon.part3.rar"]),
-    )
-
-    assert plan.kind == "zip"
-
-
-def test_should_zip_a_set_that_mixes_two_base_names(tmp_path) -> None:
-    plan = plan_models_dir(
-        models_dir(tmp_path, ["dragon.part1.rar", "wizard.part2.rar"]),
-    )
-
-    assert plan.kind == "zip"
-
-
-def test_should_zip_an_archive_that_sits_beside_another_file(tmp_path) -> None:
-    plan = plan_models_dir(models_dir(tmp_path, ["dragon.7z", "readme.txt"]))
-
-    assert plan.kind == "zip"
-
-
-def test_should_zip_loose_model_files(tmp_path) -> None:
-    plan = plan_models_dir(models_dir(tmp_path, ["knight.stl", "base.stl"]))
-
-    assert plan.kind == "zip"
-
-
-def test_should_zip_a_lone_subdirectory(tmp_path) -> None:
-    plan = plan_models_dir(models_dir(tmp_path, [], subdir_files=["parts/knight.stl"]))
-
-    assert plan.kind == "zip"
+    with zipfile.ZipFile(archive_path) as archive:
+        assert sorted(archive.namelist()) == [
+            "knight/images/group.jpg",
+            "knight/images/knight.jpg",
+            "knight/models/knight.7z",
+        ]
 
 
 def test_should_reject_an_empty_or_missing_models_directory(tmp_path) -> None:
-    with pytest.raises(ValueError, match="empty"):
-        plan_models_dir(models_dir(tmp_path, []))
+    missing = tmp_path / "missing"
+    missing.mkdir()
+    empty = make_folder(tmp_path / "empty", models=[])
+    work = tmp_path / "work"
+    work.mkdir()
 
     with pytest.raises(ValueError, match="missing"):
-        plan_models_dir(tmp_path / "absent")
-
-
-def test_should_build_a_zip_preserving_paths_relative_to_models(tmp_path) -> None:
-    source = models_dir(tmp_path, ["knight.stl"], subdir_files=["parts/base.stl"])
-    work = tmp_path / "work"
-    work.mkdir()
-
-    paths, multipart = build_upload_paths(
-        plan_models_dir(source), work, "Dragon Knight"
-    )
-
-    assert multipart is False
-    assert len(paths) == 1
-    assert paths[0].name == "Dragon Knight.zip"
-    with zipfile.ZipFile(paths[0]) as archive:
-        assert sorted(archive.namelist()) == ["knight.stl", "parts/base.stl"]
-
-
-def test_should_pass_an_as_is_archive_through_without_repacking(tmp_path) -> None:
-    source = models_dir(tmp_path, ["dragon.7z"])
-    work = tmp_path / "work"
-    work.mkdir()
-
-    paths, multipart = build_upload_paths(plan_models_dir(source), work, "Dragon")
-
-    assert multipart is False
-    assert paths == (source / "dragon.7z",)
-    assert paths[0].read_bytes() == b"dragon.7z"
-
-
-def test_should_report_a_split_set_as_multipart(tmp_path) -> None:
-    source = models_dir(tmp_path, ["dragon.part1.rar", "dragon.part2.rar"])
-    work = tmp_path / "work"
-    work.mkdir()
-
-    paths, multipart = build_upload_paths(plan_models_dir(source), work, "Dragon")
-
-    assert multipart is True
-    assert [path.name for path in paths] == [
-        "dragon.part1.rar",
-        "dragon.part2.rar",
-    ]
+        build_folder_archive(ModelFolder(missing, (), ()), (), work, "Missing")
+    with pytest.raises(ValueError, match="empty"):
+        build_folder_archive(ModelFolder(empty, (), ()), (), work, "Empty")
 
 
 def test_should_move_a_successful_folder_under_uploaded_preserving_its_path(
@@ -356,6 +285,7 @@ def test_should_suffix_a_disposal_that_collides_with_an_earlier_one(tmp_path) ->
 class FakeAlexandria:
     def __init__(self) -> None:
         self.uploads: list[tuple[str, bool]] = []
+        self.archives: list[tuple[str, list[str]]] = []
         self.appended: list[str] = []
         self.commits: list[dict] = []
         self.session = {"id": "session-1", "status": "ready_for_review"}
@@ -363,6 +293,8 @@ class FakeAlexandria:
 
     async def upload_file(self, path, upload_name, *, multipart, on_progress=None):
         self.uploads.append((upload_name, multipart))
+        with zipfile.ZipFile(path) as archive:
+            self.archives.append((upload_name, sorted(archive.namelist())))
         return f"upload-{len(self.uploads)}"
 
     async def complete_upload(self, upload_ids, *, multipart):
@@ -405,14 +337,24 @@ async def test_should_upload_a_folder_and_return_its_model_id(tmp_path) -> None:
     ).upload(folder)
 
     assert model_id == "model-1"
-    assert alexandria.uploads == [("dragon.7z", False)]
-    assert alexandria.appended == ["render.jpg"]
+    assert alexandria.uploads == [("Dragon.zip", False)]
+    assert alexandria.archives == [
+        (
+            "Dragon.zip",
+            [
+                "002501-dragon/images/render.jpg",
+                "002501-dragon/metadata.json",
+                "002501-dragon/models/dragon.7z",
+            ],
+        ),
+    ]
+    assert alexandria.appended == []
     assert alexandria.commits[0]["modelName"] == "Dragon"
     assert alexandria.commits[0]["batch_metadata"]["artist"] == "Foo"
     assert alexandria.commits[0]["batch_metadata"]["tags"] == ["dragon"]
 
 
-async def test_should_append_container_images_to_every_model_beneath_it(
+async def test_should_include_container_images_in_every_descendant_folder_archive(
     tmp_path,
 ) -> None:
     release = tmp_path / "002501-dragon-set"
@@ -427,7 +369,16 @@ async def test_should_append_container_images_to_every_model_beneath_it(
         folder
     )
 
-    assert sorted(alexandria.appended) == ["group.jpg", "knight.jpg"]
+    assert alexandria.archives == [
+        (
+            "knight.zip",
+            [
+                "knight/images/group.jpg",
+                "knight/images/knight.jpg",
+                "knight/models/knight.zip",
+            ],
+        ),
+    ]
 
 
 async def test_should_prefer_a_models_own_image_over_a_container_duplicate(
@@ -447,7 +398,7 @@ async def test_should_prefer_a_models_own_image_over_a_container_duplicate(
     ]
 
 
-async def test_should_upload_a_split_set_as_multipart(tmp_path) -> None:
+async def test_should_zip_split_archives_with_the_rest_of_the_folder(tmp_path) -> None:
     make_folder(
         tmp_path / "002501-dragon", models=["dragon.part1.rar", "dragon.part2.rar"]
     )
@@ -458,9 +409,15 @@ async def test_should_upload_a_split_set_as_multipart(tmp_path) -> None:
         folder
     )
 
-    assert alexandria.uploads == [
-        ("dragon.part1.rar", True),
-        ("dragon.part2.rar", True),
+    assert alexandria.uploads == [("dragon.zip", False)]
+    assert alexandria.archives == [
+        (
+            "dragon.zip",
+            [
+                "002501-dragon/models/dragon.part1.rar",
+                "002501-dragon/models/dragon.part2.rar",
+            ],
+        ),
     ]
 
 
@@ -603,29 +560,6 @@ def test_should_not_walk_a_nested_directory_named_failed_or_uploaded(tmp_path) -
     assert [folder.path.name for folder in found] == ["knight"]
 
 
-async def test_should_append_images_in_one_batched_request(tmp_path) -> None:
-    make_folder(
-        tmp_path / "002501-dragon",
-        models=["a.7z"],
-        images=["one.jpg", "two.jpg", "three.jpg"],
-    )
-    alexandria = FakeAlexandria()
-    calls: list[int] = []
-    original = alexandria.append_files
-
-    async def counting(session_id, paths, upload_names):
-        calls.append(len(paths))
-        return await original(session_id, paths, upload_names)
-
-    alexandria.append_files = counting
-    [folder], _ = discover(tmp_path)
-
-    await FolderUploader(alexandria=alexandria, work_root=tmp_path / "w").upload(folder)
-
-    assert calls == [3]
-    assert sorted(alexandria.appended) == ["one.jpg", "three.jpg", "two.jpg"]
-
-
 def test_should_describe_what_a_dry_run_would_upload(tmp_path) -> None:
     from alexandria_telegram_importer.folder_upload import describe_staging
 
@@ -635,6 +569,6 @@ def test_should_describe_what_a_dry_run_would_upload(tmp_path) -> None:
 
     report = describe_staging(tmp_path)
 
-    assert "as_is  002501-dragon -> 'dragon' (1 image(s))" in report
+    assert "zip    002501-dragon -> 'dragon' (1 image(s))" in report
     assert "FAIL   002502-broken" in report
     assert "1 model folder(s) would be uploaded" in report


### PR DESCRIPTION
## Summary
- package each staged model folder as one ZIP containing its models and images
- preserve inherited container images within each model ZIP
- update staged-import documentation and coverage

## Validation
- uv run --extra test pytest