### PR TITLE
Add duplicate model consolidation workflow

### DIFF
--- a/apps/backend/src/routes/tools.integration.test.ts
+++ b/apps/backend/src/routes/tools.integration.test.ts
@@ -13,10 +13,17 @@ import { and, eq, inArray } from 'drizzle-orm';
 import { buildApp } from '../app.js';
 import { db } from '../db/index.js';
 import {
+  collectionModels,
+  collections,
   duplicateFileIgnores,
   libraries,
+  metadataFieldDefinitions,
   modelFiles,
+  modelMetadata,
+  modelTags,
   models,
+  tags,
+  thumbnails,
   users,
 } from '../db/schema/index.js';
 
@@ -46,6 +53,7 @@ async function cleanupFixtures(): Promise<void> {
 
   // Model-file rows cascade from models. Remove the remaining rows in FK order.
   await db.delete(models).where(inArray(models.userId, userIds));
+  await db.delete(collections).where(inArray(collections.userId, userIds));
   await db.delete(libraries).where(inArray(libraries.userId, userIds));
   await db.delete(users).where(inArray(users.id, userIds));
 }
@@ -647,5 +655,135 @@ describe('duplicate review actions integration', () => {
       .where(eq(models.libraryId, ownerSecondLibraryId));
     expect(survivingModels.find((model) => model.id === secondLibraryModelIds[1])?.isDuplicate)
       .toBe(false);
+  });
+});
+
+describe('duplicate model consolidation integration', () => {
+  it('previews and then removes only the confirmed exact duplicate source model', async () => {
+    const [sourceFile] = await db.select({ id: modelFiles.id }).from(modelFiles)
+      .where(eq(modelFiles.modelId, defaultModelIds[1])).limit(1);
+    const [metadataField] = await db.select({ id: metadataFieldDefinitions.id })
+      .from(metadataFieldDefinitions).limit(1);
+    const [collection] = await db.insert(collections).values({
+      name: 'Consolidation Source Collection',
+      slug: `consolidation-source-${Date.now()}-${process.pid}`,
+      userId: (await db.select({ userId: models.userId }).from(models)
+        .where(eq(models.id, defaultModelIds[1])).limit(1))[0]!.userId,
+      libraryId: ownerDefaultLibraryId,
+    }).returning({ id: collections.id, name: collections.name });
+    const [tag] = await db.insert(tags).values({
+      name: `consolidation-tag-${Date.now()}-${process.pid}`,
+      slug: `consolidation-tag-${Date.now()}-${process.pid}`,
+    }).returning({ id: tags.id, name: tags.name });
+    await db.insert(modelMetadata).values({
+      modelId: defaultModelIds[1],
+      fieldDefinitionId: metadataField!.id,
+      value: 'copied metadata value',
+    });
+    await db.insert(collectionModels).values({
+      collectionId: collection.id,
+      modelId: defaultModelIds[1],
+    });
+    await db.insert(modelTags).values({ modelId: defaultModelIds[1], tagId: tag.id });
+    const [thumbnail] = await db.insert(thumbnails).values({
+      sourceFileId: sourceFile!.id,
+      storagePath: `thumbnails/${defaultModelIds[1]}/source.webp`,
+      width: 800,
+      height: 600,
+      format: 'webp',
+    }).returning({ id: thumbnails.id });
+
+    const preview = await app.inject({
+      method: 'POST',
+      url: '/tools/duplicates/consolidate/preview',
+      headers: { cookie: sessionCookie },
+      payload: { sourceModelId: defaultModelIds[1], targetModelId: defaultModelIds[0] },
+    });
+
+    expect(preview.statusCode).toBe(200);
+    expect(preview.json().data).toMatchObject({
+      sourceModel: { id: defaultModelIds[1], name: 'Default Pair 2' },
+      targetModel: { id: defaultModelIds[0], name: 'Default Pair 1' },
+      deletedFileCount: 2,
+      reclaimableBytes: 101,
+      deletedSourceModelId: defaultModelIds[1],
+    });
+    expect(preview.json().data.removedFiles).toHaveLength(2);
+    expect(preview.json().data.removedFiles.every((file: Record<string, unknown>) =>
+      !('storagePath' in file))).toBe(true);
+    expect(preview.json().data).toMatchObject({
+      removedThumbnails: [{
+        id: thumbnail.id,
+        sourceFileId: sourceFile!.id,
+        sourceFilename: 'part-1-2.stl',
+        width: 800,
+        height: 600,
+        format: 'webp',
+      }],
+      copiedMetadata: [{ fieldDefinitionId: metadataField!.id, value: 'copied metadata value' }],
+      addedCollections: [{ id: collection.id, name: collection.name }],
+      addedTags: [{ id: tag.id, name: tag.name }],
+      copiedMetadataFieldCount: 1,
+      addedCollectionCount: 1,
+      addedTagCount: 1,
+    });
+
+    const consolidation = await app.inject({
+      method: 'POST',
+      url: '/tools/duplicates/consolidate',
+      headers: { cookie: sessionCookie },
+      payload: { sourceModelId: defaultModelIds[1], targetModelId: defaultModelIds[0] },
+    });
+
+    expect(consolidation.statusCode).toBe(200);
+    expect(consolidation.json().data).toMatchObject(preview.json().data);
+
+    const [removedSource] = await db.select({ id: models.id }).from(models)
+      .where(eq(models.id, defaultModelIds[1]));
+    expect(removedSource).toBeUndefined();
+    const targetFiles = await db.select({ id: modelFiles.id, isDuplicate: modelFiles.isDuplicate }).from(modelFiles)
+      .where(eq(modelFiles.modelId, defaultModelIds[0]));
+    expect(targetFiles).toHaveLength(2);
+    expect(targetFiles.every((file) => file.isDuplicate === false)).toBe(true);
+    const sourceFiles = await db.select({ id: modelFiles.id }).from(modelFiles)
+      .where(eq(modelFiles.modelId, defaultModelIds[1]));
+    expect(sourceFiles).toHaveLength(0);
+    const targetRelationships = await Promise.all([
+      db.select().from(modelMetadata).where(and(
+        eq(modelMetadata.modelId, defaultModelIds[0]),
+        eq(modelMetadata.fieldDefinitionId, metadataField!.id),
+      )),
+      db.select().from(collectionModels).where(and(
+        eq(collectionModels.collectionId, collection.id),
+        eq(collectionModels.modelId, defaultModelIds[0]),
+      )),
+      db.select().from(modelTags).where(and(
+        eq(modelTags.modelId, defaultModelIds[0]),
+        eq(modelTags.tagId, tag.id),
+      )),
+      db.select().from(thumbnails).where(eq(thumbnails.id, thumbnail.id)),
+    ]);
+    expect(targetRelationships[0]).toHaveLength(1);
+    expect(targetRelationships[1]).toHaveLength(1);
+    expect(targetRelationships[2]).toHaveLength(1);
+    expect(targetRelationships[3]).toHaveLength(0);
+    const [targetModel] = await db.select({ isDuplicate: models.isDuplicate }).from(models)
+      .where(eq(models.id, defaultModelIds[0]));
+    expect(targetModel!.isDuplicate).toBe(false);
+  });
+
+  it('rejects a source model that merely shares one duplicate file', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/tools/duplicates/consolidate/preview',
+      headers: { cookie: sessionCookie },
+      payload: { sourceModelId: partialDuplicateModelId, targetModelId: defaultModelIds[0] },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json().errors[0]).toMatchObject({
+      code: 'VALIDATION_ERROR',
+      message: 'Models no longer have identical files',
+    });
   });
 });

--- a/apps/backend/src/routes/tools.test.ts
+++ b/apps/backend/src/routes/tools.test.ts
@@ -17,6 +17,8 @@ const mocks = vi.hoisted(() => ({
   markDuplicates: vi.fn(),
   markDuplicateFileGroup: vi.fn(),
   ignoreDuplicateFileGroup: vi.fn(),
+  previewDuplicateModelConsolidation: vi.fn(),
+  consolidateDuplicateModel: vi.fn(),
   buildDuplicateScanResult: vi.fn(),
 }));
 
