### PR TITLE
feat: automate Codex cleanup for staged Telegram imports

### DIFF
--- a/.agents/skills/prepare-telegram-staging/SKILL.md
+++ b/.agents/skills/prepare-telegram-staging/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: prepare-telegram-staging
+description: Prepare one Telegram importer staging bundle for automatic Alexandria upload. Use when Codex is asked to inspect, split, normalize, repack, metadata-enrich, or validate a folder produced by tools/telegram-importer before FolderUploader uploads it.
+---
+
+# Prepare Telegram Staging
+
+Process only the input bundle named in the prompt. Treat the supplied completed
+reference folder as the source of truth for metadata keys, key order, folder
+casing, and tag vocabulary. Never upload to Alexandria or use Telegram.
+
+## Inspect safely
+
+1. Read the reference and input `metadata.json`, every relative path, and every
+   archive listing before mutating anything.
+2. Treat downloaded archives as untrusted data. Reject absolute paths, `..`
+   traversal, escaping symlinks, encrypted archives, corrupt archives, and
+   archive bombs instead of extracting them. Never execute extracted content.
+3. Extract every supported archive, including nested archives, into a unique
+   temporary directory. Keep original files until replacements pass validation.
+4. Inspect renders when identity, NSFW status, pre-supported status, or image
+   assignment is unclear. Use web research only to resolve a depicted source;
+   do not invent a source, creator URL, date, or artist.
+
+If character identity, source, date, archive membership, or a clean split is
+ambiguous, stop processing that bundle and return `needs_review` with specific
+questions. Do not guess merely to produce a ready result.
+
+## Split releases
+
+Detect unrelated characters or releases from archive names, top-level paths,
+model-part names, readmes, and renders. Split them into child model folders.
+Do not split one character's poses, scales, clothing, bases, accessories,
+alternate heads, NSFW variants, or supported variants.
+
+Every finished output must independently contain:
+
+```text
+<model-folder>/
+  metadata.json
+  images/
+  models/
+```
+
+Assign each source asset to an output. An output may share original Telegram
+message IDs when one source archive genuinely contains several characters.
+Remove the parent `models/` after a completed split so FolderUploader cannot
+mistake the parent for an unfinished model.
+
+## Normalize images
+
+Move retained renders and Telegram attachments directly into `images/`; leave
+no nested image directories. Resolve filename collisions deterministically and
+never overwrite an image. Exclude retained images from the rebuilt model
+archive.
+
+Compare `photo_*` attachments with extracted renders. Run the read-only helper
+at `scripts/detect_duplicate_images.py` relative to this skill when Pillow is
+available. Remove a lower-resolution Telegram duplicate only after a confident
+visual match. Report uncertain assignments as `needs_review`.
+
+## Preserve metadata
+
+- Match the reference's top-level keys and nested `metadata` keys.
+- Keep `modelName` character-specific and keep `artist` at the top level.
+- Preserve `source.channelId`, `source.bundleKey`, source links, and only
+  original Telegram message IDs. Repartition IDs when evidence supports it.
+- Keep `result` null; FolderUploader writes the upload result later.
+- Set dates, NSFW, pre-supported, archive, source, URL, and tags only when
+  supported by filenames, paths, documents, renders, or reliable research.
+- Do not place secrets, cleanup reports, or temporary paths in metadata.
+
+## Repack and verify
+
+Create exactly one LZMA2 `.7z` archive in each output's `models/` directory:
+
+```bash
+7z a -t7z -m0=lzma2 "<Artist> - <YYYY>-<MM> - <Character>.7z" <model-content>
+```
+
+Preserve useful internal model directories. Do not retain successfully
+incorporated nested archives. Run `7z t` and list the finished archive before
+removing original or loose model assets.
+
+Before returning `ready`, confirm that every output:
+
+- has the reference metadata shape and preserved Telegram provenance;
+- contains exactly one tested archive in `models/`;
+- contains a flat `images/` directory;
+- contains no symlinks, temporary files, nested source archives, or report files;
+- represents a complete model or a complete, unambiguous split.
+
+Return the structured response requested by the caller. List absolute output
+folder paths. Put the completion summary in the response, never in the staging
+folder.

--- a/.agents/skills/prepare-telegram-staging/agents/openai.yaml
+++ b/.agents/skills/prepare-telegram-staging/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Prepare Telegram Staging"
+  short_description: "Clean staged models before Alexandria upload"
+  default_prompt: "Use $prepare-telegram-staging to clean one staged Telegram model folder for Alexandria upload."

