### PR TITLE
Show duplicate file count in FileTree header

### DIFF
--- a/apps/frontend/src/components/models/FileTree.test.tsx
+++ b/apps/frontend/src/components/models/FileTree.test.tsx
@@ -76,6 +76,39 @@ describe('FileTree', () => {
     expect(screen.getByText('duplicates').parentElement?.textContent).not.toContain('Duplicate');
   });
 
+  it('shows the duplicate file count in the header', () => {
+    render(
+      <FileTree
+        tree={[
+          {
+            name: 'duplicates',
+            type: 'directory',
+            isDuplicate: false,
+            children: [
+              {
+                name: 'copy.stl',
+                type: 'file',
+                fileType: 'stl',
+                id: 'duplicate-file',
+                isDuplicate: true,
+              },
+            ],
+          },
+          {
+            name: 'original.stl',
+            type: 'file',
+            fileType: 'stl',
+            id: 'original-file',
+            isDuplicate: false,
+          },
+        ]}
+        modelId="m1"
+      />,
+    );
+
+    expect(screen.getByText('2 files · 1 duplicate')).toBeInTheDocument();
+  });
+
   it('fires onOpenStl with the reconstructed relative path for a nested STL', () => {
     const onOpenStl = vi.fn();
     render(<FileTree tree={TREE} modelId="m1" onOpenStl={onOpenStl} />);

--- a/apps/frontend/src/components/models/FileTree.tsx
+++ b/apps/frontend/src/components/models/FileTree.tsx
@@ -713,6 +713,18 @@ function countFiles(nodes: FileTreeNode[]): number {
   return count;
 }
 
+function countDuplicateFiles(nodes: FileTreeNode[]): number {
+  let count = 0;
+  for (const node of nodes) {
+    if (node.type === 'file' && node.isDuplicate) {
+      count++;
+    } else if (node.type === 'directory' && node.children) {
+      count += countDuplicateFiles(node.children);
+    }
+  }
+  return count;
+}
+
 interface FileTreeProps {
   tree: FileTreeNode[];
   modelId: string;
@@ -763,6 +775,7 @@ export function FileTree({
   onSplitFolder,
 }: FileTreeProps) {
   const totalFiles = countFiles(tree);
+  const duplicateFiles = countDuplicateFiles(tree);
   const allFiles = React.useMemo(() => collectFileTargets(tree), [tree]);
   const baseDestinations = React.useMemo(
     () => [
@@ -953,7 +966,9 @@ export function FileTree({
               {operationStatus}
             </span>
           ) : (
-            <span className="text-xs text-muted-foreground">{totalFiles} files</span>
+            <span className="text-xs text-muted-foreground">
+              {totalFiles} files · {duplicateFiles} duplicate{duplicateFiles === 1 ? '' : 's'}
+            </span>
           )}
         </div>
       </div>


### PR DESCRIPTION
## Summary

- Add recursive duplicate-file counting to the FileTree.
- Display total and duplicate file counts in the header.
- Add coverage for the duplicate count display.

## Testing

- Added and ran the FileTree component test for duplicate file counts.