### PR TITLE
fix: show configured names in import metadata

### DIFF
--- a/apps/frontend/src/components/upload/BatchMetadataForm.test.tsx
+++ b/apps/frontend/src/components/upload/BatchMetadataForm.test.tsx
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import type { CollectionDetail, DetectedImportMetadata } from '@alexandria/shared';
+import type { CollectionDetail, DetectedImportMetadata, MetadataFieldDetail } from '@alexandria/shared';
 import { BatchMetadataForm } from './BatchMetadataForm';
 
 vi.mock('../../api/collections', () => ({
@@ -9,6 +9,7 @@ vi.mock('../../api/collections', () => ({
 }));
 
 vi.mock('../../api/metadata', () => ({
+  getFields: vi.fn(),
   getFieldValues: vi.fn(),
 }));
 
@@ -18,7 +19,7 @@ vi.mock('../../api/models', async (importOriginal) => {
 });
 
 import { getCollections } from '../../api/collections';
-import { getFieldValues } from '../../api/metadata';
+import { getFields, getFieldValues } from '../../api/metadata';
 import { commitImportSession } from '../../api/models';
 
 const collection: CollectionDetail = {
@@ -33,6 +34,18 @@ const collection: CollectionDetail = {
   updatedAt: '2026-01-01T00:00:00.000Z',
 };
 
+const characterField: MetadataFieldDetail = {
+  id: '33333333-3333-4333-8333-333333333333',
+  name: 'Character',
+  slug: 'character-6erm',
+  type: 'text',
+  isDefault: false,
+  isFilterable: true,
+  isBrowsable: true,
+  config: null,
+  sortOrder: 7,
+};
+
 function collectionSelect(): HTMLSelectElement {
   const select = screen.getByRole('option', { name: '— None —' }).closest('select');
   if (!select) throw new Error('collection select not found');
@@ -42,6 +55,7 @@ function collectionSelect(): HTMLSelectElement {
 describe('BatchMetadataForm', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(getFields).mockResolvedValue([]);
     vi.mocked(getFieldValues).mockResolvedValue([]);
     vi.mocked(commitImportSession).mockResolvedValue({ modelId: 'model-1', jobId: 'job-1' });
   });
@@ -318,6 +332,34 @@ describe('BatchMetadataForm', () => {
     expect(screen.getByPlaceholderText('Artist name (optional)')).toHaveValue('Foo Studios');
     expect(screen.getByText('dragon')).toBeTruthy();
     expect(screen.queryByText('guessed')).toBeNull();
+  });
+
+  it('uses configured field names for metadata from an archive', async () => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    vi.mocked(getCollections).mockResolvedValue({ data: [], meta: null, errors: null });
+    vi.mocked(getFields).mockResolvedValue([characterField]);
+
+    render(
+      <QueryClientProvider client={client}>
+        <BatchMetadataForm
+          sessionId="session-1"
+          originalFilename="starter.zip"
+          detected={{
+            modelCount: 1,
+            fileCount: 1,
+            totalSizeBytes: 100,
+            artist: null,
+            tagsGuessed: [],
+            folderStructure: [],
+            metadataFile: { metadata: { 'character-6erm': 'Rukia' } },
+          }}
+          onCommitted={vi.fn()}
+        />
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => expect(screen.getByLabelText('Character')).toHaveValue('Rukia'));
+    expect(screen.queryByLabelText('character 6erm')).toBeNull();
   });
 
   it('lets a saved draft win over the archive metadata.json', () => {

--- a/apps/frontend/src/components/upload/BatchMetadataForm.tsx
+++ b/apps/frontend/src/components/upload/BatchMetadataForm.tsx
@@ -3,7 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import { Loader2, FolderOpen, User } from 'lucide-react';
 import type { DetectedImportMetadata, BatchUploadMetadata } from '@alexandria/shared';
 import { getCollections } from '../../api/collections';
-import { getFieldValues } from '../../api/metadata';
+import { getFields, getFieldValues } from '../../api/metadata';
 import { useCommitSession } from '../../hooks/use-import-sessions';
 import { Button } from '../ui/button';
 import { Input } from '../ui/input';
@@ -189,6 +189,12 @@ export function BatchMetadataForm({
     queryFn: () => getFieldValues('tags'),
     staleTime: 60_000,
   });
+  const { data: metadataFields = [] } = useQuery({
+    queryKey: ['metadata-fields'],
+    queryFn: getFields,
+    staleTime: 60_000,
+  });
+  const metadataFieldNames = new Map(metadataFields.map((field) => [field.slug, field.name]));
 
   const commitMutation = useCommitSession();
 
@@ -356,7 +362,7 @@ export function BatchMetadataForm({
             {Object.entries(form.metadata).map(([field, value]) => (
               <div key={field} className="grid grid-cols-[minmax(90px,0.35fr)_minmax(0,1fr)] items-center gap-2">
                 <Label htmlFor={`draft-metadata-${field}`} className="truncate text-[12px] capitalize">
-                  {field.replace(/[-_]+/g, ' ')}
+                  {metadataFieldNames.get(field) ?? field.replace(/[-_]+/g, ' ')}
                 </Label>
                 {form.metadataTypes[field] === 'boolean' ? (
                   <Checkbox


### PR DESCRIPTION
## Summary\n- fetch configured metadata fields in the staged import review form\n- display each configured field name instead of formatting its slug\n- retain a readable slug fallback for missing fields\n\n## Validation\n- npm test -w @alexandria/frontend -- --run src/components/upload/BatchMetadataForm.test.tsx\n- npm run build -w @alexandria/frontend