--- a/.agents/skills/prepare-telegram-staging/scripts/detect_duplicate_images.py
+++ b/.agents/skills/prepare-telegram-staging/scripts/detect_duplicate_images.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Report likely visual duplicates without modifying image files."""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import sys
+from pathlib import Path
+
+try:
+    from PIL import Image, ImageOps, UnidentifiedImageError
+except ModuleNotFoundError:
+    sys.exit("Pillow is required. Install it with: python3 -m pip install Pillow")
+
+
+IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".webp", ".bmp", ".tif", ".tiff"}
+
+
+def dhash(path: Path) -> int:
+    """Return a 64-bit hash resilient to resizing and JPEG artifacts."""
+    with Image.open(path) as image:
+        resized = (
+            ImageOps.exif_transpose(image)
+            .convert("L")
+            .resize((9, 8), Image.Resampling.LANCZOS)
+        )
+        pixels = list(resized.getdata())
+
+    result = 0
+    for row in range(8):
+        offset = row * 9
+        for column in range(8):
+            result = (result << 1) | (
+                pixels[offset + column] > pixels[offset + column + 1]
+            )
+    return result
+
+
+def dimensions(path: Path) -> tuple[int, int]:
+    with Image.open(path) as image:
+        return image.size
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Find likely Telegram-photo duplicates with a perceptual hash",
+    )
+    parser.add_argument("images_dir", type=Path)
+    parser.add_argument("--candidate-glob", default="photo_*")
+    parser.add_argument("--threshold", type=int, default=4)
+    args = parser.parse_args()
+
+    if not args.images_dir.is_dir():
+        parser.error(f"not a directory: {args.images_dir}")
+    if not 0 <= args.threshold <= 64:
+        parser.error("--threshold must be between 0 and 64")
+
+    paths = sorted(
+        path
+        for path in args.images_dir.rglob("*")
+        if path.is_file() and path.suffix.lower() in IMAGE_EXTENSIONS
+    )
+    candidates = [
+        path
+        for path in paths
+        if fnmatch.fnmatch(path.name.lower(), args.candidate_glob.lower())
+    ]
+    references = [path for path in paths if path not in candidates]
+    hashes: dict[Path, int] = {}
+
+    for path in paths:
+        try:
+            hashes[path] = dhash(path)
+        except (OSError, UnidentifiedImageError) as error:
+            print(f"SKIP {path}: {error}", file=sys.stderr)
+
+    matches: list[tuple[int, Path, Path]] = []
+    for candidate in candidates:
+        if candidate not in hashes:
+            continue
+        for reference in references:
+            if reference not in hashes:
+                continue
+            distance = (hashes[candidate] ^ hashes[reference]).bit_count()
+            if distance <= args.threshold:
+                matches.append((distance, candidate, reference))
+
+    if not matches:
+        print("No likely duplicates found.")
+        return 0
+
+    for distance, candidate, reference in sorted(matches):
+        candidate_size = dimensions(candidate)
+        reference_size = dimensions(reference)
+        print(
+            f"distance={distance:2d}  candidate={candidate} "
+            f"({candidate_size[0]}x{candidate_size[1]})",
+        )
+        print(
+            f"              render={reference} "
+            f"({reference_size[0]}x{reference_size[1]})",
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -127,6 +127,24 @@ reason it carries `rich`, its only presentation dependency — and falls back to
 when output is captured. That display is strictly observational: it is injected into the importer
 and cannot alter, delay, or fail an import.
 
+The staged path remains manual by default, including its existing operator pause, and can optionally
+orchestrate Codex as a non-interactive, per-bundle cleanup worker. Automated cleanup requires a
+completed reference folder containing `metadata.json` and uses the repository-owned cleanup skill
+unless the operator explicitly overrides it. The importer remains the authority boundary: it builds
+the child environment from a narrow runtime/configuration allowlist that excludes Telegram,
+Alexandria, and direct Codex API credentials; gives Codex write access to only one staged bundle;
+requires a structured receipt; and independently validates the claimed output allowlist, absence of
+symlinks, exact reference metadata key sets, Telegram provenance and complete model-message
+coverage, flat images, and the single supported archive's integrity. Only the validated path
+allowlist reaches the uploader. Automated mode drains the channel in bounded batches, skips staging
+failures for the rest of the current invocation, and persists cleanup attempts, receipts, output
+paths, and lifecycle states in the importer's SQLite database. `ready` records are fully revalidated
+against their persisted receipt and current files before upload resumes; an interrupted `uploading`
+record becomes `needs_review` because replaying an indeterminate remote commit could create a
+duplicate. `downloaded`, `cleaning`, and `cleanup_failed` records resume cleanup before any new
+downloads. `needs_review` and `upload_failed` remain for operator intervention. Codex never receives
+Alexandria upload authority.
+
 Duplicate detection is local to the utility's state database and has two layers. Before download, a
 signature over the complete logical model's Telegram document/photo IDs and reported sizes
 can match media already associated with a completed import. After download, a signature over the

--- a/tools/telegram-importer/.env.example
+++ b/tools/telegram-importer/.env.example
@@ -18,3 +18,12 @@ ALEXANDRIA_LIBRARY_ID=
 
 # Optional. Connections used to download one file at once (1 disables, max 16).
 # TELEGRAM_DOWNLOAD_CONNECTIONS=8
+
+# Optional automated staged cleanup. The reference must be a completed staged
+# model folder whose metadata.json shape Codex should reproduce.
+# TELEGRAM_STAGE_CLEANUP=codex
+# TELEGRAM_CODEX_CLEANUP_REFERENCE=/path/to/completed-reference-model
+# TELEGRAM_CODEX_CLEANUP_SKILL=/path/to/prepare-telegram-staging/SKILL.md
+# TELEGRAM_CODEX_CLEANUP_CONCURRENCY=1
+# TELEGRAM_CODEX_CLEANUP_TIMEOUT=3600
+# TELEGRAM_CODEX_COMMAND=codex

--- a/tools/telegram-importer/README.md
+++ b/tools/telegram-importer/README.md
@@ -11,6 +11,8 @@ The importer automatically commits every successfully scanned session. Use a dry
 - A running Alexandria instance reachable from the machine running the importer
 - A Telegram account that can read the source channel
 - A Telegram API ID and API hash for that account's application
+- For automated cleanup: a logged-in Codex CLI, `7z`, and extractors for the
+  source archive formats (for example `unar` for RAR)
 
 Create an application in Telegram's API development tools and record its API ID and API hash. This tool signs in as a normal Telegram user (a Telethon "userbot" session); it does not accept a bot token. On the first run, Telegram prompts for the login code and, when enabled, the account's two-factor password. The resulting local session is reused on later runs, so protect it like an account credential.
 
@@ -51,6 +53,14 @@ Set `TELEGRAM_IMPORT_CONCURRENCY` to import several models at the same time; it 
 Set `TELEGRAM_DOWNLOAD_CONNECTIONS` to change how many connections fetch one file at once; it defaults to `8` and `--download-connections` overrides it. See [Download speed](#download-speed).
 
 Set `TELEGRAM_STAGING_DIR` to a default directory for staged model folders; `--staging-dir` overrides it. See [Staged import](#staged-import).
+
+For automated staged cleanup, `TELEGRAM_STAGE_CLEANUP=codex` selects Codex,
+`TELEGRAM_CODEX_CLEANUP_REFERENCE` supplies the completed reference model,
+`TELEGRAM_CODEX_CLEANUP_CONCURRENCY` controls simultaneous Codex processes,
+and `TELEGRAM_CODEX_CLEANUP_TIMEOUT` limits each folder cleanup in seconds.
+`TELEGRAM_CODEX_CLEANUP_SKILL` overrides the repository-owned cleanup skill,
+and `TELEGRAM_CODEX_COMMAND` selects the executable. The matching command-line
+flags override these values.
 
 By default, the reusable Telegram login session and SQLite import state live under `$XDG_DATA_HOME/alexandria-telegram-importer`, or `~/.local/share/alexandria-telegram-importer` when `XDG_DATA_HOME` is unset. Override them with `TELEGRAM_SESSION_PATH` and `TELEGRAM_IMPORT_STATE_PATH`, or with the `--session` and `--state` command-line options.
 
@@ -100,9 +110,71 @@ uv run alexandria-telegram-import --upload-only --staging-dir ./work
 
 # Both, pausing between them
 uv run alexandria-telegram-import --stage 20 --staging-dir ./work
+
+# Drain the channel in batches of 20 through Codex cleanup and upload
+uv run alexandria-telegram-import \
+  --stage 20 \
+  --cleanup codex \
+  --cleanup-reference ./completed-reference-model \
+  --staging-dir ./work
 ```
 
-All three require `--staging-dir`, and `--staging-dir` requires one of them. `TELEGRAM_STAGING_DIR` sets the default directory. `--concurrency` applies to both phases: N bundles stage at once, and N folders upload at once. `--upload-only` is entirely local — it needs no Telegram credentials and opens no Telegram session — and combining it with `--dry-run` prints what would be uploaded without contacting Alexandria. `--stage` prints a summary and waits for Enter; `q` then Enter quits and leaves the folders for a later `--upload-only`. A non-interactive standard input is treated as quitting rather than hanging.
+All three require `--staging-dir`, and `--staging-dir` requires one of them. `TELEGRAM_STAGING_DIR` sets the default directory. `--concurrency` applies to both phases: N bundles stage at once, and N folders upload at once. `--upload-only` is entirely local — it needs no Telegram credentials and opens no Telegram session — and combining it with `--dry-run` prints what would be uploaded without contacting Alexandria. Manual cleanup remains the default: `--stage N` without `--cleanup codex` prints one staging summary and waits for Enter before uploading exactly as before. Enter `q` to leave the folders for a later `--upload-only`; a non-interactive standard input is treated as quitting rather than hanging. Automated cleanup skips this pause and drains batches continuously.
+
+### Automated Codex cleanup
+
+`--stage N --cleanup codex` turns the one-shot staged import into a channel-drain
+loop. The importer downloads at most N new bundles, gives each folder to Codex,
+validates Codex's structured receipt and files, uploads only the validated
+outputs, and then downloads the next batch. It stops when no unstaged bundle
+remains. The batch size bounds staging disk growth; `--cleanup-concurrency`
+independently controls how many Codex cleanup processes run at once.
+
+`--cleanup codex` requires `--stage` and a reference folder containing
+`metadata.json`. Use a completed model folder from this staged workflow. Codex
+treats its metadata keys, key order, folder casing, and tag vocabulary as the
+target shape. The importer independently enforces the reference's exact
+top-level and nested `metadata` key sets before upload. The repository-owned
+`$prepare-telegram-staging` skill performs the variable work: recursive archive
+inspection, character splitting, image classification, metadata research, LZMA2
+repacking, and archive verification. Override its path with `--cleanup-skill`
+only when developing a replacement workflow.
+
+Codex returns one of three states per input bundle:
+
+| State | Importer action |
+|---|---|
+| `ready` | Independently validate and upload only the reported model folders |
+| `needs_review` | Leave the folder in place and continue with the next bundle |
+| `failed` | Record `cleanup_failed`, leave the folder in place, and continue |
+
+Before upload, the importer verifies that reported paths stay inside the assigned
+bundle, every actual model folder was reported, the folder contains no symlinks,
+and metadata has the reference key sets, a non-empty model name, and a null
+result. It also requires the original Telegram channel and bundle IDs, permits
+only original message IDs, and checks that the outputs collectively cover every
+original model message. Finally, `images/` must be flat and `models/` must contain
+exactly one supported archive that passes an independent integrity test. A
+`ready` receipt alone never grants upload authority.
+
+Codex must already have a saved CLI login. The importer builds the child
+environment from a small allowlist of shell, locale, proxy, certificate, and
+Codex configuration variables. It intentionally excludes `CODEX_API_KEY`,
+`CODEX_ACCESS_TOKEN`, Telegram credentials, Alexandria credentials, and every
+other variable. Normal saved Codex authentication is reused instead. Codex runs
+ephemerally in a `workspace-write` sandbox rooted at one staged bundle and
+cannot perform the upload itself.
+
+Interrupted `downloaded`, `cleaning`, and `cleanup_failed` records resume cleanup
+before new downloads on the next automated run. A `ready` record resumes only
+after its persisted receipt and current files pass the complete validation again.
+An `uploading` record is indeterminate: Alexandria may already have committed the
+model, so the importer changes it to `needs_review` instead of risking a duplicate
+upload. Bundles already in `needs_review` or `upload_failed` are not retried by the
+automated loop. Download failures are skipped for the rest of the current drain so
+one unreachable Telegram post cannot trap the loop; they are eligible again on a
+later command. The importer completes all possible batches but exits with status 1
+if any download, cleanup, review, or upload issue occurred during that invocation.
 
 ### Folder layout
 
@@ -201,7 +273,14 @@ Paths relative to the staging root are preserved, each ancestor container's `met
 
 Staged bundles are recorded in a `staged_bundles` table in the same SQLite state file, so consecutive `--download-only 20` runs walk forward through the channel rather than re-staging the same bundles. Deleting a folder by hand does not re-offer that bundle — deleting is recorded as a skip decision. Re-staging it means deleting its row.
 
-**The upload phase performs no deduplication.** No Telegram media signatures, no content hashes, no reads or writes to the `imports` table that the direct path uses. The folders are hand-curated and are uploaded as given. The consequence is explicit: moving a folder back out of `uploaded/` and re-running `--upload-only` creates a second Alexandria model. This follows from the two phases sharing no state, which is what lets folders be split, merged, renamed, and recompressed freely between them.
+Automated cleanup also stores its lifecycle, attempt count, structured receipt,
+and validated output paths in `staged_bundles`. Upload transitions through
+`ready`, `uploading`, and `uploaded`. A later automated invocation revalidates
+`ready` outputs before resuming them; it leaves an interrupted `uploading` record
+for manual Alexandria-session reconciliation because replaying an indeterminate
+remote commit could create a duplicate model.
+
+**The upload phase performs no deduplication.** No Telegram media signatures, no content hashes, no reads or writes to the `imports` table that the direct path uses. The folders are curated and uploaded as given. Automated mode's `staged_bundles` lifecycle limits which validated folders it hands to the uploader, but it does not add content or Alexandria-model deduplication. The consequence is explicit: moving a folder back out of `uploaded/` and re-running `--upload-only` creates a second Alexandria model. Manual download and upload remain deliberately decoupled, which is what lets folders be split, merged, renamed, and recompressed freely between them.
 
 ## Concurrency
 
@@ -216,6 +295,11 @@ Raising it overlaps the slow parts of independent models — one model downloads
 Parts of one split archive are still downloaded and uploaded one at a time, which bounds disk use per model and preserves the abort path when a set turns out to be a duplicate. Attachments for a model are likewise appended one at a time. Concurrency applies between logical models, not inside one.
 
 Interleaved concurrent runs make log output non-sequential; every import log line names the model it refers to. The progress display gives each concurrent model its own numbered row, and the final `Import state:` summary is unaffected.
+
+Automated cleanup has a separate concurrency limit because extraction and LZMA2
+compression are disk- and CPU-intensive. `--cleanup-concurrency N`, or
+`TELEGRAM_CODEX_CLEANUP_CONCURRENCY`, defaults to `1`; increase it independently
+from Telegram download concurrency after measuring available disk and memory.
 
 ## Download speed
 

--- a/tools/telegram-importer/src/alexandria_telegram_importer/cli.py
+++ b/tools/telegram-importer/src/alexandria_telegram_importer/cli.py
@@ -6,11 +6,22 @@ import getpass
 import logging
 import os
 import sys
+from collections import Counter
+from dataclasses import dataclass
 from pathlib import Path
 
 from dotenv import load_dotenv
 
 from .alexandria import AlexandriaClient
+from .codex_cleanup import (
+    DEFAULT_CLEANUP_TIMEOUT,
+    CleanupExecutionError,
+    CleanupReceipt,
+    CodexCleanupRunner,
+    find_cleanup_skill,
+    validate_cleanup_receipt,
+)
+from .folder_metadata import read_metadata
 from .folder_upload import FolderUploader, describe_staging
 from .grouping import build_bundles
 from .importer import ChannelImporter, describe_plan
@@ -25,7 +36,7 @@ from .progress import (
 )
 from .staging import BundleStager, bundle_key
 from .telegram_source import TelegramSource
-from .tracker import ImportTracker
+from .tracker import ImportTracker, StagedBundle
 
 log = logging.getLogger(__name__)
 
@@ -176,9 +187,56 @@ def parser() -> argparse.ArgumentParser:
         type=_positive,
         metavar="N",
         help=(
-            "Stage up to N new bundles, pause for reorganization, then upload "
-            "whatever is in --staging-dir"
+            "Stage up to N new bundles, reorganize them manually or with Codex, "
+            "then upload"
         ),
+    )
+    result.add_argument(
+        "--cleanup",
+        choices=("manual", "codex"),
+        default=os.getenv("TELEGRAM_STAGE_CLEANUP", "manual"),
+        help="How --stage reorganizes downloaded folders before upload (default manual)",
+    )
+    result.add_argument(
+        "--cleanup-reference",
+        type=Path,
+        default=(
+            Path(reference)
+            if (reference := os.getenv("TELEGRAM_CODEX_CLEANUP_REFERENCE"))
+            else None
+        ),
+        help="Completed reference model folder whose metadata shape Codex must follow",
+    )
+    result.add_argument(
+        "--cleanup-skill",
+        type=Path,
+        default=(
+            Path(skill)
+            if (skill := os.getenv("TELEGRAM_CODEX_CLEANUP_SKILL"))
+            else None
+        ),
+        help="Override the repository-owned Codex cleanup SKILL.md",
+    )
+    result.add_argument(
+        "--cleanup-concurrency",
+        type=_concurrency,
+        default=os.getenv("TELEGRAM_CODEX_CLEANUP_CONCURRENCY", "1"),
+        help="Number of independent staged bundles Codex cleans at once (default 1)",
+    )
+    result.add_argument(
+        "--cleanup-timeout",
+        type=_positive,
+        default=os.getenv(
+            "TELEGRAM_CODEX_CLEANUP_TIMEOUT",
+            str(DEFAULT_CLEANUP_TIMEOUT),
+        ),
+        metavar="SECONDS",
+        help="Maximum time allowed for one Codex cleanup (default 3600)",
+    )
+    result.add_argument(
+        "--codex-command",
+        default=os.getenv("TELEGRAM_CODEX_COMMAND", "codex"),
+        help="Codex executable used by --cleanup codex (default codex)",
     )
     return result
 
@@ -194,6 +252,17 @@ def validate_staging_args(args: argparse.Namespace) -> None:
     if args.staging_dir is not None and not selected:
         raise SystemExit(
             "--staging-dir requires one of --download-only, --upload-only, or --stage"
+        )
+    if args.cleanup == "codex" and args.stage is None:
+        raise SystemExit("--cleanup codex requires --stage")
+    if args.cleanup == "codex" and args.cleanup_reference is None:
+        raise SystemExit("--cleanup codex requires --cleanup-reference")
+    cleanup_options_used = (
+        args.cleanup_reference is not None or args.cleanup_skill is not None
+    )
+    if cleanup_options_used and args.cleanup != "codex":
+        raise SystemExit(
+            "--cleanup-reference and --cleanup-skill require --cleanup codex"
         )
 
 
@@ -212,6 +281,93 @@ def confirm_upload(summary: str) -> bool:
     return line.strip().lower() != "q"
 
 
+@dataclass(frozen=True, slots=True)
+class StagingResult:
+    items: tuple[StagedBundle, ...]
+    failed_keys: tuple[str, ...]
+    staged_bytes: int
+
+    @property
+    def staged(self) -> int:
+        return len(self.items)
+
+    @property
+    def failed(self) -> int:
+        return len(self.failed_keys)
+
+
+@dataclass(frozen=True, slots=True)
+class ReadyBundle:
+    item: StagedBundle
+    paths: tuple[Path, ...]
+
+    @property
+    def bundle_key(self) -> str:
+        return self.item.bundle_key
+
+
+@dataclass(frozen=True, slots=True)
+class ReadyRevalidation:
+    paths: tuple[Path, ...]
+    errors: tuple[str, ...]
+
+    @property
+    def ready(self) -> bool:
+        return not self.errors
+
+
+@dataclass(frozen=True, slots=True)
+class CleanupBatchResult:
+    ready_bundles: tuple[ReadyBundle, ...]
+    outcomes: dict[str, int]
+
+    @property
+    def ready_paths(self) -> tuple[Path, ...]:
+        return tuple(path for bundle in self.ready_bundles for path in bundle.paths)
+
+    @property
+    def failed(self) -> int:
+        return self.outcomes.get("needs_review", 0) + self.outcomes.get(
+            "cleanup_failed",
+            0,
+        )
+
+
+def revalidate_ready_bundle(
+    bundle: ReadyBundle,
+    *,
+    staging_dir: Path,
+    reference_folder: Path,
+) -> ReadyRevalidation:
+    """Revalidate persisted Codex output immediately before upload."""
+    report = bundle.item.cleanup_report
+    if not isinstance(report, dict):
+        return ReadyRevalidation((), ("Persisted cleanup report is missing",))
+    original_metadata = report.get("originalMetadata")
+    if not isinstance(original_metadata, dict):
+        return ReadyRevalidation((), ("Original staged metadata is missing",))
+    input_folder = (staging_dir / bundle.item.folder_name).resolve()
+    try:
+        receipt = CleanupReceipt.from_payload(report, input_folder=input_folder)
+        validation = validate_cleanup_receipt(
+            receipt,
+            staging_root=staging_dir,
+            original_metadata=original_metadata,
+            reference_folder=reference_folder,
+        )
+    except Exception as error:  # noqa: BLE001 - untrusted persisted/Codex data
+        return ReadyRevalidation((), (f"Cleanup revalidation failed: {error}",))
+    if not validation.ready:
+        return ReadyRevalidation((), validation.errors)
+    validated_paths = tuple(folder.path.resolve() for folder in validation.folders)
+    if {path.resolve() for path in bundle.paths} != set(validated_paths):
+        return ReadyRevalidation(
+            (),
+            ("Persisted output allowlist does not match the validated receipt",),
+        )
+    return ReadyRevalidation(validated_paths, ())
+
+
 async def stage_bundles(
     *,
     telegram: TelegramSource,
@@ -221,13 +377,14 @@ async def stage_bundles(
     limit: int,
     progress: ProgressReporter,
     concurrency: int = 1,
-) -> tuple[int, int, int]:
+    exclude_keys: set[str] | None = None,
+) -> StagingResult:
     """Stage up to `limit` not-yet-staged bundles.
 
