### PR TITLE
fix: omit blank metadata on upload

### DIFF
--- a/apps/frontend/src/components/upload/BatchMetadataForm.test.tsx
+++ b/apps/frontend/src/components/upload/BatchMetadataForm.test.tsx
@@ -320,6 +320,37 @@ describe('BatchMetadataForm', () => {
     expect(screen.queryByText('guessed')).toBeNull();
   });
 
+  it('does not submit blank optional metadata values from an archive', async () => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    vi.mocked(getCollections).mockResolvedValue({ data: [], meta: null, errors: null });
+
+    render(
+      <QueryClientProvider client={client}>
+        <BatchMetadataForm
+          sessionId="session-1"
+          originalFilename="starter.zip"
+          detected={{
+            modelCount: 1,
+            fileCount: 1,
+            totalSizeBytes: 100,
+            artist: null,
+            tagsGuessed: [],
+            folderStructure: [],
+            metadataFile: { metadata: { url: '', source: 'Dragon Quest' } },
+          }}
+          onCommitted={vi.fn()}
+        />
+      </QueryClientProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Import one model' }));
+
+    await waitFor(() => expect(commitImportSession).toHaveBeenCalledWith(
+      'session-1',
+      expect.objectContaining({ metadata: { source: 'Dragon Quest' } }),
+    ));
+  });
+
   it('lets a saved draft win over the archive metadata.json', () => {
     const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
     vi.mocked(getCollections).mockResolvedValue({ data: [], meta: null, errors: null });

--- a/apps/frontend/src/components/upload/BatchMetadataForm.tsx
+++ b/apps/frontend/src/components/upload/BatchMetadataForm.tsx
@@ -118,6 +118,23 @@ function createInitialForm(
   };
 }
 
+/**
+ * An archive metadata file often uses an empty string for an unknown optional
+ * value (for example, `url: ""`). Metadata fields such as URL and number do
+ * not accept that placeholder, so omit it rather than turning a prefill into
+ * a failed import. `null` is intentionally retained because it means clear
+ * this value when a saved draft explicitly includes it.
+ */
+function omitBlankMetadataValues(
+  metadata: NonNullable<BatchUploadMetadata['metadata']>,
+): NonNullable<BatchUploadMetadata['metadata']> {
+  return Object.fromEntries(
+    Object.entries(metadata).filter(([, value]) => (
+      typeof value !== 'string' || value.trim().length > 0
+    )),
+  );
+}
+
 /** Where a prefilled field's value came from, for the review-form badges. */
 type FieldSource = 'file' | 'detected' | null;
 
@@ -198,6 +215,7 @@ export function BatchMetadataForm({
     const hasExistingCollection = !!form.collectionId && form.collectionId !== '__new__';
     const modelName = form.modelName.trim();
     const description = form.description.trim();
+    const metadata = omitBlankMetadataValues(form.metadata);
     const batchMetadata: BatchUploadMetadata = {
       modelName,
       description: description || null,
@@ -207,7 +225,7 @@ export function BatchMetadataForm({
         : {}),
       ...(form.artist.trim() ? { artist: form.artist.trim() } : {}),
       ...(form.tags.length > 0 ? { tags: form.tags } : {}),
-      ...(Object.keys(form.metadata).length > 0 ? { metadata: form.metadata } : {}),
+      ...(Object.keys(metadata).length > 0 ? { metadata } : {}),
       options: {
         markPreSupported: form.markPreSupported,
         autoThumbnails: form.autoThumbnails,


### PR DESCRIPTION
## Summary\n- omit blank optional metadata values when submitting staged archive imports\n- prevent empty URL placeholders in metadata.json from blocking imports\n- add a regression test for empty URL metadata\n\n## Validation\n- npm test -w @alexandria/frontend -- --run src/components/upload/BatchMetadataForm.test.tsx\n- npm run build -w @alexandria/shared\n- npm run build -w @alexandria/frontend\n- npm test -w @alexandria/frontend -- --run src/components/models/FileTree.test.tsx