@@ -32,6 +34,12 @@ vi.mock('../services/duplicate-scanner.service.js', () => ({
 }));
 vi.mock('../services/presenter.service.js', () => ({
   presenterService: { buildDuplicateScanResult: mocks.buildDuplicateScanResult },
+}));
+vi.mock('../services/model.service.js', () => ({
+  modelService: {
+    previewDuplicateModelConsolidation: mocks.previewDuplicateModelConsolidation,
+    consolidateDuplicateModel: mocks.consolidateDuplicateModel,
+  },
 }));
 
 import { toolsRoutes } from './tools.js';
@@ -63,6 +71,8 @@ describe('Tools routes', () => {
       ignoredFileGroupCount: 1,
       ignoredModelGroupCount: 0,
     });
+    mocks.previewDuplicateModelConsolidation.mockResolvedValue({ deletedFileCount: 2 });
+    mocks.consolidateDuplicateModel.mockResolvedValue({ deletedFileCount: 2 });
     app = Fastify();
     app.setErrorHandler(errorHandler);
     await app.register(toolsRoutes, { prefix: '/tools' });
@@ -155,6 +165,60 @@ describe('Tools routes', () => {
       meta: null,
       errors: null,
     });
+  });
+
+  it('previews one exact-model consolidation without changing the library', async () => {
+    const sourceModelId = '33333333-3333-4333-8333-333333333333';
+    const targetModelId = '44444444-4444-4444-8444-444444444444';
+    const response = await app.inject({
+      method: 'POST',
+      url: '/tools/duplicates/consolidate/preview',
+      payload: { sourceModelId, targetModelId },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(mocks.previewDuplicateModelConsolidation).toHaveBeenCalledWith(
+      sourceModelId,
+      targetModelId,
+      USER_ID,
+      LIBRARY_ID,
+    );
+    expect(response.json()).toEqual({ data: { deletedFileCount: 2 }, meta: null, errors: null });
+  });
+
+  it('consolidates one confirmed exact-model pair', async () => {
+    const sourceModelId = '33333333-3333-4333-8333-333333333333';
+    const targetModelId = '44444444-4444-4444-8444-444444444444';
+    const response = await app.inject({
+      method: 'POST',
+      url: '/tools/duplicates/consolidate',
+      payload: { sourceModelId, targetModelId },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(mocks.consolidateDuplicateModel).toHaveBeenCalledWith(
+      sourceModelId,
+      targetModelId,
+      USER_ID,
+      LIBRARY_ID,
+    );
+    expect(response.json()).toEqual({ data: { deletedFileCount: 2 }, meta: null, errors: null });
+  });
+
+  it.each(['/tools/duplicates/consolidate/preview', '/tools/duplicates/consolidate'])
+  ('rejects self-consolidation at the route boundary: %s', async (url) => {
+    const response = await app.inject({
+      method: 'POST',
+      url,
+      payload: {
+        sourceModelId: '33333333-3333-4333-8333-333333333333',
+        targetModelId: '33333333-3333-4333-8333-333333333333',
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(mocks.previewDuplicateModelConsolidation).not.toHaveBeenCalled();
+    expect(mocks.consolidateDuplicateModel).not.toHaveBeenCalled();
   });
 
   it.each(['short', 'A'.repeat(64), `${'a'.repeat(63)}g`])(

--- a/apps/backend/src/routes/tools.ts
+++ b/apps/backend/src/routes/tools.ts
@@ -1,12 +1,15 @@
 import type { FastifyInstance } from 'fastify';
 import {
+  consolidateDuplicateModelsSchema,
   duplicateFileGroupParamsSchema,
+  type ConsolidateDuplicateModelsRequest,
   type DuplicateFileGroupParams,
 } from '@alexandria/shared';
 import { requireAuth } from '../middleware/auth.js';
 import { requireLibrary } from '../middleware/library.js';
 import { duplicateScannerService } from '../services/duplicate-scanner.service.js';
 import { presenterService } from '../services/presenter.service.js';
+import { modelService } from '../services/model.service.js';
 import { validationError } from '../utils/errors.js';
 
 function parseDuplicateFileGroupParams(value: unknown): DuplicateFileGroupParams {
@@ -59,6 +62,46 @@ export async function toolsRoutes(app: FastifyInstance): Promise<void> {
       const result = await duplicateScannerService.ignoreDuplicateFileGroup(
         request.libraryId!,
         hash,
+      );
+      return reply.status(200).send({ data: result, meta: null, errors: null });
+    },
+  );
+
+  app.post(
+    '/duplicates/consolidate/preview',
+    { preHandler: [requireAuth, requireLibrary] },
+    async (request, reply) => {
+      const parsed = consolidateDuplicateModelsSchema.safeParse(request.body ?? {});
+      if (!parsed.success) {
+        const issue = parsed.error.issues[0];
+        throw validationError(issue?.message ?? 'Invalid consolidation request', issue?.path.join('.'));
+      }
+      const body = parsed.data as ConsolidateDuplicateModelsRequest;
+      const result = await modelService.previewDuplicateModelConsolidation(
+        body.sourceModelId,
+        body.targetModelId,
+        request.user!.id,
+        request.libraryId!,
+      );
+      return reply.status(200).send({ data: result, meta: null, errors: null });
+    },
+  );
+
+  app.post(
+    '/duplicates/consolidate',
+    { preHandler: [requireAuth, requireLibrary] },
+    async (request, reply) => {
+      const parsed = consolidateDuplicateModelsSchema.safeParse(request.body ?? {});
+      if (!parsed.success) {
+        const issue = parsed.error.issues[0];
+        throw validationError(issue?.message ?? 'Invalid consolidation request', issue?.path.join('.'));
+      }
+      const body = parsed.data as ConsolidateDuplicateModelsRequest;
+      const result = await modelService.consolidateDuplicateModel(
+        body.sourceModelId,
+        body.targetModelId,
+        request.user!.id,
+        request.libraryId!,
       );
       return reply.status(200).send({ data: result, meta: null, errors: null });
     },

--- a/apps/backend/src/services/model.service.ts
+++ b/apps/backend/src/services/model.service.ts
@@ -10,6 +10,8 @@ import type {
   SplitModelFolderResponse,
   UpdateModelFileRequest,
   UpdateModelFolderRequest,
+  ConsolidateDuplicateModelsPreview,
+  ConsolidateDuplicateModelsResult,
 } from '@alexandria/shared';
 import { MAX_MODEL_FILE_SELECTION_COUNT } from '@alexandria/shared';
 import { db } from '../db/index.js';
@@ -22,6 +24,9 @@ import {
   collectionModels,
   modelMetadata,
   modelTags,
+  metadataFieldDefinitions,
+  collections,
+  tags,
 } from '../db/schema/index.js';
 import { conflict, notFound, validationError } from '../utils/errors.js';
 import type { Model } from '../db/schema/model.js';
@@ -33,6 +38,11 @@ import { duplicateScannerService } from './duplicate-scanner.service.js';
 import { createLogger } from '../utils/logger.js';
 
 const logger = createLogger('ModelService');
+
+interface DuplicateConsolidationBuild {
+  result: ConsolidateDuplicateModelsResult;
+  storagePaths: string[];
+}
 
 export interface CreateModelData {
   id?: string;
@@ -1466,6 +1476,273 @@ export class ModelService {
       mergedModelIds: uniqueSourceIds,
       movedFileCount,
     };
+  }
+
+  /**
+   * Describe the effect of retaining targetModelId and removing sourceModelId.
+   * Consolidation is deliberately stricter than the ordinary model merge: the
+   * complete sorted hash multisets must be identical, so no unique source file
+   * can be discarded.
+   */
+  async previewDuplicateModelConsolidation(
+    sourceModelId: string,
+    targetModelId: string,
+    userId: string,
+    libraryId: string,
+  ): Promise<ConsolidateDuplicateModelsPreview> {
+    const rows = await this.requireOwnedModels(
+      [sourceModelId, targetModelId],
+      userId,
+      libraryId,
+    );
+    return (await this.buildDuplicateConsolidationResult(
+      sourceModelId,
+      targetModelId,
+      rows,
+      db,
+    )).result;
+  }
+
+  /**
+   * Consolidate one exact duplicate model into a retained target. Source
+   * relationships are merged where lossless, while its file records and their
+   * managed storage objects are removed. There is intentionally no bulk form.
+   */
+  async consolidateDuplicateModel(
+    sourceModelId: string,
+    targetModelId: string,
+    userId: string,
+    libraryId: string,
+  ): Promise<ConsolidateDuplicateModelsResult> {
+    let result!: ConsolidateDuplicateModelsResult;
+    let resultStoragePaths: string[] = [];
+
+    await db.transaction(async (tx) => {
+      const rows = await this.lockOwnedModels(
+        [sourceModelId, targetModelId],
+        userId,
+        libraryId,
+        tx,
+      );
+      // Parent model locks prevent new FK memberships; relation-row locks make
+      // the snapshots below stable against concurrent membership/metadata
+      // removal. This prevents a source relationship from disappearing after
+      // it was inspected but before it can be unioned onto the target.
+      await this.lockDuplicateConsolidationRelations(sourceModelId, targetModelId, tx);
+      const build = await this.buildDuplicateConsolidationResult(
+        sourceModelId,
+        targetModelId,
+        rows,
+        tx,
+      );
+      result = build.result;
+      resultStoragePaths = build.storagePaths;
+
+      const targetMetadataRows = await tx
+        .select({ fieldDefinitionId: modelMetadata.fieldDefinitionId })
+        .from(modelMetadata)
+        .where(eq(modelMetadata.modelId, targetModelId));
+      const targetMetadataFieldIds = new Set(
+        targetMetadataRows.map((row) => row.fieldDefinitionId),
+      );
+      const sourceMetadataRows = await tx
+        .select({ fieldDefinitionId: modelMetadata.fieldDefinitionId, value: modelMetadata.value })
+        .from(modelMetadata)
+        .where(eq(modelMetadata.modelId, sourceModelId));
+      const metadataToCopy = sourceMetadataRows.filter((row) =>
+        !targetMetadataFieldIds.has(row.fieldDefinitionId));
+      if (metadataToCopy.length > 0) {
+        await tx.insert(modelMetadata).values(metadataToCopy.map((row) => ({
+          modelId: targetModelId,
+          fieldDefinitionId: row.fieldDefinitionId,
+          value: row.value,
+        })));
+      }
+
+      const sourceCollections = await tx
+        .select({ collectionId: collectionModels.collectionId })
+        .from(collectionModels)
+        .where(eq(collectionModels.modelId, sourceModelId));
+      if (sourceCollections.length > 0) {
+        await tx.insert(collectionModels).values(sourceCollections.map((row) => ({
+          collectionId: row.collectionId,
+          modelId: targetModelId,
+        }))).onConflictDoNothing();
+      }
+
+      const sourceTags = await tx
+        .select({ tagId: modelTags.tagId })
+        .from(modelTags)
+        .where(eq(modelTags.modelId, sourceModelId));
+      if (sourceTags.length > 0) {
+        await tx.insert(modelTags).values(sourceTags.map((row) => ({
+          modelId: targetModelId,
+          tagId: row.tagId,
+        }))).onConflictDoNothing();
+      }
+
+      await tx.delete(models).where(eq(models.id, sourceModelId));
+      await this.recalculateModelStats(targetModelId, tx);
+      await duplicateScannerService.reconcileDuplicateFlags(libraryId, tx);
+    }, { isolationLevel: 'serializable' });
+
+    // The database mutation is authoritative. Storage cleanup is best effort,
+    // matching model/file deletion semantics: a missed object is orphaned but
+    // never causes a partial relationship or file-record mutation.
+    const storagePaths = resultStoragePaths;
+    try {
+      const failures = await storageService.deleteMany(storagePaths);
+      for (const failure of failures) {
+        logger.warn(
+          { sourceModelId, storagePath: failure.filePath, err: failure.reason },
+          'Best-effort duplicate consolidation storage cleanup failed',
+        );
+      }
+    } catch (error) {
+      logger.warn(
+        { sourceModelId, err: error },
+        'Best-effort duplicate consolidation storage cleanup failed',
+      );
+    }
+
+    logger.info(
+      {
+        service: 'ModelService',
+        sourceModelId,
+        targetModelId,
+        deletedFileCount: result.deletedFileCount,
+        reclaimableBytes: result.reclaimableBytes,
+      },
+      'Consolidated exact duplicate model',
+    );
+    return result;
+  }
+
+  private async buildDuplicateConsolidationResult(
+    sourceModelId: string,
+    targetModelId: string,
+    rows: Model[],
+    executor: DatabaseExecutor,
+  ): Promise<DuplicateConsolidationBuild> {
+    if (sourceModelId === targetModelId) {
+      throw validationError('A model cannot be consolidated into itself', 'sourceModelId');
+    }
+    const source = rows.find((row) => row.id === sourceModelId);
+    const target = rows.find((row) => row.id === targetModelId);
+    if (!source || !target) throw notFound('One or more models were not found');
+    if (source.status !== 'ready' || target.status !== 'ready') {
+      throw validationError('Both models must be ready before consolidating', 'sourceModelId');
+    }
+
+    const [sourceFiles, targetFiles] = await Promise.all([
+      executor.select().from(modelFiles).where(eq(modelFiles.modelId, sourceModelId))
+        .orderBy(asc(modelFiles.hash), asc(modelFiles.id)),
+      executor.select().from(modelFiles).where(eq(modelFiles.modelId, targetModelId))
+        .orderBy(asc(modelFiles.hash), asc(modelFiles.id)),
+    ]);
+    if (sourceFiles.length === 0 || sourceFiles.length !== targetFiles.length
+      || sourceFiles.some((file, index) => file.hash !== targetFiles[index]?.hash)) {
+      throw validationError('Models no longer have identical files', 'sourceModelId');
+    }
+
+    const [sourceMetadataRows, targetMetadataRows, sourceCollections, targetCollections, sourceTags, targetTags,
+      thumbnailRows] = await Promise.all([
+      executor.select({
+        fieldDefinitionId: modelMetadata.fieldDefinitionId,
+        fieldName: metadataFieldDefinitions.name,
+        fieldSlug: metadataFieldDefinitions.slug,
+        value: modelMetadata.value,
+      }).from(modelMetadata)
+        .innerJoin(
+          metadataFieldDefinitions,
+          eq(modelMetadata.fieldDefinitionId, metadataFieldDefinitions.id),
+        )
+        .where(eq(modelMetadata.modelId, sourceModelId)),
+      executor.select({ fieldDefinitionId: modelMetadata.fieldDefinitionId }).from(modelMetadata)
+        .where(eq(modelMetadata.modelId, targetModelId)),
+      executor.select({ id: collections.id, name: collections.name }).from(collectionModels)
+        .innerJoin(collections, eq(collectionModels.collectionId, collections.id))
+        .where(eq(collectionModels.modelId, sourceModelId)),
+      executor.select({ collectionId: collectionModels.collectionId }).from(collectionModels)
+        .where(eq(collectionModels.modelId, targetModelId)),
+      executor.select({ id: tags.id, name: tags.name }).from(modelTags)
+        .innerJoin(tags, eq(modelTags.tagId, tags.id))
+        .where(eq(modelTags.modelId, sourceModelId)),
+      executor.select({ tagId: modelTags.tagId }).from(modelTags)
+        .where(eq(modelTags.modelId, targetModelId)),
+      executor.select({
+        id: thumbnails.id,
+        sourceFileId: thumbnails.sourceFileId,
+        sourceFilename: modelFiles.filename,
+        width: thumbnails.width,
+        height: thumbnails.height,
+        format: thumbnails.format,
+        storagePath: thumbnails.storagePath,
+      }).from(thumbnails)
+        .innerJoin(modelFiles, eq(thumbnails.sourceFileId, modelFiles.id))
+        .where(eq(modelFiles.modelId, sourceModelId)),
+    ]);
+    const targetMetadataIds = new Set(targetMetadataRows.map((row) => row.fieldDefinitionId));
+    const targetCollectionIds = new Set(targetCollections.map((row) => row.collectionId));
+    const targetTagIds = new Set(targetTags.map((row) => row.tagId));
+    const copiedMetadata = sourceMetadataRows
+      .filter((row) => !targetMetadataIds.has(row.fieldDefinitionId))
+      .sort((left, right) => left.fieldSlug.localeCompare(right.fieldSlug));
+    const addedCollections = sourceCollections
+      .filter((row) => !targetCollectionIds.has(row.id))
+      .sort((left, right) => left.name.localeCompare(right.name) || left.id.localeCompare(right.id));
+    const addedTags = sourceTags
+      .filter((row) => !targetTagIds.has(row.id))
+      .sort((left, right) => left.name.localeCompare(right.name) || left.id.localeCompare(right.id));
+
+    return {
+      result: {
+        sourceModel: { id: source.id, name: source.name },
+        targetModel: { id: target.id, name: target.name },
+        removedFiles: sourceFiles.map((file) => ({
+          id: file.id,
+          filename: file.filename,
+          relativePath: file.relativePath,
+          sizeBytes: file.sizeBytes,
+          hash: file.hash,
+        })),
+        removedThumbnails: thumbnailRows
+          .map(({ storagePath: _storagePath, ...thumbnail }) => thumbnail)
+          .sort((left, right) => left.sourceFilename.localeCompare(right.sourceFilename)
+            || left.id.localeCompare(right.id)),
+        copiedMetadata,
+        addedCollections,
+        addedTags,
+        copiedMetadataFieldCount: copiedMetadata.length,
+        addedCollectionCount: addedCollections.length,
+        addedTagCount: addedTags.length,
+        deletedFileCount: sourceFiles.length,
+        reclaimableBytes: sourceFiles.reduce((total, file) => total + file.sizeBytes, 0),
+        deletedSourceModelId: source.id,
+      },
+      storagePaths: [
+        ...sourceFiles.map((file) => file.storagePath),
+        ...thumbnailRows.map((row) => row.storagePath),
+      ],
+    };
+  }
+
+  private async lockDuplicateConsolidationRelations(
+    sourceModelId: string,
+    targetModelId: string,
+    executor: DatabaseExecutor,
+  ): Promise<void> {
+    const modelIds = [sourceModelId, targetModelId];
+    await Promise.all([
+      executor.select({ id: modelFiles.id }).from(modelFiles)
+        .where(inArray(modelFiles.modelId, modelIds)).for('update'),
+      executor.select({ id: modelMetadata.id }).from(modelMetadata)
+        .where(inArray(modelMetadata.modelId, modelIds)).for('update'),
+      executor.select({ collectionId: collectionModels.collectionId }).from(collectionModels)
+        .where(inArray(collectionModels.modelId, modelIds)).for('update'),
+      executor.select({ tagId: modelTags.tagId }).from(modelTags)
+        .where(inArray(modelTags.modelId, modelIds)).for('update'),
+    ]);
   }
 
   async deleteModel(id: string): Promise<void> {

--- a/apps/frontend/src/api/tools.ts
+++ b/apps/frontend/src/api/tools.ts
@@ -1,4 +1,6 @@
 import type {
+  ConsolidateDuplicateModelsPreview,
+  ConsolidateDuplicateModelsResult,
   DuplicateScanResult,
   IgnoreDuplicatesResult,
   MarkDuplicatesResult,
@@ -26,5 +28,27 @@ export async function ignoreDuplicateFileGroup(hash: string): Promise<IgnoreDupl
   const response = await post<IgnoreDuplicatesResult>(
     `/tools/duplicates/file-groups/${encodeURIComponent(hash)}/ignore`,
   );
+  return response.data;
+}
+
+export async function previewDuplicateModelConsolidation(
+  sourceModelId: string,
+  targetModelId: string,
+): Promise<ConsolidateDuplicateModelsPreview> {
+  const response = await post<ConsolidateDuplicateModelsPreview>('/tools/duplicates/consolidate/preview', {
+    sourceModelId,
+    targetModelId,
+  });
+  return response.data;
+}
+
+export async function consolidateDuplicateModels(
+  sourceModelId: string,
+  targetModelId: string,
+): Promise<ConsolidateDuplicateModelsResult> {
+  const response = await post<ConsolidateDuplicateModelsResult>('/tools/duplicates/consolidate', {
+    sourceModelId,
+    targetModelId,
+  });
   return response.data;
 }

--- a/apps/frontend/src/components/tools/ConsolidateDuplicateDialog.tsx
+++ b/apps/frontend/src/components/tools/ConsolidateDuplicateDialog.tsx
@@ -1,0 +1,232 @@
+import { useEffect, useState } from 'react';
+import { Loader2, Trash2 } from 'lucide-react';
+import type { ConsolidateDuplicateModelsPreview, DuplicateModel } from '@alexandria/shared';
+import { consolidateDuplicateModels, previewDuplicateModelConsolidation } from '../../api/tools';
+import { formatFileSize } from '../../lib/format';
+import { Button } from '../ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '../ui/dialog';
+
+interface ConsolidateDuplicateDialogProps {
+  source: DuplicateModel | null;
+  candidates: DuplicateModel[];
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onComplete: (result: ConsolidateDuplicateModelsPreview) => void;
+}
+
+/**
+ * Previews an exact-duplicate consolidation before it can remove a model.
+ * The server remains authoritative: it repeats the duplicate check when the
+ * user confirms, so a scan result cannot be used after it has become stale.
+ */
+export function ConsolidateDuplicateDialog({
+  source,
+  candidates,
+  open,
+  onOpenChange,
+  onComplete,
+}: ConsolidateDuplicateDialogProps) {
+  const [targetId, setTargetId] = useState<string | null>(null);
+  const [preview, setPreview] = useState<ConsolidateDuplicateModelsPreview | null>(null);
+  const [previewError, setPreviewError] = useState<string | null>(null);
+  const [isPreviewing, setIsPreviewing] = useState(false);
+  const [isConfirming, setIsConfirming] = useState(false);
+  const targets = source ? candidates.filter((candidate) => candidate.id !== source.id) : [];
+
+  useEffect(() => {
+    if (!open || !source) {
+      setTargetId(null);
+      setPreview(null);
+      setPreviewError(null);
+      return;
+    }
+    setTargetId(targets[0]?.id ?? null);
+    setPreview(null);
+    setPreviewError(null);
+  }, [open, source?.id]); // The source identifies a new per-model operation.
+
+  const loadPreview = async () => {
+    if (!source || !targetId) return;
+    setPreviewError(null);
+    setIsPreviewing(true);
+    try {
+      setPreview(await previewDuplicateModelConsolidation(source.id, targetId));
+    } catch (error) {
+      setPreviewError(error instanceof Error ? error.message : 'Could not prepare this consolidation.');
+    } finally {
+      setIsPreviewing(false);
+    }
+  };
+
+  const confirm = async () => {
+    if (!source || !targetId) return;
+    setPreviewError(null);
+    setIsConfirming(true);
+    try {
+      const result = await consolidateDuplicateModels(source.id, targetId);
+      onComplete(result);
+      onOpenChange(false);
+    } catch (error) {
+      setPreviewError(error instanceof Error ? error.message : 'Consolidation failed. No changes were applied.');
+    } finally {
+      setIsConfirming(false);
+    }
+  };
+
+  const pending = isPreviewing || isConfirming;
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!pending || nextOpen) onOpenChange(nextOpen);
+      }}
+    >
+      <DialogContent className="max-w-2xl" showCloseButton={!pending}>
+        <DialogHeader>
+          <DialogTitle>Consolidate duplicate model</DialogTitle>
+          <DialogDescription>
+            {source
+              ? `Choose which identical model to keep. ${source.name} and its duplicate files will be removed only after you confirm the complete preview below.`
+              : 'Choose a duplicate model to consolidate.'}
+          </DialogDescription>
+        </DialogHeader>
+
+        {source && (
+          <fieldset className="rounded-lg border p-3">
+            <legend className="px-1 text-sm font-medium text-foreground">Keep this model</legend>
+            <div className="mt-1 flex flex-col gap-2">
+              {targets.map((target) => (
+                <label key={target.id} className="flex cursor-pointer items-center gap-3 rounded-md px-2 py-1.5 hover:bg-muted">
+                  <input
+                    type="radio"
+                    name="consolidate-target"
+                    checked={targetId === target.id}
+                    onChange={() => {
+                      setTargetId(target.id);
+                      setPreview(null);
+                      setPreviewError(null);
+                    }}
+                    disabled={pending}
+                    className="h-4 w-4 accent-primary"
+                  />
+                  <span className="text-sm font-medium text-foreground">{target.name}</span>
+                  {target.id === targets[0]?.id && (
+                    <span className="text-xs text-muted-foreground">Oldest copy</span>
+                  )}
+                </label>
+              ))}
+            </div>
+          </fieldset>
+        )}
+
+        {!preview && !previewError && (
+          <p className="text-sm text-muted-foreground">
+            First review the exact files, metadata, tags, and collection memberships that this action will handle.
+          </p>
+        )}
+
+        {preview && <ConsolidationPreview preview={preview} />}
+
+        {previewError && <p role="alert" className="rounded-md border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive">{previewError}</p>}
+
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={pending}>
+            Cancel
+          </Button>
+          {preview ? (
+            <Button type="button" variant="destructive" onClick={() => void confirm()} disabled={pending}>
+              {isConfirming && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              Consolidate and remove duplicate
+            </Button>
+          ) : (
+            <Button type="button" onClick={() => void loadPreview()} disabled={!targetId || pending}>
+              {isPreviewing && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              {isPreviewing ? 'Preparing preview…' : 'Review changes'}
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function ConsolidationPreview({ preview }: { preview: ConsolidateDuplicateModelsPreview }) {
+  return (
+    <div className="flex max-h-[48vh] flex-col gap-4 overflow-y-auto rounded-lg border bg-muted/20 p-4">
+      <div className="flex items-start gap-2 text-sm">
+        <Trash2 className="mt-0.5 h-4 w-4 shrink-0 text-destructive" />
+        <p>
+          <strong>{preview.sourceModel.name}</strong> will be deleted. <strong>{preview.targetModel.name}</strong> will remain.
+          {' '}{preview.deletedFileCount} duplicate {preview.deletedFileCount === 1 ? 'file' : 'files'} ({formatFileSize(preview.reclaimableBytes)}) will be removed from storage.
+        </p>
+      </div>
+
+      <div>
+        <h3 className="text-sm font-medium text-foreground">Files to remove</h3>
+        <ul className="mt-2 divide-y rounded-md border bg-background text-sm">
+          {preview.removedFiles.map((file) => (
+            <li key={file.id} className="flex items-center justify-between gap-3 px-3 py-2">
+              <span className="min-w-0 truncate font-mono text-xs text-muted-foreground" title={file.relativePath}>{file.relativePath}</span>
+              <span className="shrink-0 text-xs text-muted-foreground">{formatFileSize(file.sizeBytes)}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <div>
+        <h3 className="text-sm font-medium text-foreground">Generated thumbnails to remove</h3>
+        <ActionList
+          items={preview.removedThumbnails.map((thumbnail) =>
+            `${thumbnail.sourceFilename} — ${thumbnail.width} × ${thumbnail.height} ${thumbnail.format.toUpperCase()}`,
+          )}
+          empty="No generated thumbnails will be removed."
+        />
+      </div>
+
+      <div>
+        <h3 className="text-sm font-medium text-foreground">Metadata copied to the kept model</h3>
+        <ActionList
+          items={preview.copiedMetadata.map((metadata) => `${metadata.fieldName}: ${metadata.value}`)}
+          empty="No metadata fields need to be copied."
+        />
+      </div>
+
+      <div>
+        <h3 className="text-sm font-medium text-foreground">Collections added to the kept model</h3>
+        <ActionList
+          items={preview.addedCollections.map((collection) => collection.name)}
+          empty="No collection memberships need to be added."
+        />
+      </div>
+
+      <div>
+        <h3 className="text-sm font-medium text-foreground">Tags added to the kept model</h3>
+        <ActionList
+          items={preview.addedTags.map((tag) => tag.name)}
+          empty="No tags need to be added."
+        />
+      </div>
+      <p className="text-xs text-muted-foreground">This cannot be undone.</p>
+    </div>
+  );
+}
+
+function ActionList({ items, empty }: { items: string[]; empty: string }) {
+  return (
+    <ul className="mt-2 divide-y rounded-md border bg-background text-sm">
+      {items.length > 0 ? items.map((item) => (
+        <li key={item} className="px-3 py-2 text-muted-foreground">{item}</li>
+      )) : (
+        <li className="px-3 py-2 text-muted-foreground">{empty}</li>
+      )}
+    </ul>
+  );
+}

--- a/apps/frontend/src/pages/ToolsPage.test.tsx
+++ b/apps/frontend/src/pages/ToolsPage.test.tsx
@@ -3,9 +3,11 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  consolidateDuplicateModels,
   ignoreDuplicateFileGroup,
   markDuplicateFileGroup,
   markDuplicates,
+  previewDuplicateModelConsolidation,
   scanDuplicates,
 } from '../api/tools';
 import { ToolsPage } from './ToolsPage';
@@ -15,12 +17,16 @@ vi.mock('../api/tools', () => ({
   markDuplicates: vi.fn(),
   markDuplicateFileGroup: vi.fn(),
   ignoreDuplicateFileGroup: vi.fn(),
+  previewDuplicateModelConsolidation: vi.fn(),
+  consolidateDuplicateModels: vi.fn(),
 }));
 
 const mockScanDuplicates = vi.mocked(scanDuplicates);
 const mockMarkDuplicates = vi.mocked(markDuplicates);
 const mockMarkDuplicateFileGroup = vi.mocked(markDuplicateFileGroup);
 const mockIgnoreDuplicateFileGroup = vi.mocked(ignoreDuplicateFileGroup);
+const mockPreviewDuplicateModelConsolidation = vi.mocked(previewDuplicateModelConsolidation);
+const mockConsolidateDuplicateModels = vi.mocked(consolidateDuplicateModels);
 
 const duplicateScanResult = {
   scannedModelCount: 2,
@@ -89,6 +95,42 @@ describe('ToolsPage', () => {
     mockIgnoreDuplicateFileGroup.mockResolvedValue({
       ignoredFileGroupCount: 0,
       ignoredModelGroupCount: 0,
+    });
+    mockPreviewDuplicateModelConsolidation.mockResolvedValue({
+      sourceModel: { id: 'model-2', name: 'Dragon copy' },
+      targetModel: { id: 'model-1', name: 'Dragon original' },
+      removedFiles: [{
+        id: 'file-2',
+        filename: 'body-copy.stl',
+        relativePath: 'parts/body-copy.stl',
+        sizeBytes: 1024,
+        hash: 'a'.repeat(64),
+      }],
+      removedThumbnails: [],
+      copiedMetadata: [],
+      addedCollections: [],
+      addedTags: [],
+      copiedMetadataFieldCount: 1,
+      addedCollectionCount: 1,
+      addedTagCount: 2,
+      deletedFileCount: 1,
+      reclaimableBytes: 1024,
+      deletedSourceModelId: 'model-2',
+    });
+    mockConsolidateDuplicateModels.mockResolvedValue({
+      sourceModel: { id: 'model-2', name: 'Dragon copy' },
+      targetModel: { id: 'model-1', name: 'Dragon original' },
+      removedFiles: [],
+      removedThumbnails: [],
+      copiedMetadata: [],
+      addedCollections: [],
+      addedTags: [],
+      copiedMetadataFieldCount: 1,
+      addedCollectionCount: 1,
+      addedTagCount: 2,
+      deletedFileCount: 1,
+      reclaimableBytes: 1024,
+      deletedSourceModelId: 'model-2',
     });
   });
 
@@ -175,12 +217,51 @@ describe('ToolsPage', () => {
     expect(screen.getByRole('button', { name: /mark duplicates in file set 1/i })).toBeTruthy();
     expect(screen.getByRole('button', { name: /ignore duplicates in file set 1/i })).toBeTruthy();
     expect(screen.queryByRole('button', { name: /^ignore duplicates$/i })).toBeNull();
+    expect(screen.getByRole('button', { name: 'Consolidate' })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: /consolidate all/i })).toBeNull();
 
     const fileHeading = screen.getByRole('heading', { name: 'Duplicate files' });
     const modelHeading = screen.getByRole('heading', { name: 'Whole-model duplicates' });
     expect(
       fileHeading.compareDocumentPosition(modelHeading) & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
+  });
+
+  it('previews every file action and requires confirmation before consolidating one model', async () => {
+    mockScanDuplicates.mockResolvedValue({
+      ...duplicateScanResult,
+      groups: [{
+        fingerprint: 'same-files',
+        fileCount: 1,
+        totalSizeBytes: 100,
+        reclaimableBytes: 100,
+        models: [
+          { id: 'model-1', name: 'First model', originalFilename: 'first.zip', createdAt: '2025-01-01T00:00:00.000Z' },
+          { id: 'model-2', name: 'Second model', originalFilename: 'second.zip', createdAt: '2025-02-01T00:00:00.000Z' },
+        ],
+      }],
+    });
+
+    render(<ToolsPage />, { wrapper: makeWrapper() });
+    fireEvent.click(screen.getByRole('button', { name: /scan library/i }));
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Consolidate' })).toBeTruthy());
+    fireEvent.click(screen.getByRole('button', { name: 'Consolidate' }));
+
+    expect(screen.getByRole('dialog')).toBeTruthy();
+    expect(mockConsolidateDuplicateModels).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole('button', { name: 'Review changes' }));
+
+    await waitFor(() => {
+      expect(mockPreviewDuplicateModelConsolidation).toHaveBeenCalledWith('model-2', 'model-1');
+    });
+    expect(screen.getByText('Files to remove')).toBeTruthy();
+    expect(screen.getByText('parts/body-copy.stl')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: /consolidate and remove duplicate/i }));
+    await waitFor(() => {
+      expect(mockConsolidateDuplicateModels).toHaveBeenCalledWith('model-2', 'model-1');
+    });
   });
 
   it('announces scan progress and completion', async () => {

--- a/apps/frontend/src/pages/ToolsPage.tsx
+++ b/apps/frontend/src/pages/ToolsPage.tsx
@@ -3,6 +3,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
   ArrowLeft,
   CheckCircle2,
+  Combine,
   Copy,
   EyeOff,
   FileSearch,
@@ -21,6 +22,7 @@ import {
 } from '../api/tools';
 import { Badge } from '../components/ui/badge';
 import { Button } from '../components/ui/button';
+import { ConsolidateDuplicateDialog } from '../components/tools/ConsolidateDuplicateDialog';
 import { useLibraryPath } from '../hooks/use-libraries';
 import { formatDate, formatFileSize } from '../lib/format';
 
@@ -33,6 +35,7 @@ export function ToolsPage() {
   const libPath = useLibraryPath();
   const queryClient = useQueryClient();
   const [actionFeedback, setActionFeedback] = useState('');
+  const [consolidationSource, setConsolidationSource] = useState<DuplicateModel | null>(null);
   const scan = useQuery({
     queryKey: ['tools', 'duplicate-scan'],
     queryFn: scanDuplicates,
@@ -209,30 +212,53 @@ export function ToolsPage() {
               </p>
             </div>
           ) : scan.data ? (
-            <DuplicateResults
-              result={scan.data}
-              onMarkAll={() => {
-                resetActions();
-                markMutation.mutate();
-              }}
-              onMarkFileGroup={(target) => {
-                resetActions();
-                markFileGroupMutation.mutate(target);
-              }}
-              onIgnoreFileGroup={(target) => {
-                resetActions();
-                ignoreFileGroupMutation.mutate(target);
-              }}
-              markingAll={markMutation.isPending}
-              activeFileGroupAction={
-                markFileGroupMutation.isPending
-                  ? { hash: markFileGroupMutation.variables.hash, action: 'mark' }
-                  : ignoreFileGroupMutation.isPending
-                    ? { hash: ignoreFileGroupMutation.variables.hash, action: 'ignore' }
-                    : null
-              }
-              actionsDisabled={actionPending || scan.isFetching}
-            />
+            <>
+              <DuplicateResults
+                result={scan.data}
+                onMarkAll={() => {
+                  resetActions();
+                  markMutation.mutate();
+                }}
+                onMarkFileGroup={(target) => {
+                  resetActions();
+                  markFileGroupMutation.mutate(target);
+                }}
+                onIgnoreFileGroup={(target) => {
+                  resetActions();
+                  ignoreFileGroupMutation.mutate(target);
+                }}
+                onConsolidateModel={setConsolidationSource}
+                markingAll={markMutation.isPending}
+                activeFileGroupAction={
+                  markFileGroupMutation.isPending
+                    ? { hash: markFileGroupMutation.variables.hash, action: 'mark' }
+                    : ignoreFileGroupMutation.isPending
+                      ? { hash: ignoreFileGroupMutation.variables.hash, action: 'ignore' }
+                      : null
+                }
+                actionsDisabled={actionPending || scan.isFetching}
+              />
+              <ConsolidateDuplicateDialog
+                source={consolidationSource}
+                candidates={
+                  consolidationSource
+                    ? scan.data.groups.find((group) =>
+                        group.models.some((model) => model.id === consolidationSource.id),
+                      )?.models ?? []
+                    : []
+                }
+                open={consolidationSource !== null}
+                onOpenChange={(open) => {
+                  if (!open) setConsolidationSource(null);
+                }}
+                onComplete={(result) => {
+                  setActionFeedback(
+                    `Consolidated ${result.sourceModel.name} into ${result.targetModel.name}. Removed ${countPhrase(result.deletedFileCount, 'duplicate file')}.`,
+                  );
+                  void refreshDuplicateData();
+                }}
+              />
+            </>
           ) : (
             <div className="flex flex-col items-center justify-center gap-3 py-12 text-center">
               <Copy className="h-8 w-8 text-muted-foreground/60" />
@@ -268,6 +294,7 @@ function DuplicateResults({
   onMarkAll,
   onMarkFileGroup,
   onIgnoreFileGroup,
+  onConsolidateModel,
   markingAll,
   activeFileGroupAction,
   actionsDisabled,
@@ -276,6 +303,7 @@ function DuplicateResults({
   onMarkAll: () => void;
   onMarkFileGroup: (target: FileGroupActionTarget) => void;
   onIgnoreFileGroup: (target: FileGroupActionTarget) => void;
+  onConsolidateModel: (model: DuplicateModel) => void;
   markingAll: boolean;
   activeFileGroupAction: { hash: string; action: 'mark' | 'ignore' } | null;
   actionsDisabled: boolean;
@@ -443,8 +471,8 @@ function DuplicateResults({
               Whole-model duplicates
             </h2>
             <p className="mt-1 text-sm text-muted-foreground">
-              Ready models whose complete file sets match exactly. These matches are shown for
-              reference and do not have separate review actions.
+              Ready models whose complete file sets match exactly. Consolidate one model at a time
+              to remove its duplicate files while preserving the selected model.
             </p>
           </div>
 
@@ -458,8 +486,8 @@ function DuplicateResults({
           <div className="flex flex-col gap-4">
             {result.groups.map((group, index) => (
               <div key={group.fingerprint} className="overflow-hidden rounded-lg border">
-                <div className="flex flex-col gap-1 border-b bg-muted/30 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
-                  <div>
+                  <div className="flex flex-col gap-3 border-b bg-muted/30 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
+                    <div>
                     <h3 className="text-sm font-semibold text-foreground">
                       Duplicate model set {index + 1}
                     </h3>
@@ -467,11 +495,11 @@ function DuplicateResults({
                       {group.fileCount} {group.fileCount === 1 ? 'file' : 'files'} per model ·{' '}
                       {formatFileSize(group.totalSizeBytes)} each
                     </p>
-                  </div>
-                  <Badge variant="outline">
-                    {group.models.length} identical models ·{' '}
-                    {formatFileSize(group.reclaimableBytes)} reclaimable
-                  </Badge>
+                    </div>
+                    <Badge variant="outline">
+                      {group.models.length} identical models ·{' '}
+                      {formatFileSize(group.reclaimableBytes)} reclaimable
+                    </Badge>
                 </div>
                 <div className="divide-y">
                   {group.models.map((model, modelIndex) => (
@@ -479,6 +507,8 @@ function DuplicateResults({
                       key={model.id}
                       model={model}
                       suggestedKeep={modelIndex === 0}
+                      onConsolidate={modelIndex === 0 ? undefined : () => onConsolidateModel(model)}
+                      disabled={actionsDisabled}
                     />
                   ))}
                 </div>
@@ -543,7 +573,17 @@ function DuplicateFileRow({
   );
 }
 
-function DuplicateModelRow({ model, suggestedKeep }: { model: DuplicateModel; suggestedKeep: boolean }) {
+function DuplicateModelRow({
+  model,
+  suggestedKeep,
+  onConsolidate,
+  disabled,
+}: {
+  model: DuplicateModel;
+  suggestedKeep: boolean;
+  onConsolidate?: () => void;
+  disabled: boolean;
+}) {
   const libPath = useLibraryPath();
 
   return (
@@ -562,9 +602,17 @@ function DuplicateModelRow({ model, suggestedKeep }: { model: DuplicateModel; su
           {model.originalFilename ?? 'No original filename'}
         </p>
       </div>
-      <span className="whitespace-nowrap text-xs text-muted-foreground">
-        Added {formatDate(model.createdAt)}
-      </span>
+      <div className="flex shrink-0 items-center gap-3 sm:flex-col sm:items-end">
+        <span className="whitespace-nowrap text-xs text-muted-foreground">
+          Added {formatDate(model.createdAt)}
+        </span>
+        {onConsolidate && (
+          <Button size="sm" variant="outline" onClick={onConsolidate} disabled={disabled}>
+            <Combine className="mr-2 h-4 w-4" />
+            Consolidate
+          </Button>
+        )}
+      </div>
     </div>
   );
 }

--- a/docs/API.md
+++ b/docs/API.md
@@ -1555,7 +1555,7 @@ Values are validated against the resolved field definition before storage. Numbe
 
 ## Tools
 
-Tools are library maintenance operations exposed from the library-scoped Tools page at `/lib/:id/tools`. Duplicate review supports marking the complete report or marking and ignoring one duplicate file set at a time. There is no bulk ignore endpoint.
+Tools are library maintenance operations exposed from the library-scoped Tools page at `/lib/:id/tools`. Duplicate review supports marking the complete report or marking and ignoring one duplicate file set at a time. Exact whole-model duplicates can be consolidated one source model at a time after reviewing a server-generated preview; there is no bulk consolidation or bulk ignore endpoint.
 
 ### GET /tools/duplicates
 
@@ -1672,6 +1672,29 @@ Only `ready` models with at least one file are scanned. PostgreSQL aggregates ea
 Each member of `fileGroups` is a `DuplicateFileGroup`, whose `files` are `DuplicateFile` values. `scannedFileCount` counts all files read from eligible models. Within a file group, candidates are ordered by file creation time and file UUID, with owning model creation time and model UUID as later tie-breakers. `sizeBytes` is the oldest candidate's stored size, while `reclaimableBytes` sums every later candidate's size. `redundantFileCount` and `fileReclaimableBytes` aggregate those later candidates across all file groups. File groups are ordered by their oldest file's creation time, then hash and oldest file UUID.
 
 The example's `Dragon Bust Variant` has one file identical to both whole-model copies but different remaining content, so it appears in a file group without joining the whole-model group. File-level savings are independent from and may overlap whole-model savings; do not add `fileReclaimableBytes` to `reclaimableBytes`. All byte values are estimates only—the decision and any deletion remain manual.
+
+### POST /tools/duplicates/consolidate/preview
+
+Preview exactly one model consolidation for the confirmation modal. This endpoint is read-only.
+
+### POST /tools/duplicates/consolidate
+
+Confirm exactly one model consolidation. There is no global or multi-model action.
+
+**Auth required:** Yes. Both routes apply `requireAuth` followed by `requireLibrary`.
+
+**Request body (both routes):**
+
+```json
+{
+  "sourceModelId": "22222222-2222-4222-8222-222222222222",
+  "targetModelId": "11111111-1111-4111-8111-111111111111"
+}
+```
+
+The source and target must be distinct owned `ready` models in the active library, each with at least one file, whose complete sorted SHA-256 hash multisets are exactly equal. The confirmed route locks both models and their current file/metadata/tag/collection relationships in a serializable transaction, then repeats that check, so a stale modal can never discard a changed or non-identical source or silently lose a concurrent relationship update. A failed validation returns `400 VALIDATION_ERROR`; an unowned or missing model returns `404 NOT_FOUND`.
+
+The result of both routes is `ConsolidateDuplicateModelsResult`. It lists every source file and thumbnail that will be/was removed, reclaimed source-file bytes, and the exact named metadata, collection, and tag actions (`copiedMetadata`, `addedCollections`, and `addedTags`); matching count fields remain as summaries. Managed storage paths are not exposed. Confirmation retains the target's files, copies only metadata absent from the target, unions source collections and tags onto it, deletes the source model and its duplicate files, then performs managed-storage cleanup best-effort. The preview and execution payload shapes are intentionally identical.
 
 ### POST /tools/duplicates/mark
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -199,7 +199,7 @@ Routes that apply `requireLibrary` (as of P5):
 - `POST /models/upload`, `POST /models/upload/:uploadId/complete`, `POST /models/upload/multipart/complete`, `POST /models/import`
 - `GET /models/import-sessions`, `POST /models/import-sessions/:id/commit`
 - `GET /search`
-- `GET /tools/duplicates`, `POST /tools/duplicates/mark`, `POST /tools/duplicates/file-groups/:hash/mark`, `POST /tools/duplicates/file-groups/:hash/ignore`
+- `GET /tools/duplicates`, `POST /tools/duplicates/mark`, `POST /tools/duplicates/file-groups/:hash/mark`, `POST /tools/duplicates/file-groups/:hash/ignore`, `POST /tools/duplicates/consolidate/preview`, `POST /tools/duplicates/consolidate`
 - All `/smart-collections` routes
 - All `/bulk/*` routes
 - `POST /ai/chat`, `POST /ai/proposals/:id/apply`
@@ -374,6 +374,8 @@ File candidates are ordered by file creation time and file UUID, with owning-mod
 **Does not own:** Metadata CRUD (delegates to MetadataService), collection membership, ingestion pipeline, search, storage implementation, or thumbnail generation. Structural operations may copy existing metadata relationships as part of their transaction. Structural file operations use StorageService's backend-independent copy/delete interface.
 
 **Selected-file deletion behavior:** `deleteModelFiles` accepts 1–500 unique file IDs from an owned model in the active library. It locks the model to serialize file-membership aggregate updates, verifies the complete selection, captures file and thumbnail storage paths, deletes the file rows, recalculates model statistics, and reconciles duplicate-review flags in one transaction. A missing file aborts without deleting any of the selection, while a concurrent selection change produces a conflict and rolls back the transaction. After commit, batched deletion of the captured storage objects is best-effort, logs individual failures, and cannot change the successful database result.
+
+**Duplicate consolidation behavior:** ModelService previews and confirms one source/target pair from the duplicate Tools pane. Both models are revalidated as owned, active-library, ready, non-empty, and exact equal sorted hash multisets; confirmation locks both rows before repeating that validation. It retains the target's file rows and deletes the source model, cascading source file records, folders, thumbnails, and relationships. Before deletion, source metadata fills only target-missing fields and source collection/tag memberships are unioned onto the target. Source file and thumbnail objects are deleted in a best-effort batch after commit. The preview and confirmed result expose every removed source file, thumbnail cleanup path, and relationship count, and no operation accepts multiple source models or applies globally.
 
 **Split behavior:** The split endpoint accepts exactly one selection from an owned, ready model in the active library. `splitModelFolder` accepts a folder containing at least one file. Its files become the root contents of a new ready, `manual` model; descendant paths are rebased by removing the selected folder prefix, while persisted nested folders, including empty descendants, are preserved. `splitModelFiles` accepts 1–500 unique file IDs from the source model, moves all selected files into the same new model, and preserves each file's relative path. Existing ModelFile IDs and thumbnail records remain attached to their files. If the source model's selected preview is among the moved files, its preview selection and crop values transfer to the new model and are cleared on the source. Both models' file count and total size are recalculated. The new model receives the requested name and only the populated metadata values selected by field slug. The special `tags` slug copies tag memberships. Copied metadata remains on the source model; collection memberships, description, and other source provenance are never copied.
 
@@ -776,6 +778,8 @@ All provider routes apply `requireAuth` and enforce provider ownership in `AiPro
 | POST | /tools/duplicates/mark | Mark every file in the current non-ignored scan | DuplicateScannerService | Yes |
 | POST | /tools/duplicates/file-groups/:hash/mark | Mark one current duplicate file set | DuplicateScannerService | Yes |
 | POST | /tools/duplicates/file-groups/:hash/ignore | Ignore one current duplicate file set and clear its flags | DuplicateScannerService | Yes |
+| POST | /tools/duplicates/consolidate/preview | Preview one exact-duplicate model consolidation | ModelService | Yes |
+| POST | /tools/duplicates/consolidate | Confirm one exact-duplicate model consolidation | ModelService → StorageService | Yes |
 
 **Bulk Operations**
 | Method | Route | Purpose | Service Chain | Library-scoped |

--- a/docs/TYPES.md
+++ b/docs/TYPES.md
@@ -591,11 +591,56 @@ interface IgnoreDuplicatesResult {
   ignoredFileGroupCount: number;
   ignoredModelGroupCount: number;
 }
+
+interface ConsolidatedDuplicateFile {
+  id: string;
+  filename: string;
+  relativePath: string;
+  sizeBytes: number;
+  hash: string;
+}
+
+interface ConsolidatedDuplicateThumbnail {
+  id: string;
+  sourceFileId: string;
+  sourceFilename: string;
+  width: number;
+  height: number;
+  format: string;
+}
+
+interface ConsolidatedDuplicateMetadata {
+  fieldDefinitionId: string;
+  fieldName: string;
+  fieldSlug: string;
+  value: string;
+}
+
+interface ConsolidatedDuplicateCollection { id: string; name: string; }
+interface ConsolidatedDuplicateTag { id: string; name: string; }
+
+interface ConsolidateDuplicateModelsResult {
+  sourceModel: { id: string; name: string };
+  targetModel: { id: string; name: string };
+  removedFiles: ConsolidatedDuplicateFile[];
+  removedThumbnails: ConsolidatedDuplicateThumbnail[];
+  copiedMetadata: ConsolidatedDuplicateMetadata[];
+  addedCollections: ConsolidatedDuplicateCollection[];
+  addedTags: ConsolidatedDuplicateTag[];
+  copiedMetadataFieldCount: number;
+  addedCollectionCount: number;
+  addedTagCount: number;
+  deletedFileCount: number;
+  reclaimableBytes: number;
+  deletedSourceModelId: string;
+}
 ```
 
 PostgreSQL aggregates each `ready`, non-empty model's file hashes into one model row and returns file detail only for hashes that occur more than once in the same scope. Individual file identity is exact SHA-256 equality. Whole-model identity uses the complete sorted multiset of per-file SHA-256 hashes. File order, filenames, and relative paths are ignored, but hash multiplicity is preserved. Models that are not `ready` or contain no files are excluded. File hashes and whole-model fingerprints stored as ignored for the active library are excluded from the result.
 
 Files within a `DuplicateFileGroup` are ordered by file creation time and file UUID, with owning model creation time and model UUID as later tie-breakers. File groups are ordered by their oldest file's creation time, then hash and oldest file UUID. Models within a `DuplicateGroup` are ordered by creation time and UUID; whole-model groups are ordered by their oldest model, with fingerprint as the final tie-breaker. `fileReclaimableBytes` is independent from `reclaimableBytes` and can describe some of the same stored data, so the two estimates must not be added together. `DuplicateScanResult` describes a report only; scanning does not delete, merge, or otherwise modify a model or file. `POST /tools/duplicates/mark` marks the complete current report, while `POST /tools/duplicates/file-groups/:hash/mark` marks one current file group and preserves other current marks; both return the total marked file and model counts in `MarkDuplicatesResult`. `POST /tools/duplicates/file-groups/:hash/ignore` returns `{ ignoredFileGroupCount: 1, ignoredModelGroupCount: 0 }` after storing that file group's hash as a library-scoped ignore key, clearing its file marks, and recalculating derived model marks. There is no bulk ignore endpoint. Both per-file-group actions return `NOT_FOUND` when the hash is not a current, non-ignored duplicate file group. Reconciliation after a file-set mutation preserves marked files only while they remain in a current, non-ignored duplicate group; it clears stale marks without marking unrelated groups.
+
+`ConsolidateDuplicateModelsPreview` and `ConsolidateDuplicateModelsResult` share the latter shape. They are strictly per-model: source and target must be distinct, owned, ready models in the active library with equal non-empty sorted hash multisets. Preview is read-only. Confirmed consolidation retains every target file, deletes every source file record and its managed storage objects, deletes the source model, copies only source metadata fields absent from the target, and unions source collection and tag memberships onto the target. `removedThumbnails`, `copiedMetadata`, `addedCollections`, and `addedTags` enumerate the exact named actions for the confirmation dialog; the count fields are matching compatibility summaries. Managed storage paths are deliberately never returned. The returned action summary is the complete confirmation-dialog contract; there is no global or bulk consolidation request.
 
 ### Metadata Response Types
 

--- a/packages/shared/src/types/tools.ts
+++ b/packages/shared/src/types/tools.ts
@@ -50,3 +50,71 @@ export interface IgnoreDuplicatesResult {
   ignoredFileGroupCount: number;
   ignoredModelGroupCount: number;
 }
+
+/** One physical object removed while consolidating an exact duplicate model. */
+export interface ConsolidatedDuplicateFile {
+  id: string;
+  filename: string;
+  relativePath: string;
+  sizeBytes: number;
+  hash: string;
+}
+
+/** A generated rendition removed with one of the source files. */
+export interface ConsolidatedDuplicateThumbnail {
+  id: string;
+  sourceFileId: string;
+  sourceFilename: string;
+  width: number;
+  height: number;
+  format: string;
+}
+
+/** A source metadata value copied because the target did not have that field. */
+export interface ConsolidatedDuplicateMetadata {
+  fieldDefinitionId: string;
+  fieldName: string;
+  fieldSlug: string;
+  value: string;
+}
+
+export interface ConsolidatedDuplicateCollection {
+  id: string;
+  name: string;
+}
+
+export interface ConsolidatedDuplicateTag {
+  id: string;
+  name: string;
+}
+
+export interface ConsolidatedDuplicateModel {
+  id: string;
+  name: string;
+}
+
+/**
+ * The complete, per-model effect of consolidating one exact duplicate into a
+ * retained model. The preview and confirmed result intentionally have the
+ * same shape so the confirmation dialog can display every action up front.
+ */
+export interface ConsolidateDuplicateModelsResult {
+  sourceModel: ConsolidatedDuplicateModel;
+  targetModel: ConsolidatedDuplicateModel;
+  removedFiles: ConsolidatedDuplicateFile[];
+  removedThumbnails: ConsolidatedDuplicateThumbnail[];
+  copiedMetadata: ConsolidatedDuplicateMetadata[];
+  addedCollections: ConsolidatedDuplicateCollection[];
+  addedTags: ConsolidatedDuplicateTag[];
+  /** Compatibility summary for copiedMetadata.length. */
+  copiedMetadataFieldCount: number;
+  /** Compatibility summary for addedCollections.length. */
+  addedCollectionCount: number;
+  /** Compatibility summary for addedTags.length. */
+  addedTagCount: number;
+  deletedFileCount: number;
+  reclaimableBytes: number;
+  deletedSourceModelId: string;
+}
+
+export type ConsolidateDuplicateModelsPreview = ConsolidateDuplicateModelsResult;

--- a/packages/shared/src/validation/tools.ts
+++ b/packages/shared/src/validation/tools.ts
@@ -5,3 +5,13 @@ export const duplicateFileGroupParamsSchema = z.object({
 });
 
 export type DuplicateFileGroupParams = z.infer<typeof duplicateFileGroupParamsSchema>;
+
+export const consolidateDuplicateModelsSchema = z.object({
+  sourceModelId: z.string().uuid(),
+  targetModelId: z.string().uuid(),
+}).refine((value) => value.sourceModelId !== value.targetModelId, {
+  message: 'Source and target models must be different',
+  path: ['sourceModelId'],
+});
+
+export type ConsolidateDuplicateModelsRequest = z.infer<typeof consolidateDuplicateModelsSchema>;


### PR DESCRIPTION
## Summary

- Add backend support for consolidating duplicate models
- Expose shared types, validation, and API client functionality
- Add a frontend consolidation dialog and Tools page integration
- Update API, architecture, and type documentation

## Testing

- Added and updated backend route, service, integration, and frontend page tests
- Not run (not requested)