-    Returns (staged, failed, bytes). `concurrency` bundles are staged at once,
-    matching what the direct import path does across models.
+    Returns the new persisted bundle records plus failures and downloaded bytes.
+    `concurrency` bundles are staged at once, matching the direct import path.
     """
-    already = tracker.staged_keys(telegram.channel_id)
+    already = tracker.staged_keys(telegram.channel_id) | (exclude_keys or set())
     stager = BundleStager(telegram=telegram, root=staging_dir)
     pending = []
     for bundle in build_bundles(telegram.channel_id, refs):
@@ -237,14 +394,14 @@ async def stage_bundles(
         if key not in already:
             pending.append((key, bundle))
 
-    staged = 0
-    failed = 0
+    staged_items: list[StagedBundle] = []
+    failed_keys: list[str] = []
     staged_bytes = 0
     slots = asyncio.Semaphore(concurrency)
     lock = asyncio.Lock()
 
     async def stage_one(key: str, bundle) -> None:
-        nonlocal staged, failed, staged_bytes
+        nonlocal staged_bytes
         label = bundle.models[0].logical_filename
         async with slots:
             try:
@@ -254,23 +411,24 @@ async def stage_bundles(
             except Exception as error:  # noqa: BLE001
                 log.error("Failed to stage bundle at %s: %s", label, error)
                 async with lock:
-                    failed += 1
+                    failed_keys.append(key)
                 return
             size = sum(
                 path.stat().st_size for path in folder.rglob("*") if path.is_file()
             )
         async with lock:
-            tracker.record_staged(
-                bundle_key=key,
-                source_channel_id=telegram.channel_id,
-                folder_name=folder.name,
-                model_message_ids=tuple(
-                    part.message_id for unit in bundle.models for part in unit.parts
+            staged_items.append(
+                tracker.record_staged(
+                    bundle_key=key,
+                    source_channel_id=telegram.channel_id,
+                    folder_name=folder.name,
+                    model_message_ids=tuple(
+                        part.message_id for unit in bundle.models for part in unit.parts
+                    ),
                 ),
             )
-            staged += 1
             staged_bytes += size
-            _report_staging(progress, staged, len(pending), failed)
+            _report_staging(progress, len(staged_items), len(pending), len(failed_keys))
 
     with guarded_reporter(progress):
         _report_staging(progress, 0, len(pending), 0)
@@ -281,7 +439,161 @@ async def stage_bundles(
     for result in results:
         if isinstance(result, BaseException):
             raise result
-    return staged, failed, staged_bytes
+    return StagingResult(
+        items=tuple(sorted(staged_items, key=lambda item: item.folder_name)),
+        failed_keys=tuple(sorted(failed_keys)),
+        staged_bytes=staged_bytes,
+    )
+
+
+async def cleanup_staged_bundles(
+    *,
+    items: tuple[StagedBundle, ...],
+    staging_dir: Path,
+    tracker: ImportTracker,
+    runner: CodexCleanupRunner,
+    work_root: Path,
+    concurrency: int = 1,
+) -> CleanupBatchResult:
+    """Run isolated Codex cleanups and validate every claimed ready folder."""
+    outcomes: Counter[str] = Counter()
+    ready_bundles: list[ReadyBundle] = []
+    slots = asyncio.Semaphore(concurrency)
+    lock = asyncio.Lock()
+
+    async def clean(item: StagedBundle) -> None:
+        input_folder = (staging_dir / item.folder_name).resolve()
+        persisted_original = (
+            item.cleanup_report.get("originalMetadata")
+            if isinstance(item.cleanup_report, dict)
+            else None
+        )
+        original_metadata = (
+            persisted_original
+            if isinstance(persisted_original, dict)
+            else read_metadata(input_folder)
+        )
+        if original_metadata is None:
+            report = {"status": "failed", "error": "Original metadata.json is missing"}
+            tracker.update_staged_cleanup(
+                item.bundle_key,
+                status="cleanup_failed",
+                report=report,
+            )
+            async with lock:
+                outcomes["cleanup_failed"] += 1
+            return
+
+        tracker.update_staged_cleanup(
+            item.bundle_key,
+            status="cleaning",
+            report={"originalMetadata": original_metadata},
+        )
+        try:
+            async with slots:
+                receipt = await runner.run(
+                    bundle_key=item.bundle_key,
+                    input_folder=input_folder,
+                    work_root=work_root,
+                )
+        except CleanupExecutionError as error:
+            log.error("Codex cleanup failed for %s: %s", item.folder_name, error)
+            tracker.update_staged_cleanup(
+                item.bundle_key,
+                status="cleanup_failed",
+                report={
+                    "status": "failed",
+                    "error": str(error),
+                    "originalMetadata": original_metadata,
+                },
+            )
+            async with lock:
+                outcomes["cleanup_failed"] += 1
+            return
+
+        report = {
+            **receipt.as_payload(),
+            "originalMetadata": original_metadata,
+        }
+        relative_outputs = tuple(
+            str(path.relative_to(staging_dir.resolve()))
+            for path in receipt.output_folders
+            if path == staging_dir.resolve()
+            or path.is_relative_to(staging_dir.resolve())
+        )
+        if receipt.status != "ready":
+            status = (
+                "needs_review" if receipt.status == "needs_review" else "cleanup_failed"
+            )
+            tracker.update_staged_cleanup(
+                item.bundle_key,
+                status=status,
+                output_folders=relative_outputs,
+                report=report,
+            )
+            log.warning(
+                "Codex left %s in %s: %s", item.folder_name, status, receipt.summary
+            )
+            async with lock:
+                outcomes[status] += 1
+            return
+
+        try:
+            validation = await asyncio.to_thread(
+                validate_cleanup_receipt,
+                receipt,
+                staging_root=staging_dir,
+                original_metadata=original_metadata,
+                reference_folder=runner.reference_folder,
+            )
+        except Exception as error:
+            report["validationErrors"] = [f"Unexpected validation error: {error}"]
+            tracker.update_staged_cleanup(
+                item.bundle_key,
+                status="cleanup_failed",
+                output_folders=relative_outputs,
+                report=report,
+            )
+            log.exception("Cleanup validation crashed for %s", item.folder_name)
+            async with lock:
+                outcomes["cleanup_failed"] += 1
+            return
+        if not validation.ready:
+            report["validationErrors"] = list(validation.errors)
+            tracker.update_staged_cleanup(
+                item.bundle_key,
+                status="cleanup_failed",
+                output_folders=relative_outputs,
+                report=report,
+            )
+            log.error(
+                "Cleanup validation failed for %s: %s",
+                item.folder_name,
+                "; ".join(validation.errors),
+            )
+            async with lock:
+                outcomes["cleanup_failed"] += 1
+            return
+
+        validated_paths = tuple(folder.path.resolve() for folder in validation.folders)
+        ready_item = tracker.update_staged_cleanup(
+            item.bundle_key,
+            status="ready",
+            output_folders=tuple(
+                str(path.relative_to(staging_dir.resolve())) for path in validated_paths
+            ),
+            report=report,
+        )
+        log.info("Codex prepared %s: %s", item.folder_name, receipt.summary)
+        async with lock:
+            ready_bundles.append(ReadyBundle(ready_item, validated_paths))
+            outcomes["ready"] += 1
+
+    await asyncio.gather(*(clean(item) for item in items))
+    return CleanupBatchResult(
+        ready_bundles=tuple(sorted(ready_bundles, key=lambda item: item.bundle_key)),
+        outcomes=dict(outcomes),
+    )
 
 
 def _report_staging(
@@ -306,6 +618,14 @@ def _upload_summary(outcomes: dict[str, int]) -> str:
     )
 
 
+def _cleanup_summary(outcomes: dict[str, int]) -> str:
+    if not outcomes:
+        return "Cleanup state: no new folders"
+    return "Cleanup state: " + ", ".join(
+        f"{status}={count}" for status, count in sorted(outcomes.items())
+    )
+
+
 async def _login(args: argparse.Namespace) -> AlexandriaClient:
     email = os.getenv("ALEXANDRIA_EMAIL") or input("Alexandria email: ").strip()
     password = os.getenv("ALEXANDRIA_PASSWORD") or getpass.getpass(
@@ -319,6 +639,209 @@ async def _login(args: argparse.Namespace) -> AlexandriaClient:
     )
     await client.login(email, password)
     return client
+
+
+async def run_codex_staged_batches(
+    *,
+    args: argparse.Namespace,
+    telegram: TelegramSource,
+    tracker: ImportTracker,
+    refs: list[MediaRef],
+    progress: ProgressReporter,
+    work_root: Path,
+) -> int:
+    """Drain Telegram through stage, Codex cleanup, and scoped upload batches."""
+    skill_path = args.cleanup_skill or find_cleanup_skill()
+    if skill_path is None:
+        raise SystemExit(
+            "Repository Codex cleanup skill was not found; use --cleanup-skill",
+        )
+    runner = CodexCleanupRunner(
+        skill_path=skill_path,
+        reference_folder=args.cleanup_reference,
+        command=args.codex_command,
+        timeout_seconds=args.cleanup_timeout,
+    )
+    try:
+        runner.preflight()
+    except CleanupExecutionError as error:
+        raise SystemExit(str(error)) from error
+
+    excluded_keys: set[str] = set()
+    totals: Counter[str] = Counter()
+    batch_number = 0
+    alexandria: AlexandriaClient | None = None
+
+    async def upload_ready(bundle: ReadyBundle, *, label: str) -> None:
+        nonlocal alexandria
+        revalidation = await asyncio.to_thread(
+            revalidate_ready_bundle,
+            bundle,
+            staging_dir=args.staging_dir,
+            reference_folder=runner.reference_folder,
+        )
+        if not revalidation.ready:
+            report = dict(bundle.item.cleanup_report or {})
+            report["preUploadValidationErrors"] = list(revalidation.errors)
+            tracker.update_staged_cleanup(
+                bundle.bundle_key,
+                status="cleanup_failed",
+                output_folders=bundle.item.output_folders,
+                report=report,
+            )
+            totals["cleanup_failed"] += 1
+            log.error(
+                "%s failed pre-upload validation: %s",
+                label,
+                "; ".join(revalidation.errors),
+            )
+            return
+        if alexandria is None:
+            alexandria = await _login(args)
+        tracker.update_staged_status(bundle.bundle_key, status="uploading")
+        try:
+            upload_outcomes = await FolderUploader(
+                alexandria=alexandria,
+                work_root=work_root,
+                concurrency=args.concurrency,
+                progress=progress,
+            ).run(args.staging_dir, include_paths=revalidation.paths)
+        except Exception as error:  # noqa: BLE001 - record the bundle before aborting
+            tracker.update_staged_status(bundle.bundle_key, status="upload_failed")
+            totals["upload_failed"] += 1
+            log.error("Upload failed for %s: %s", label, error)
+            return
+        print(f"{label}: {_upload_summary(upload_outcomes)}")
+        completed = upload_outcomes.get("completed", 0)
+        failed = upload_outcomes.get("failed", 0)
+        totals["uploaded"] += completed
+        totals["upload_failed"] += failed
+        tracker.update_staged_status(
+            bundle.bundle_key,
+            status="uploaded"
+            if completed == len(revalidation.paths) and not failed
+            else "upload_failed",
+        )
+
+    async def clean_and_upload(
+        items: tuple[StagedBundle, ...],
+        *,
+        label: str,
+    ) -> None:
+        cleanup = await cleanup_staged_bundles(
+            items=items,
+            staging_dir=args.staging_dir,
+            tracker=tracker,
+            runner=runner,
+            work_root=work_root,
+            concurrency=args.cleanup_concurrency,
+        )
+        print(f"{label}: {_cleanup_summary(cleanup.outcomes)}")
+        for status, count in cleanup.outcomes.items():
+            totals[status] += count
+        for bundle in cleanup.ready_bundles:
+            await upload_ready(bundle, label=label)
+
+    try:
+        indeterminate_uploads = tracker.staged_by_status(
+            telegram.channel_id,
+            ("uploading",),
+        )
+        for item in indeterminate_uploads:
+            report = dict(item.cleanup_report or {})
+            report["uploadRecovery"] = (
+                "A previous process stopped after upload began. Reconcile the "
+                "Alexandria session before retrying to avoid a duplicate model."
+            )
+            tracker.update_staged_cleanup(
+                item.bundle_key,
+                status="needs_review",
+                output_folders=item.output_folders,
+                report=report,
+            )
+            totals["needs_review"] += 1
+            log.error(
+                "Upload state is indeterminate for %s; manual reconciliation required",
+                item.folder_name,
+            )
+
+        resumable_uploads = tracker.staged_by_status(
+            telegram.channel_id,
+            ("ready",),
+        )
+        for item in resumable_uploads:
+            batch_number += 1
+            paths = tuple(
+                (args.staging_dir / path).resolve() for path in item.output_folders
+            )
+            print(f"Batch {batch_number}: resuming upload for {item.folder_name}")
+            await upload_ready(
+                ReadyBundle(item, paths),
+                label=f"Batch {batch_number}",
+            )
+
+        resumable_cleanups = tracker.staged_by_status(
+            telegram.channel_id,
+            ("downloaded", "cleaning", "cleanup_failed"),
+        )
+        for offset in range(0, len(resumable_cleanups), args.stage):
+            items = resumable_cleanups[offset : offset + args.stage]
+            batch_number += 1
+            totals["resumed"] += len(items)
+            print(f"Batch {batch_number}: resuming cleanup for {len(items)} folder(s)")
+            await clean_and_upload(items, label=f"Batch {batch_number}")
+
+        while True:
+            staging = await stage_bundles(
+                telegram=telegram,
+                tracker=tracker,
+                refs=refs,
+                staging_dir=args.staging_dir,
+                limit=args.stage,
+                progress=progress,
+                concurrency=args.concurrency,
+                exclude_keys=excluded_keys,
+            )
+            excluded_keys.update(staging.failed_keys)
+            totals["stage_failed"] += staging.failed
+            if not staging.items and not staging.failed_keys:
+                break
+
+            batch_number += 1
+            print(
+                f"Batch {batch_number}: "
+                + _staging_summary(
+                    args.staging_dir,
+                    staging.staged,
+                    staging.failed,
+                    staging.staged_bytes,
+                ),
+            )
+            if not staging.items:
+                continue
+            totals["staged"] += staging.staged
+            await clean_and_upload(staging.items, label=f"Batch {batch_number}")
+    finally:
+        if alexandria is not None:
+            await alexandria.close()
+
+    print(
+        "Automated staged import: "
+        + ", ".join(
+            [f"batches={batch_number}"]
+            + [f"{status}={count}" for status, count in sorted(totals.items())],
+        ),
+    )
+    failed = any(
+        totals.get(status, 0)
+        for status in (
+            "stage_failed",
+            "needs_review",
+            "cleanup_failed",
+            "upload_failed",
+        )
+    )
+    return 1 if failed else 0
 
 
 async def run(args: argparse.Namespace) -> int:
@@ -382,7 +905,16 @@ async def run(args: argparse.Namespace) -> int:
 
         if args.download_only is not None or args.stage is not None:
             tracker = ImportTracker(args.state)
-            staged, failed_to_stage, staged_bytes = await stage_bundles(
+            if args.stage is not None and args.cleanup == "codex":
+                return await run_codex_staged_batches(
+                    args=args,
+                    telegram=telegram,
+                    tracker=tracker,
+                    refs=refs,
+                    progress=progress,
+                    work_root=work_root,
+                )
+            staging = await stage_bundles(
                 telegram=telegram,
                 tracker=tracker,
                 refs=refs,
@@ -392,12 +924,16 @@ async def run(args: argparse.Namespace) -> int:
                 concurrency=args.concurrency,
             )
             summary = _staging_summary(
-                args.staging_dir, staged, failed_to_stage, staged_bytes
+                args.staging_dir,
+                staging.staged,
+                staging.failed,
+                staging.staged_bytes,
             )
+            failed_to_stage = staging.failed
             if args.download_only is not None:
                 print(summary)
                 return 1 if failed_to_stage else 0
-            if not confirm_upload(summary):
+            if args.cleanup == "manual" and not confirm_upload(summary):
                 return 1 if failed_to_stage else 0
 
         if args.stage is not None:

--- a/tools/telegram-importer/src/alexandria_telegram_importer/codex_cleanup.py
+++ b/tools/telegram-importer/src/alexandria_telegram_importer/codex_cleanup.py
@@ -1,0 +1,635 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import shutil
+import signal
+import subprocess
+import tarfile
+import zipfile
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .folder_upload import ModelFolder, discover
+
+log = logging.getLogger(__name__)
+
+DEFAULT_CLEANUP_TIMEOUT = 60 * 60
+SAFE_ENV_NAMES = frozenset(
+    {
+        "CODEX_CA_CERTIFICATE",
+        "CODEX_HOME",
+        "CODEX_SQLITE_HOME",
+        "HOME",
+        "HTTPS_PROXY",
+        "HTTP_PROXY",
+        "LANG",
+        "LOGNAME",
+        "NO_PROXY",
+        "PATH",
+        "RUST_LOG",
+        "SHELL",
+        "SSL_CERT_FILE",
+        "TERM",
+        "TMPDIR",
+        "TZ",
+        "USER",
+        "XDG_CACHE_HOME",
+        "XDG_CONFIG_HOME",
+        "XDG_DATA_HOME",
+        "https_proxy",
+        "http_proxy",
+        "no_proxy",
+    },
+)
+SUPPORTED_ARCHIVE_SUFFIXES = (
+    ".7z",
+    ".zip",
+    ".rar",
+    ".tar.gz",
+    ".tgz",
+)
+
+CLEANUP_OUTPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "status": {
+            "type": "string",
+            "enum": ["ready", "needs_review", "failed"],
+        },
+        "inputFolder": {"type": "string"},
+        "outputFolders": {
+            "type": "array",
+            "items": {"type": "string"},
+            "uniqueItems": True,
+        },
+        "summary": {"type": "string"},
+        "warnings": {"type": "array", "items": {"type": "string"}},
+        "checks": {
+            "type": "object",
+            "properties": {
+                "archivesTested": {"type": "boolean"},
+                "metadataValid": {"type": "boolean"},
+                "imagesFlat": {"type": "boolean"},
+                "splitComplete": {"type": "boolean"},
+            },
+            "required": [
+                "archivesTested",
+                "metadataValid",
+                "imagesFlat",
+                "splitComplete",
+            ],
+            "additionalProperties": False,
+        },
+    },
+    "required": [
+        "status",
+        "inputFolder",
+        "outputFolders",
+        "summary",
+        "warnings",
+        "checks",
+    ],
+    "additionalProperties": False,
+}
+
+
+class CleanupExecutionError(RuntimeError):
+    """Codex could not produce a usable cleanup receipt."""
+
+
+@dataclass(frozen=True, slots=True)
+class CleanupReceipt:
+    status: str
+    input_folder: Path
+    output_folders: tuple[Path, ...]
+    summary: str
+    warnings: tuple[str, ...]
+    checks: Mapping[str, bool]
+
+    @classmethod
+    def from_payload(cls, payload: Any, *, input_folder: Path) -> CleanupReceipt:
+        if not isinstance(payload, dict):
+            raise CleanupExecutionError("Codex cleanup receipt must be a JSON object")
+        try:
+            status = payload["status"]
+            receipt_input = Path(payload["inputFolder"]).resolve()
+            raw_outputs = payload["outputFolders"]
+            summary = payload["summary"]
+            warnings = payload["warnings"]
+            checks = payload["checks"]
+        except (KeyError, TypeError) as error:
+            raise CleanupExecutionError(
+                f"Codex cleanup receipt is missing required data: {error}",
+            ) from error
+
+        expected_input = input_folder.resolve()
+        if receipt_input != expected_input:
+            raise CleanupExecutionError(
+                f"Codex reported input folder {receipt_input}, expected {expected_input}",
+            )
+        if status not in {"ready", "needs_review", "failed"}:
+            raise CleanupExecutionError(f"Unknown Codex cleanup status {status!r}")
+        if not isinstance(raw_outputs, list) or not all(
+            isinstance(value, str) for value in raw_outputs
+        ):
+            raise CleanupExecutionError("outputFolders must be a list of paths")
+        if (
+            not isinstance(summary, str)
+            or not isinstance(warnings, list)
+            or not all(isinstance(value, str) for value in warnings)
+        ):
+            raise CleanupExecutionError(
+                "Cleanup summary or warnings have invalid types"
+            )
+        expected_checks = {
+            "archivesTested",
+            "metadataValid",
+            "imagesFlat",
+            "splitComplete",
+        }
+        if (
+            not isinstance(checks, dict)
+            or set(checks) != expected_checks
+            or not all(isinstance(value, bool) for value in checks.values())
+        ):
+            raise CleanupExecutionError("Cleanup checks have an invalid shape")
+
+        lexical_outputs = tuple(
+            (
+                Path(value) if Path(value).is_absolute() else input_folder / value
+            ).absolute()
+            for value in raw_outputs
+        )
+        if any(path.is_symlink() for path in lexical_outputs):
+            raise CleanupExecutionError("Codex reported a symlinked output folder")
+        output_folders = tuple(path.resolve() for path in lexical_outputs)
+        if len(set(output_folders)) != len(output_folders):
+            raise CleanupExecutionError("Codex reported a duplicate output folder")
+        return cls(
+            status=status,
+            input_folder=receipt_input,
+            output_folders=output_folders,
+            summary=summary,
+            warnings=tuple(warnings),
+            checks=dict(checks),
+        )
+
+    def as_payload(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "inputFolder": str(self.input_folder),
+            "outputFolders": [str(path) for path in self.output_folders],
+            "summary": self.summary,
+            "warnings": list(self.warnings),
+            "checks": dict(self.checks),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class CleanupValidation:
+    folders: tuple[ModelFolder, ...]
+    errors: tuple[str, ...]
+
+    @property
+    def ready(self) -> bool:
+        return not self.errors
+
+
+def find_cleanup_skill() -> Path | None:
+    """Find the repository-owned skill from a source checkout."""
+    configured = os.getenv("TELEGRAM_CODEX_CLEANUP_SKILL")
+    if configured:
+        return Path(configured).expanduser().resolve()
+
+    package_file = Path(__file__).resolve()
+    candidates = [
+        parent / ".agents" / "skills" / "prepare-telegram-staging" / "SKILL.md"
+        for parent in package_file.parents
+    ]
+    return next((path for path in candidates if path.is_file()), None)
+
+
+def sanitized_codex_environment(
+    source: Mapping[str, str] | None = None,
+) -> dict[str, str]:
+    """Pass only shell/config state; saved Codex login supplies authentication."""
+    environment = dict(source or os.environ)
+    return {
+        name: value
+        for name, value in environment.items()
+        if name in SAFE_ENV_NAMES or name.startswith("LC_")
+    }
+
+
+class CodexCleanupRunner:
+    def __init__(
+        self,
+        *,
+        skill_path: Path,
+        reference_folder: Path,
+        command: str = "codex",
+        timeout_seconds: int = DEFAULT_CLEANUP_TIMEOUT,
+        environment: Mapping[str, str] | None = None,
+    ) -> None:
+        if timeout_seconds < 1:
+            raise ValueError("Codex cleanup timeout must be at least one second")
+        self.skill_path = skill_path.resolve()
+        self.reference_folder = reference_folder.resolve()
+        self.command = command
+        self.timeout_seconds = timeout_seconds
+        self.environment = sanitized_codex_environment(environment)
+
+    def preflight(self) -> None:
+        if not self.skill_path.is_file():
+            raise CleanupExecutionError(
+                f"Cleanup skill does not exist: {self.skill_path}"
+            )
+        if not (self.reference_folder / "metadata.json").is_file():
+            raise CleanupExecutionError(
+                "Cleanup reference must be a folder containing metadata.json: "
+                f"{self.reference_folder}",
+            )
+        if shutil.which(self.command, path=self.environment.get("PATH")) is None:
+            raise CleanupExecutionError(
+                f"Codex executable {self.command!r} was not found on PATH",
+            )
+
+    async def run(
+        self,
+        *,
+        bundle_key: str,
+        input_folder: Path,
+        work_root: Path,
+    ) -> CleanupReceipt:
+        self.preflight()
+        input_folder = input_folder.resolve()
+        if not input_folder.is_dir():
+            raise CleanupExecutionError(
+                f"Staged input folder is missing: {input_folder}"
+            )
+
+        receipt_dir = work_root / "codex-cleanup"
+        receipt_dir.mkdir(parents=True, exist_ok=True)
+        schema_path = receipt_dir / "cleanup-result.schema.json"
+        schema_path.write_text(
+            json.dumps(CLEANUP_OUTPUT_SCHEMA, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        receipt_path = receipt_dir / f"{bundle_key}.json"
+        receipt_path.unlink(missing_ok=True)
+
+        prompt = self._prompt(input_folder)
+        command = (
+            self.command,
+            "exec",
+            "--ephemeral",
+            "--skip-git-repo-check",
+            "--sandbox",
+            "workspace-write",
+            "--color",
+            "never",
+            "-C",
+            str(input_folder),
+            "--output-schema",
+            str(schema_path),
+            "--output-last-message",
+            str(receipt_path),
+            prompt,
+        )
+        log.info("Handing staged bundle %s to Codex", input_folder.name)
+        try:
+            process = await asyncio.create_subprocess_exec(
+                *command,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env=self.environment,
+                start_new_session=os.name == "posix",
+            )
+        except OSError as error:
+            raise CleanupExecutionError(f"Could not start Codex: {error}") from error
+
+        try:
+            stdout, stderr = await asyncio.wait_for(
+                process.communicate(),
+                timeout=self.timeout_seconds,
+            )
+        except TimeoutError as error:
+            await self._kill(process)
+            raise CleanupExecutionError(
+                f"Codex cleanup exceeded {self.timeout_seconds} seconds",
+            ) from error
+        except asyncio.CancelledError:
+            await self._kill(process)
+            raise
+
+        if process.returncode != 0:
+            detail = stderr.decode(errors="replace").strip()
+            if not detail:
+                detail = stdout.decode(errors="replace").strip()
+            if len(detail) > 4000:
+                detail = detail[-4000:]
+            raise CleanupExecutionError(
+                f"Codex cleanup exited with status {process.returncode}: {detail}",
+            )
+        if not receipt_path.is_file():
+            raise CleanupExecutionError(
+                "Codex exited without writing a cleanup receipt"
+            )
+        try:
+            payload = json.loads(receipt_path.read_text(encoding="utf-8"))
+        except (OSError, ValueError) as error:
+            raise CleanupExecutionError(
+                f"Codex cleanup receipt could not be read: {error}",
+            ) from error
+        return CleanupReceipt.from_payload(payload, input_folder=input_folder)
+
+    async def _kill(self, process: asyncio.subprocess.Process) -> None:
+        try:
+            if os.name == "posix":
+                os.killpg(process.pid, signal.SIGKILL)
+            else:
+                process.kill()
+        except ProcessLookupError:
+            pass
+        await process.wait()
+
+    def _prompt(self, input_folder: Path) -> str:
+        return (
+            f"Read and follow the skill at {self.skill_path}. "
+            f"Prepare only the staged Telegram bundle at {input_folder}. "
+            f"Use the completed reference folder at {self.reference_folder}. "
+            "Do not edit the reference, the skill, the repository, or any sibling "
+            "staging folder. Do not upload anything. If any decision requires human "
+            "judgment, return needs_review. Return only the requested structured receipt."
+        )
+
+
+def _inside(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent)
+    except ValueError:
+        return False
+    return True
+
+
+def _read_object(path: Path) -> tuple[dict[str, Any] | None, str | None]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as error:
+        return None, str(error)
+    if not isinstance(payload, dict):
+        return None, "must contain a JSON object"
+    return payload, None
+
+
+def _archive_error(path: Path) -> str | None:
+    name = path.name.lower()
+    try:
+        if name.endswith(".zip"):
+            with zipfile.ZipFile(path) as archive:
+                if corrupt := archive.testzip():
+                    return f"contains a corrupt member: {corrupt}"
+            return None
+        if name.endswith((".tar.gz", ".tgz")):
+            with tarfile.open(path, "r:gz") as archive:
+                archive.getmembers()
+            return None
+        seven_zip = shutil.which("7z")
+        if not seven_zip:
+            return "7z is required to test this archive"
+        completed = subprocess.run(
+            [seven_zip, "t", "-bso0", "-bsp0", "-y", str(path)],
+            capture_output=True,
+            text=True,
+            timeout=10 * 60,
+            check=False,
+        )
+    except (
+        OSError,
+        subprocess.TimeoutExpired,
+        tarfile.TarError,
+        zipfile.BadZipFile,
+    ) as error:
+        return str(error)
+    if completed.returncode != 0:
+        return (completed.stderr or completed.stdout).strip() or "7z test failed"
+    return None
+
+
+def _model_folder_errors(
+    folder: ModelFolder,
+    *,
+    reference_metadata: Mapping[str, Any],
+    original_source: Mapping[str, Any],
+    archive_tester: Callable[[Path], str | None],
+) -> list[str]:
+    errors: list[str] = []
+    path = folder.path
+    if path.is_symlink():
+        errors.append(f"{path}: model folder must not be a symlink")
+    for candidate in path.rglob("*"):
+        if candidate.is_symlink():
+            errors.append(f"{path}: contains symlink {candidate.relative_to(path)}")
+
+    images_dir = path / "images"
+    if not images_dir.is_dir():
+        errors.append(f"{path}: images/ is missing")
+    elif any(not child.is_file() for child in images_dir.iterdir()):
+        errors.append(
+            f"{path}: images/ must contain files only, with no subdirectories"
+        )
+
+    models_dir = path / "models"
+    model_entries = list(models_dir.iterdir()) if models_dir.is_dir() else []
+    if len(model_entries) != 1 or not model_entries[0].is_file():
+        errors.append(f"{path}: models/ must contain exactly one archive file")
+    else:
+        archive_path = model_entries[0]
+        if not archive_path.name.lower().endswith(SUPPORTED_ARCHIVE_SUFFIXES):
+            errors.append(f"{path}: unsupported model archive {archive_path.name}")
+        elif archive_error := archive_tester(archive_path):
+            errors.append(f"{archive_path}: archive validation failed: {archive_error}")
+
+    metadata_path = path / "metadata.json"
+    payload, metadata_error = _read_object(metadata_path)
+    if metadata_error or payload is None:
+        errors.append(f"{metadata_path}: {metadata_error}")
+        return errors
+    if set(payload) != set(reference_metadata):
+        errors.append(
+            f"{metadata_path}: top-level keys do not match the reference metadata",
+        )
+    nested = payload.get("metadata")
+    reference_nested = reference_metadata.get("metadata")
+    if not isinstance(nested, dict) or not isinstance(reference_nested, dict):
+        errors.append(f"{metadata_path}: metadata must be an object")
+    elif set(nested) != set(reference_nested):
+        errors.append(
+            f"{metadata_path}: nested metadata keys do not match the reference"
+        )
+    if (
+        not isinstance(payload.get("modelName"), str)
+        or not payload["modelName"].strip()
+    ):
+        errors.append(f"{metadata_path}: modelName must be a non-empty string")
+    if payload.get("result") is not None:
+        errors.append(f"{metadata_path}: result must remain null before upload")
+
+    source = payload.get("source")
+    if not isinstance(source, dict):
+        errors.append(f"{metadata_path}: Telegram source provenance is missing")
+        return errors
+    for key in ("channelId", "bundleKey"):
+        if source.get(key) != original_source.get(key):
+            errors.append(f"{metadata_path}: source.{key} changed during cleanup")
+    original_ids = _message_ids(
+        original_source.get("modelMessageIds"),
+        field="original source.modelMessageIds",
+        errors=errors,
+        required=True,
+    )
+    output_ids = _message_ids(
+        source.get("modelMessageIds"),
+        field=f"{metadata_path}: source.modelMessageIds",
+        errors=errors,
+        required=True,
+    )
+    if (
+        output_ids is not None
+        and original_ids is not None
+        and not output_ids.issubset(original_ids)
+    ):
+        errors.append(f"{metadata_path}: source.modelMessageIds contains unknown IDs")
+    original_attachments = _message_ids(
+        original_source.get("attachmentMessageIds"),
+        field="original source.attachmentMessageIds",
+        errors=errors,
+    )
+    output_attachments = _message_ids(
+        source.get("attachmentMessageIds"),
+        field=f"{metadata_path}: source.attachmentMessageIds",
+        errors=errors,
+    )
+    if (
+        output_attachments is not None
+        and original_attachments is not None
+        and not output_attachments.issubset(original_attachments)
+    ):
+        errors.append(
+            f"{metadata_path}: source.attachmentMessageIds contains unknown IDs"
+        )
+    return errors
+
+
+def _message_ids(
+    value: Any,
+    *,
+    field: str,
+    errors: list[str],
+    required: bool = False,
+) -> set[int] | None:
+    if not isinstance(value, list) or any(
+        not isinstance(item, int) or isinstance(item, bool) for item in value
+    ):
+        errors.append(f"{field} must be a list of integer message IDs")
+        return None
+    if required and not value:
+        errors.append(f"{field} must be non-empty")
+        return None
+    return set(value)
+
+
+def validate_cleanup_receipt(
+    receipt: CleanupReceipt,
+    *,
+    staging_root: Path,
+    original_metadata: Mapping[str, Any],
+    reference_folder: Path,
+    archive_tester: Callable[[Path], str | None] = _archive_error,
+) -> CleanupValidation:
+    """Validate Codex's claimed outputs before granting upload authority."""
+    errors: list[str] = []
+    if receipt.status != "ready":
+        return CleanupValidation((), (f"Codex returned {receipt.status}",))
+    if not receipt.output_folders:
+        return CleanupValidation((), ("Codex returned ready without output folders",))
+    if not receipt.input_folder.is_dir():
+        return CleanupValidation((), ("The staged input folder no longer exists",))
+    for output in receipt.output_folders:
+        if not _inside(output, receipt.input_folder):
+            errors.append(f"Codex output escapes its assigned bundle: {output}")
+
+    reference_metadata, reference_error = _read_object(
+        reference_folder / "metadata.json",
+    )
+    if reference_error or reference_metadata is None:
+        errors.append(f"Reference metadata could not be read: {reference_error}")
+        return CleanupValidation((), tuple(errors))
+    original_source = original_metadata.get("source")
+    if not isinstance(original_source, dict):
+        errors.append("Original staged metadata has no Telegram source provenance")
+        return CleanupValidation((), tuple(errors))
+
+    found, ambiguous = discover(staging_root)
+    found_in_bundle = tuple(
+        folder
+        for folder in found
+        if _inside(folder.path.resolve(), receipt.input_folder)
+    )
+    ambiguous_in_bundle = [
+        (path, reason)
+        for path, reason in ambiguous
+        if _inside(path.resolve(), receipt.input_folder)
+    ]
+    for path, reason in ambiguous_in_bundle:
+        errors.append(f"{path}: {reason}")
+
+    expected = {path.resolve() for path in receipt.output_folders}
+    actual = {folder.path.resolve() for folder in found_in_bundle}
+    if expected != actual:
+        missing = sorted(str(path) for path in expected - actual)
+        unreported = sorted(str(path) for path in actual - expected)
+        if missing:
+            errors.append(
+                "Reported output folders are not uploadable: " + ", ".join(missing)
+            )
+        if unreported:
+            errors.append(
+                "Codex left unreported model folders: " + ", ".join(unreported)
+            )
+
+    original_model_ids = _message_ids(
+        original_source.get("modelMessageIds"),
+        field="Original source.modelMessageIds",
+        errors=errors,
+        required=True,
+    )
+    covered_model_ids: set[int] = set()
+    for folder in found_in_bundle:
+        errors.extend(
+            _model_folder_errors(
+                folder,
+                reference_metadata=reference_metadata,
+                original_source=original_source,
+                archive_tester=archive_tester,
+            ),
+        )
+        payload, _ = _read_object(folder.path / "metadata.json")
+        if payload and isinstance(payload.get("source"), dict):
+            output_ids = _message_ids(
+                payload["source"].get("modelMessageIds"),
+                field=f"{folder.path / 'metadata.json'}: source.modelMessageIds",
+                errors=errors,
+                required=True,
+            )
+            if output_ids is not None:
+                covered_model_ids.update(output_ids)
+    if original_model_ids is not None and covered_model_ids != original_model_ids:
+        errors.append("Cleaned outputs do not cover every original model message ID")
+
+    return CleanupValidation(found_in_bundle if not errors else (), tuple(errors))

--- a/tools/telegram-importer/src/alexandria_telegram_importer/folder_upload.py
+++ b/tools/telegram-importer/src/alexandria_telegram_importer/folder_upload.py
@@ -7,6 +7,7 @@ import shutil
 import tempfile
 import zipfile
 from collections import Counter
+from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -283,8 +284,28 @@ class FolderUploader:
                     by_name[path.name] = path
         return tuple(by_name.values())
 
-    async def run(self, root: Path) -> dict[str, int]:
+    async def run(
+        self,
+        root: Path,
+        *,
+        include_paths: Sequence[Path] | None = None,
+    ) -> dict[str, int]:
         found, ambiguous = discover(root)
+        if include_paths is not None:
+            selected = {path.resolve() for path in include_paths}
+            discoverable = {
+                *(folder.path.resolve() for folder in found),
+                *(path.resolve() for path, _ in ambiguous),
+            }
+            if missing := selected - discoverable:
+                joined = ", ".join(str(path) for path in sorted(missing))
+                raise ValueError(f"Selected staging folders are not uploadable: {joined}")
+            found = [folder for folder in found if folder.path.resolve() in selected]
+            ambiguous = [
+                (path, reason)
+                for path, reason in ambiguous
+                if path.resolve() in selected
+            ]
         outcomes: Counter[str] = Counter()
         settled = 0
         total = len(found) + len(ambiguous)

--- a/tools/telegram-importer/src/alexandria_telegram_importer/tracker.py
+++ b/tools/telegram-importer/src/alexandria_telegram_importer/tracker.py
@@ -5,6 +5,7 @@ import sqlite3
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any
 
 from filelock import FileLock, Timeout
 
@@ -34,6 +35,10 @@ class StagedBundle:
     model_message_ids: tuple[int, ...]
     status: str
     downloaded_at: str
+    output_folders: tuple[str, ...] = ()
+    cleanup_report: dict[str, Any] | None = None
+    cleanup_attempts: int = 0
+    updated_at: str | None = None
 
 
 class ImportTracker:
@@ -100,9 +105,34 @@ class ImportTracker:
                 folder_name TEXT NOT NULL,
                 model_message_ids TEXT NOT NULL,
                 status TEXT NOT NULL,
-                downloaded_at TEXT NOT NULL
+                downloaded_at TEXT NOT NULL,
+                output_folders TEXT NOT NULL DEFAULT '[]',
+                cleanup_report TEXT,
+                cleanup_attempts INTEGER NOT NULL DEFAULT 0,
+                updated_at TEXT
             )
             """,
+        )
+        staged_columns = {
+            row["name"]
+            for row in self._connection.execute(
+                "PRAGMA table_info(staged_bundles)",
+            ).fetchall()
+        }
+        staged_migrations = {
+            "output_folders": "TEXT NOT NULL DEFAULT '[]'",
+            "cleanup_report": "TEXT",
+            "cleanup_attempts": "INTEGER NOT NULL DEFAULT 0",
+            "updated_at": "TEXT",
+        }
+        for column, declaration in staged_migrations.items():
+            if column not in staged_columns:
+                self._connection.execute(
+                    f"ALTER TABLE staged_bundles ADD COLUMN {column} {declaration}",
+                )
+        self._connection.execute(
+            "UPDATE staged_bundles SET updated_at = downloaded_at "
+            "WHERE updated_at IS NULL",
         )
         self._connection.execute(
             "CREATE INDEX IF NOT EXISTS staged_bundles_channel_idx "
@@ -307,8 +337,8 @@ class ImportTracker:
                 """
                 INSERT INTO staged_bundles (
                     bundle_key, source_channel_id, folder_name,
-                    model_message_ids, status, downloaded_at
-                ) VALUES (?, ?, ?, ?, 'downloaded', ?)
+                    model_message_ids, status, downloaded_at, updated_at
+                ) VALUES (?, ?, ?, ?, 'downloaded', ?, ?)
                 ON CONFLICT(bundle_key) DO NOTHING
                 """,
                 (
@@ -316,6 +346,7 @@ class ImportTracker:
                     source_channel_id,
                     folder_name,
                     json.dumps(model_message_ids),
+                    now,
                     now,
                 ),
             )
@@ -338,6 +369,89 @@ class ImportTracker:
             model_message_ids=tuple(json.loads(row["model_message_ids"])),
             status=row["status"],
             downloaded_at=row["downloaded_at"],
+            output_folders=tuple(json.loads(row["output_folders"] or "[]")),
+            cleanup_report=(
+                json.loads(row["cleanup_report"]) if row["cleanup_report"] else None
+            ),
+            cleanup_attempts=row["cleanup_attempts"] or 0,
+            updated_at=row["updated_at"] or row["downloaded_at"],
+        )
+
+    def update_staged_cleanup(
+        self,
+        bundle_key: str,
+        *,
+        status: str,
+        output_folders: tuple[str, ...] = (),
+        report: dict[str, Any] | None = None,
+    ) -> StagedBundle:
+        allowed = {"cleaning", "ready", "needs_review", "cleanup_failed"}
+        if status not in allowed:
+            raise ValueError(f"Unsupported staged cleanup status {status!r}")
+        now = datetime.now(UTC).isoformat()
+        with self._connection:
+            result = self._connection.execute(
+                """
+                UPDATE staged_bundles
+                SET status = ?,
+                    output_folders = ?,
+                    cleanup_report = ?,
+                    cleanup_attempts = cleanup_attempts + ?,
+                    updated_at = ?
+                WHERE bundle_key = ?
+                """,
+                (
+                    status,
+                    json.dumps(output_folders),
+                    json.dumps(report) if report is not None else None,
+                    1 if status == "cleaning" else 0,
+                    now,
+                    bundle_key,
+                ),
+            )
+        if result.rowcount != 1:
+            raise KeyError(bundle_key)
+        staged = self.get_staged(bundle_key)
+        if staged is None:
+            raise KeyError(bundle_key)
+        return staged
+
+    def update_staged_status(self, bundle_key: str, *, status: str) -> StagedBundle:
+        allowed = {"uploading", "uploaded", "upload_failed"}
+        if status not in allowed:
+            raise ValueError(f"Unsupported staged status {status!r}")
+        now = datetime.now(UTC).isoformat()
+        with self._connection:
+            result = self._connection.execute(
+                "UPDATE staged_bundles SET status = ?, updated_at = ? "
+                "WHERE bundle_key = ?",
+                (status, now, bundle_key),
+            )
+        if result.rowcount != 1:
+            raise KeyError(bundle_key)
+        staged = self.get_staged(bundle_key)
+        if staged is None:
+            raise KeyError(bundle_key)
+        return staged
+
+    def staged_by_status(
+        self,
+        source_channel_id: int,
+        statuses: tuple[str, ...],
+    ) -> tuple[StagedBundle, ...]:
+        if not statuses:
+            return ()
+        placeholders = ", ".join("?" for _ in statuses)
+        rows = self._connection.execute(
+            f"SELECT bundle_key FROM staged_bundles "
+            f"WHERE source_channel_id = ? AND status IN ({placeholders}) "
+            "ORDER BY downloaded_at, bundle_key",
+            (source_channel_id, *statuses),
+        ).fetchall()
+        return tuple(
+            staged
+            for row in rows
+            if (staged := self.get_staged(row["bundle_key"])) is not None
         )
 
     def staged_keys(self, source_channel_id: int) -> set[str]:

--- a/tools/telegram-importer/tests/test_cli.py
+++ b/tools/telegram-importer/tests/test_cli.py
@@ -1,5 +1,11 @@
 from __future__ import annotations
 
+import json
+import zipfile
+from dataclasses import replace
+from pathlib import Path
+from types import SimpleNamespace
+
 import pytest
 
 from alexandria_telegram_importer.cli import (
@@ -143,6 +149,34 @@ def test_should_accept_each_staging_mode(tmp_path) -> None:
         validate_staging_args(args)
 
 
+def test_should_require_a_reference_for_codex_cleanup(tmp_path) -> None:
+    args = parser().parse_args(
+        ["--stage", "5", "--cleanup", "codex", "--staging-dir", str(tmp_path)],
+    )
+
+    with pytest.raises(SystemExit, match="--cleanup-reference"):
+        validate_staging_args(args)
+
+
+def test_should_accept_codex_cleanup_for_a_staged_import(tmp_path) -> None:
+    args = parser().parse_args(
+        [
+            "--stage",
+            "5",
+            "--cleanup",
+            "codex",
+            "--cleanup-reference",
+            str(tmp_path / "reference"),
+            "--staging-dir",
+            str(tmp_path / "staging"),
+        ],
+    )
+
+    validate_staging_args(args)
+    assert args.cleanup_concurrency == 1
+    assert args.cleanup_timeout == 3600
+
+
 def test_should_treat_a_closed_stdin_as_quitting_the_pause(monkeypatch) -> None:
     import io
 
@@ -279,6 +313,396 @@ async def test_should_report_a_staging_directory_that_does_not_exist(
 
     with pytest.raises(SystemExit, match="does not exist"):
         await cli.run(args)
+
+
+async def test_should_continue_with_the_next_codex_batch_after_upload(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    from alexandria_telegram_importer import cli
+    from alexandria_telegram_importer.tracker import StagedBundle
+
+    staging_dir = tmp_path / "staging"
+    first_path = staging_dir / "first"
+    second_path = staging_dir / "second"
+    first_path.mkdir(parents=True)
+    second_path.mkdir()
+
+    def item(key: str, folder_name: str) -> StagedBundle:
+        return StagedBundle(
+            bundle_key=key,
+            source_channel_id=-100123,
+            folder_name=folder_name,
+            model_message_ids=(1,),
+            status="downloaded",
+            downloaded_at="2026-01-01T00:00:00+00:00",
+        )
+
+    stage_results = [
+        cli.StagingResult((), ("bad-bundle",), 0),
+        cli.StagingResult((item("first-key", "first"),), (), 10),
+        cli.StagingResult((item("second-key", "second"),), (), 20),
+        cli.StagingResult((), (), 0),
+    ]
+    stage_calls: list[set[str]] = []
+    uploads: list[tuple[Path, ...]] = []
+    statuses: list[tuple[str, str]] = []
+    logins: list[str] = []
+    closes: list[str] = []
+
+    async def fake_stage_bundles(**kwargs):
+        stage_calls.append(set(kwargs["exclude_keys"]))
+        return stage_results.pop(0)
+
+    async def fake_cleanup_staged_bundles(**kwargs):
+        staged = kwargs["items"][0]
+        path = (staging_dir / staged.folder_name).resolve()
+        return cli.CleanupBatchResult(
+            (cli.ReadyBundle(staged, (path,)),),
+            {"ready": 1},
+        )
+
+    class FakeRunner:
+        def __init__(self, **kwargs) -> None:
+            self.reference_folder = kwargs["reference_folder"]
+
+        def preflight(self) -> None:
+            return None
+
+    class FakeUploader:
+        def __init__(self, **kwargs) -> None:
+            pass
+
+        async def run(self, root, *, include_paths):
+            uploads.append(tuple(include_paths))
+            return {"completed": len(include_paths)}
+
+    class FakeTracker:
+        def staged_by_status(self, channel_id, states):
+            return ()
+
+        def update_staged_status(self, bundle_key, *, status):
+            statuses.append((bundle_key, status))
+
+    class FakeClient:
+        async def close(self) -> None:
+            closes.append("close")
+
+    async def fake_login(args):
+        logins.append("login")
+        return FakeClient()
+
+    monkeypatch.setattr(cli, "CodexCleanupRunner", FakeRunner)
+    monkeypatch.setattr(cli, "stage_bundles", fake_stage_bundles)
+    monkeypatch.setattr(cli, "cleanup_staged_bundles", fake_cleanup_staged_bundles)
+    monkeypatch.setattr(
+        cli,
+        "revalidate_ready_bundle",
+        lambda bundle, **kwargs: cli.ReadyRevalidation(bundle.paths, ()),
+    )
+    monkeypatch.setattr(cli, "FolderUploader", FakeUploader)
+    monkeypatch.setattr(cli, "_login", fake_login)
+
+    args = SimpleNamespace(
+        cleanup_skill=tmp_path / "SKILL.md",
+        cleanup_reference=tmp_path / "reference",
+        codex_command="codex",
+        cleanup_timeout=60,
+        cleanup_concurrency=1,
+        concurrency=1,
+        stage=1,
+        staging_dir=staging_dir,
+    )
+    telegram = SimpleNamespace(channel_id=-100123)
+
+    exit_code = await cli.run_codex_staged_batches(
+        args=args,
+        telegram=telegram,
+        tracker=FakeTracker(),
+        refs=[],
+        progress=None,
+        work_root=tmp_path / "work",
+    )
+
+    assert exit_code == 1  # the failed download is reported after draining the rest
+    assert len(stage_calls) == 4
+    assert "bad-bundle" in stage_calls[1]
+    assert uploads == [((first_path.resolve()),), ((second_path.resolve()),)]
+    assert logins == ["login"]
+    assert closes == ["close"]
+    assert statuses == [
+        ("first-key", "uploading"),
+        ("first-key", "uploaded"),
+        ("second-key", "uploading"),
+        ("second-key", "uploaded"),
+    ]
+
+
+async def test_should_refuse_a_mutated_ready_bundle_on_resume(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    from alexandria_telegram_importer import cli
+    from alexandria_telegram_importer.tracker import StagedBundle
+
+    staging_dir = tmp_path / "staging"
+    model = staging_dir / "first"
+    (model / "models").mkdir(parents=True)
+    (model / "images").mkdir()
+    with zipfile.ZipFile(model / "models" / "Dragon.zip", "w") as archive:
+        archive.writestr("dragon.stl", b"model")
+    original = {
+        "modelName": "Dragon",
+        "metadata": {"character": "Dragon"},
+        "source": {
+            "channelId": -100123,
+            "bundleKey": "first-key",
+            "modelMessageIds": [1],
+            "attachmentMessageIds": [],
+        },
+        "result": None,
+    }
+    mutated = {**original, "result": {"modelId": "tampered"}}
+    (model / "metadata.json").write_text(json.dumps(mutated), encoding="utf-8")
+    reference = tmp_path / "reference"
+    reference.mkdir()
+    (reference / "metadata.json").write_text(json.dumps(original), encoding="utf-8")
+    receipt = cli.CleanupReceipt(
+        status="ready",
+        input_folder=model.resolve(),
+        output_folders=(model.resolve(),),
+        summary="ready",
+        warnings=(),
+        checks={
+            "archivesTested": True,
+            "metadataValid": True,
+            "imagesFlat": True,
+            "splitComplete": True,
+        },
+    )
+    item = StagedBundle(
+        bundle_key="first-key",
+        source_channel_id=-100123,
+        folder_name="first",
+        model_message_ids=(1,),
+        status="ready",
+        downloaded_at="2026-01-01T00:00:00+00:00",
+        output_folders=("first",),
+        cleanup_report={**receipt.as_payload(), "originalMetadata": original},
+    )
+    transitions: list[tuple[str, str]] = []
+
+    class FakeTracker:
+        def staged_by_status(self, channel_id, statuses):
+            return (item,) if statuses == ("ready",) else ()
+
+        def update_staged_cleanup(self, bundle_key, *, status, **kwargs):
+            transitions.append((bundle_key, status))
+            return item
+
+    class FakeRunner:
+        def __init__(self, **kwargs) -> None:
+            self.reference_folder = kwargs["reference_folder"]
+
+        def preflight(self) -> None:
+            return None
+
+    async def no_more_bundles(**kwargs):
+        return cli.StagingResult((), (), 0)
+
+    monkeypatch.setattr(cli, "CodexCleanupRunner", FakeRunner)
+    monkeypatch.setattr(cli, "stage_bundles", no_more_bundles)
+    monkeypatch.setattr(cli, "_login", lambda args: _fail("must not upload"))
+    args = SimpleNamespace(
+        cleanup_skill=tmp_path / "SKILL.md",
+        cleanup_reference=reference,
+        codex_command="codex",
+        cleanup_timeout=60,
+        cleanup_concurrency=1,
+        concurrency=1,
+        stage=1,
+        staging_dir=staging_dir,
+    )
+
+    exit_code = await cli.run_codex_staged_batches(
+        args=args,
+        telegram=SimpleNamespace(channel_id=-100123),
+        tracker=FakeTracker(),
+        refs=[],
+        progress=None,
+        work_root=tmp_path / "work",
+    )
+
+    assert exit_code == 1
+    assert transitions == [("first-key", "cleanup_failed")]
+
+
+async def test_should_require_review_for_an_indeterminate_upload(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    from alexandria_telegram_importer import cli
+    from alexandria_telegram_importer.tracker import StagedBundle
+
+    item = StagedBundle(
+        bundle_key="first-key",
+        source_channel_id=-100123,
+        folder_name="first",
+        model_message_ids=(1,),
+        status="uploading",
+        downloaded_at="2026-01-01T00:00:00+00:00",
+        output_folders=("first",),
+        cleanup_report={"status": "ready"},
+    )
+    transitions: list[tuple[str, str]] = []
+
+    class FakeTracker:
+        def staged_by_status(self, channel_id, statuses):
+            return (item,) if statuses == ("uploading",) else ()
+
+        def update_staged_cleanup(self, bundle_key, *, status, **kwargs):
+            transitions.append((bundle_key, status))
+            return item
+
+    class FakeRunner:
+        def __init__(self, **kwargs) -> None:
+            self.reference_folder = kwargs["reference_folder"]
+
+        def preflight(self) -> None:
+            return None
+
+    async def no_more_bundles(**kwargs):
+        return cli.StagingResult((), (), 0)
+
+    monkeypatch.setattr(cli, "CodexCleanupRunner", FakeRunner)
+    monkeypatch.setattr(cli, "stage_bundles", no_more_bundles)
+    monkeypatch.setattr(cli, "_login", lambda args: _fail("must not upload"))
+    args = SimpleNamespace(
+        cleanup_skill=tmp_path / "SKILL.md",
+        cleanup_reference=tmp_path / "reference",
+        codex_command="codex",
+        cleanup_timeout=60,
+        cleanup_concurrency=1,
+        concurrency=1,
+        stage=1,
+        staging_dir=tmp_path / "staging",
+    )
+
+    exit_code = await cli.run_codex_staged_batches(
+        args=args,
+        telegram=SimpleNamespace(channel_id=-100123),
+        tracker=FakeTracker(),
+        refs=[],
+        progress=None,
+        work_root=tmp_path / "work",
+    )
+
+    assert exit_code == 1
+    assert transitions == [("first-key", "needs_review")]
+
+
+async def test_should_record_malformed_cleanup_and_continue_with_its_sibling(
+    tmp_path,
+) -> None:
+    from alexandria_telegram_importer import cli
+    from alexandria_telegram_importer.tracker import StagedBundle
+
+    staging_dir = tmp_path / "staging"
+    reference = tmp_path / "reference"
+    reference.mkdir()
+
+    def payload(key: str, message_id: int) -> dict:
+        return {
+            "modelName": key,
+            "metadata": {"character": key},
+            "source": {
+                "channelId": -100123,
+                "bundleKey": key,
+                "modelMessageIds": [message_id],
+                "attachmentMessageIds": [],
+            },
+            "result": None,
+        }
+
+    originals = {"bad": payload("bad", 1), "good": payload("good", 2)}
+    (reference / "metadata.json").write_text(
+        json.dumps(originals["good"]),
+        encoding="utf-8",
+    )
+    for key, original in originals.items():
+        folder = staging_dir / key
+        (folder / "models").mkdir(parents=True)
+        (folder / "images").mkdir()
+        with zipfile.ZipFile(folder / "models" / f"{key}.zip", "w") as archive:
+            archive.writestr(f"{key}.stl", b"model")
+        current = json.loads(json.dumps(original))
+        if key == "bad":
+            current["source"]["modelMessageIds"] = [{"malformed": 1}]
+        (folder / "metadata.json").write_text(json.dumps(current), encoding="utf-8")
+
+    items = tuple(
+        StagedBundle(
+            bundle_key=key,
+            source_channel_id=-100123,
+            folder_name=key,
+            model_message_ids=(index,),
+            status="downloaded",
+            downloaded_at="2026-01-01T00:00:00+00:00",
+            cleanup_report={"originalMetadata": originals[key]},
+        )
+        for index, key in enumerate(("bad", "good"), start=1)
+    )
+    by_key = {item.bundle_key: item for item in items}
+    transitions: list[tuple[str, str]] = []
+
+    class FakeTracker:
+        def update_staged_cleanup(
+            self,
+            bundle_key,
+            *,
+            status,
+            output_folders=(),
+            report=None,
+        ):
+            transitions.append((bundle_key, status))
+            return replace(
+                by_key[bundle_key],
+                status=status,
+                output_folders=output_folders,
+                cleanup_report=report,
+            )
+
+    class FakeRunner:
+        reference_folder = reference
+
+        async def run(self, *, bundle_key, input_folder, work_root):
+            return cli.CleanupReceipt(
+                status="ready",
+                input_folder=input_folder,
+                output_folders=(input_folder,),
+                summary="prepared",
+                warnings=(),
+                checks={
+                    "archivesTested": True,
+                    "metadataValid": True,
+                    "imagesFlat": True,
+                    "splitComplete": True,
+                },
+            )
+
+    result = await cli.cleanup_staged_bundles(
+        items=items,
+        staging_dir=staging_dir,
+        tracker=FakeTracker(),
+        runner=FakeRunner(),
+        work_root=tmp_path / "work",
+        concurrency=2,
+    )
+
+    assert result.outcomes == {"cleanup_failed": 1, "ready": 1}
+    assert [bundle.bundle_key for bundle in result.ready_bundles] == ["good"]
+    assert ("bad", "cleanup_failed") in transitions
+    assert ("good", "ready") in transitions
 
 
 def _forbidden_telegram(**kwargs):

--- a/tools/telegram-importer/tests/test_codex_cleanup.py
+++ b/tools/telegram-importer/tests/test_codex_cleanup.py
@@ -1,0 +1,289 @@
+from __future__ import annotations
+
+import json
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from alexandria_telegram_importer.codex_cleanup import (
+    CleanupReceipt,
+    CodexCleanupRunner,
+    sanitized_codex_environment,
+    validate_cleanup_receipt,
+)
+
+
+def metadata(*, bundle_key: str = "bundle-1") -> dict:
+    return {
+        "schemaVersion": 1,
+        "modelName": "Dragon",
+        "description": "A dragon",
+        "artist": "Example Artist",
+        "tags": ["dragon"],
+        "metadata": {"character": "Dragon", "year": 2026},
+        "options": {},
+        "collectionId": None,
+        "newCollectionName": None,
+        "source": {
+            "channelId": -100123,
+            "bundleKey": bundle_key,
+            "modelMessageIds": [10, 11],
+            "attachmentMessageIds": [8, 9],
+        },
+        "result": None,
+    }
+
+
+def make_ready_folder(path: Path, payload: dict) -> None:
+    (path / "models").mkdir(parents=True)
+    (path / "images").mkdir()
+    with zipfile.ZipFile(path / "models" / "Dragon.zip", "w") as archive:
+        archive.writestr("dragon.stl", b"model")
+    (path / "images" / "render.jpg").write_bytes(b"image")
+    (path / "metadata.json").write_text(json.dumps(payload), encoding="utf-8")
+
+
+def receipt(input_folder: Path, *outputs: Path) -> CleanupReceipt:
+    return CleanupReceipt(
+        status="ready",
+        input_folder=input_folder.resolve(),
+        output_folders=tuple(path.resolve() for path in outputs),
+        summary="prepared",
+        warnings=(),
+        checks={
+            "archivesTested": True,
+            "metadataValid": True,
+            "imagesFlat": True,
+            "splitComplete": True,
+        },
+    )
+
+
+def test_should_remove_importer_credentials_from_the_codex_environment() -> None:
+    cleaned = sanitized_codex_environment(
+        {
+            "PATH": "/bin",
+            "CODEX_HOME": "/codex",
+            "CODEX_API_KEY": "codex-key",
+            "TELEGRAM_API_HASH": "telegram-secret",
+            "TELEGRAM_PHONE": "+15555555555",
+            "ALEXANDRIA_PASSWORD": "alexandria-secret",
+            "API_ID": "123",
+            "API_HASH": "hash",
+            "PHONE": "phone",
+        },
+    )
+
+    assert cleaned == {
+        "PATH": "/bin",
+        "CODEX_HOME": "/codex",
+    }
+
+
+def test_should_validate_one_ready_model_folder(tmp_path) -> None:
+    staging = tmp_path / "staging"
+    model = staging / "002501-dragon"
+    original = metadata()
+    make_ready_folder(model, original)
+    reference = tmp_path / "reference"
+    reference.mkdir()
+    (reference / "metadata.json").write_text(json.dumps(metadata()), encoding="utf-8")
+
+    validation = validate_cleanup_receipt(
+        receipt(model, model),
+        staging_root=staging,
+        original_metadata=original,
+        reference_folder=reference,
+    )
+
+    assert validation.ready
+    assert [folder.path for folder in validation.folders] == [model]
+
+
+def test_should_reject_unreported_split_outputs(tmp_path) -> None:
+    staging = tmp_path / "staging"
+    bundle = staging / "002501-dragons"
+    original = metadata()
+    first = bundle / "red"
+    second = bundle / "blue"
+    red = metadata()
+    red["source"]["modelMessageIds"] = [10]
+    blue = metadata()
+    blue["source"]["modelMessageIds"] = [11]
+    make_ready_folder(first, red)
+    make_ready_folder(second, blue)
+    reference = tmp_path / "reference"
+    reference.mkdir()
+    (reference / "metadata.json").write_text(json.dumps(metadata()), encoding="utf-8")
+
+    validation = validate_cleanup_receipt(
+        receipt(bundle, first),
+        staging_root=staging,
+        original_metadata=original,
+        reference_folder=reference,
+        archive_tester=lambda path: None,
+    )
+
+    assert not validation.ready
+    assert any("unreported model folders" in error for error in validation.errors)
+
+
+def test_should_reject_an_output_outside_the_assigned_bundle(tmp_path) -> None:
+    staging = tmp_path / "staging"
+    bundle = staging / "002501-dragon"
+    outside = staging / "002502-other"
+    make_ready_folder(bundle, metadata())
+    make_ready_folder(outside, metadata(bundle_key="other"))
+    reference = tmp_path / "reference"
+    reference.mkdir()
+    (reference / "metadata.json").write_text(json.dumps(metadata()), encoding="utf-8")
+
+    validation = validate_cleanup_receipt(
+        receipt(bundle, outside),
+        staging_root=staging,
+        original_metadata=metadata(),
+        reference_folder=reference,
+        archive_tester=lambda path: None,
+    )
+
+    assert not validation.ready
+    assert any("escapes its assigned bundle" in error for error in validation.errors)
+
+
+def test_should_reject_malformed_message_ids_without_crashing(tmp_path) -> None:
+    staging = tmp_path / "staging"
+    model = staging / "002501-dragon"
+    original = metadata()
+    malformed = metadata()
+    malformed["source"]["modelMessageIds"] = [10, {"unexpected": 11}]
+    make_ready_folder(model, malformed)
+    reference = tmp_path / "reference"
+    reference.mkdir()
+    (reference / "metadata.json").write_text(json.dumps(metadata()), encoding="utf-8")
+
+    validation = validate_cleanup_receipt(
+        receipt(model, model),
+        staging_root=staging,
+        original_metadata=original,
+        reference_folder=reference,
+        archive_tester=lambda path: None,
+    )
+
+    assert not validation.ready
+    assert any("integer message IDs" in error for error in validation.errors)
+
+
+def test_should_reject_a_symlinked_output_folder(tmp_path) -> None:
+    bundle = tmp_path / "bundle"
+    target = bundle / "target"
+    make_ready_folder(target, metadata())
+    linked = bundle / "linked"
+    linked.symlink_to(target, target_is_directory=True)
+
+    with pytest.raises(Exception, match="symlinked output folder"):
+        CleanupReceipt.from_payload(
+            {
+                **receipt(bundle, linked).as_payload(),
+                "inputFolder": str(bundle),
+                "outputFolders": [str(linked)],
+            },
+            input_folder=bundle,
+        )
+
+
+async def test_should_run_codex_with_a_schema_and_sanitized_environment(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    skill = tmp_path / "SKILL.md"
+    skill.write_text("# Prepare", encoding="utf-8")
+    reference = tmp_path / "reference"
+    reference.mkdir()
+    (reference / "metadata.json").write_text(json.dumps(metadata()), encoding="utf-8")
+    input_folder = tmp_path / "input"
+    input_folder.mkdir()
+    captured: dict = {}
+
+    class FakeProcess:
+        returncode = 0
+
+        async def communicate(self):
+            return b"", b""
+
+        def kill(self) -> None:
+            raise AssertionError("process should not be killed")
+
+        async def wait(self) -> int:
+            return 0
+
+    async def fake_exec(*command, **kwargs):
+        captured["command"] = command
+        captured["environment"] = kwargs["env"]
+        output = Path(command[command.index("--output-last-message") + 1])
+        output.write_text(
+            json.dumps(
+                {
+                    "status": "needs_review",
+                    "inputFolder": str(input_folder),
+                    "outputFolders": [],
+                    "summary": "identity is ambiguous",
+                    "warnings": ["choose a character"],
+                    "checks": {
+                        "archivesTested": False,
+                        "metadataValid": False,
+                        "imagesFlat": False,
+                        "splitComplete": False,
+                    },
+                },
+            ),
+            encoding="utf-8",
+        )
+        return FakeProcess()
+
+    monkeypatch.setattr("asyncio.create_subprocess_exec", fake_exec)
+    runner = CodexCleanupRunner(
+        skill_path=skill,
+        reference_folder=reference,
+        command="python3",
+        environment={
+            "PATH": "/usr/bin:/bin",
+            "CODEX_HOME": "/codex",
+            "TELEGRAM_API_HASH": "secret",
+            "ALEXANDRIA_PASSWORD": "secret",
+        },
+    )
+
+    result = await runner.run(
+        bundle_key="bundle-1",
+        input_folder=input_folder,
+        work_root=tmp_path / "work",
+    )
+
+    assert result.status == "needs_review"
+    assert "--ephemeral" in captured["command"]
+    assert "--output-schema" in captured["command"]
+    assert captured["environment"] == {
+        "PATH": "/usr/bin:/bin",
+        "CODEX_HOME": "/codex",
+    }
+
+
+def test_should_reject_a_receipt_for_another_input_folder(tmp_path) -> None:
+    with pytest.raises(Exception, match="expected"):
+        CleanupReceipt.from_payload(
+            {
+                "status": "failed",
+                "inputFolder": str(tmp_path / "wrong"),
+                "outputFolders": [],
+                "summary": "failed",
+                "warnings": [],
+                "checks": {
+                    "archivesTested": False,
+                    "metadataValid": False,
+                    "imagesFlat": False,
+                    "splitComplete": False,
+                },
+            },
+            input_folder=tmp_path / "expected",
+        )

--- a/tools/telegram-importer/tests/test_folder_upload.py
+++ b/tools/telegram-importer/tests/test_folder_upload.py
@@ -469,6 +469,22 @@ async def test_should_keep_going_after_one_folder_fails(tmp_path) -> None:
     assert (tmp_path / "failed" / "002501-broken").is_dir()
 
 
+async def test_should_upload_only_the_explicit_folder_allowlist(tmp_path) -> None:
+    selected = make_folder(tmp_path / "002501-selected", models=["selected.7z"])
+    untouched = make_folder(tmp_path / "002502-untouched", models=["untouched.7z"])
+    alexandria = FakeAlexandria()
+
+    outcomes = await FolderUploader(
+        alexandria=alexandria,
+        work_root=tmp_path / "work",
+    ).run(tmp_path, include_paths=(selected,))
+
+    assert outcomes == {"completed": 1}
+    assert (tmp_path / "uploaded" / "002501-selected").is_dir()
+    assert untouched.is_dir()
+    assert alexandria.uploads == [("selected.zip", False)]
+
+
 # --- Data-loss regressions ------------------------------------------------
 
 

--- a/tools/telegram-importer/tests/test_tracker.py
+++ b/tools/telegram-importer/tests/test_tracker.py
@@ -389,3 +389,64 @@ def test_should_add_the_staged_bundles_table_to_an_existing_state_file(tmp_path)
         assert tracker.get_staged("abc123") is not None
     finally:
         tracker.close()
+
+
+def test_should_persist_cleanup_lifecycle_and_outputs(tmp_path) -> None:
+    tracker = ImportTracker(tmp_path / "state.sqlite3")
+    try:
+        tracker.record_staged(
+            bundle_key="abc123",
+            source_channel_id=-100987654,
+            folder_name="002501-dragon-set",
+            model_message_ids=(2501,),
+        )
+
+        cleaning = tracker.update_staged_cleanup(
+            "abc123",
+            status="cleaning",
+            report={"originalMetadata": {"source": {"bundleKey": "abc123"}}},
+        )
+        ready = tracker.update_staged_cleanup(
+            "abc123",
+            status="ready",
+            output_folders=("002501-dragon-set/dragon",),
+            report={"status": "ready"},
+        )
+        uploaded = tracker.update_staged_status("abc123", status="uploaded")
+
+        assert cleaning.cleanup_attempts == 1
+        assert ready.output_folders == ("002501-dragon-set/dragon",)
+        assert ready.cleanup_report == {"status": "ready"}
+        assert uploaded.status == "uploaded"
+        assert tracker.staged_by_status(-100987654, ("uploaded",)) == (uploaded,)
+    finally:
+        tracker.close()
+
+
+def test_should_migrate_cleanup_columns_into_an_existing_staged_table(tmp_path) -> None:
+    path = tmp_path / "legacy-staged.sqlite3"
+    legacy = sqlite3.connect(path)
+    legacy.execute(
+        "CREATE TABLE staged_bundles ("
+        "bundle_key TEXT PRIMARY KEY, source_channel_id INTEGER NOT NULL, "
+        "folder_name TEXT NOT NULL, model_message_ids TEXT NOT NULL, "
+        "status TEXT NOT NULL, downloaded_at TEXT NOT NULL)",
+    )
+    legacy.execute(
+        "INSERT INTO staged_bundles VALUES "
+        "('abc123', -100987654, '002501-dragon', '[2501]', 'downloaded', "
+        "'2026-01-01T00:00:00+00:00')",
+    )
+    legacy.commit()
+    legacy.close()
+
+    tracker = ImportTracker(path)
+    try:
+        staged = tracker.get_staged("abc123")
+
+        assert staged is not None
+        assert staged.output_folders == ()
+        assert staged.cleanup_attempts == 0
+        assert staged.updated_at == staged.downloaded_at
+    finally:
+        tracker.close()


### PR DESCRIPTION
## What changed

- add a repository-owned Codex skill for preparing one Telegram staging bundle
- add isolated `codex exec` cleanup workers with structured receipts and credential-safe environments
- use the Codex-supported structured-output JSON Schema subset and enforce duplicate output paths locally
- independently validate metadata, provenance, archive integrity, image layout, symlinks, splits, and the exact output allowlist before upload
- persist cleanup/upload lifecycle state and continuously download the next batch after each completed batch
- revalidate resumed ready bundles and require manual reconciliation for indeterminate interrupted uploads
- delete automated-mode local outputs after confirmed commit using a crash-safe `committed_cleanup_pending` handoff with persisted session/model IDs
- resume pending deletions without replaying uploads, while retaining uncommitted split outputs for review
- document the automated workflow and configuration

## Why

The staged Telegram importer previously required a manual pause between downloading and uploading. This automates the cleanup handoff while keeping the importer—not Codex—as the upload authority, drains the channel in bounded batches until no unstaged work remains, and frees completed local staging storage safely.

## Validation

- `uv run --extra test pytest` — 257 passed
- targeted Ruff checks — passed
- Python bytecode compilation — passed
- importer CLI help smoke test — passed
- cleanup skill validation — passed
- live synthetic skill forward test with independent `7z t` verification — passed
- repository reviewer pass and targeted crash-recovery verification — passed
