### PR TITLE
fix: complete Codex staged import follow-ups

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -143,7 +143,12 @@ against their persisted receipt and current files before upload resumes; an inte
 record becomes `needs_review` because replaying an indeterminate remote commit could create a
 duplicate. `downloaded`, `cleaning`, and `cleanup_failed` records resume cleanup before any new
 downloads. `needs_review` and `upload_failed` remain for operator intervention. Codex never receives
-Alexandria upload authority.
+Alexandria upload authority. After Alexandria confirms a model is committed, automated mode deletes
+that validated local output folder only after durably recording its session and model identity in a
+`committed_cleanup_pending` lifecycle state, then finalizes the bundle as `uploaded`. Startup finishes
+pending deletions without replaying the remote commit; a partially committed split retains its
+uncommitted outputs for review. Manual staged uploads continue moving completed folders beneath
+`uploaded/` for operator retention.
 
 Duplicate detection is local to the utility's state database and has two layers. Before download, a
 signature over the complete logical model's Telegram document/photo IDs and reported sizes

--- a/tools/telegram-importer/README.md
+++ b/tools/telegram-importer/README.md
@@ -126,9 +126,11 @@ All three require `--staging-dir`, and `--staging-dir` requires one of them. `TE
 `--stage N --cleanup codex` turns the one-shot staged import into a channel-drain
 loop. The importer downloads at most N new bundles, gives each folder to Codex,
 validates Codex's structured receipt and files, uploads only the validated
-outputs, and then downloads the next batch. It stops when no unstaged bundle
-remains. The batch size bounds staging disk growth; `--cleanup-concurrency`
-independently controls how many Codex cleanup processes run at once.
+outputs, deletes each local output folder after Alexandria confirms it is
+committed, and then downloads the next batch. It stops when no unstaged bundle
+remains. Failed, review-required, and indeterminate folders are retained. The
+batch size bounds staging disk growth; `--cleanup-concurrency` independently
+controls how many Codex cleanup processes run at once.
 
 `--cleanup codex` requires `--stage` and a reference folder containing
 `metadata.json`. Use a completed model folder from this staged workflow. Codex
@@ -168,6 +170,8 @@ cannot perform the upload itself.
 Interrupted `downloaded`, `cleaning`, and `cleanup_failed` records resume cleanup
 before new downloads on the next automated run. A `ready` record resumes only
 after its persisted receipt and current files pass the complete validation again.
+`committed_cleanup_pending` records finish deleting only outputs whose Alexandria
+session and model IDs were already persisted, without replaying their uploads.
 An `uploading` record is indeterminate: Alexandria may already have committed the
 model, so the importer changes it to `needs_review` instead of risking a duplicate
 upload. Bundles already in `needs_review` or `upload_failed` are not retried by the
@@ -278,7 +282,15 @@ and validated output paths in `staged_bundles`. Upload transitions through
 `ready`, `uploading`, and `uploaded`. A later automated invocation revalidates
 `ready` outputs before resuming them; it leaves an interrupted `uploading` record
 for manual Alexandria-session reconciliation because replaying an indeterminate
-remote commit could create a duplicate model.
+remote commit could create a duplicate model. Once Alexandria reports
+`committed`, automated mode first records that output's Alexandria session and
+model IDs as `committed_cleanup_pending`, then removes the corresponding local
+model folder instead of moving it beneath `uploaded/`, and finally records the
+bundle as `uploaded`. On restart it safely finishes a pending deletion; for a
+partially committed split bundle it deletes only the recorded committed outputs
+and leaves the remainder in `needs_review`. These durable lifecycle rows prevent
+the Telegram bundle from being staged again. Manual `--upload-only` and manual
+`--stage` runs retain their completed folders beneath `uploaded/` as before.
 
 **The upload phase performs no deduplication.** No Telegram media signatures, no content hashes, no reads or writes to the `imports` table that the direct path uses. The folders are curated and uploaded as given. Automated mode's `staged_bundles` lifecycle limits which validated folders it hands to the uploader, but it does not add content or Alexandria-model deduplication. The consequence is explicit: moving a folder back out of `uploaded/` and re-running `--upload-only` creates a second Alexandria model. Manual download and upload remain deliberately decoupled, which is what lets folders be split, merged, renamed, and recompressed freely between them.
 

--- a/tools/telegram-importer/src/alexandria_telegram_importer/cli.py
+++ b/tools/telegram-importer/src/alexandria_telegram_importer/cli.py
@@ -22,7 +22,7 @@ from .codex_cleanup import (
     validate_cleanup_receipt,
 )
 from .folder_metadata import read_metadata
-from .folder_upload import FolderUploader, describe_staging
+from .folder_upload import FolderUploader, delete_committed, describe_staging
 from .grouping import build_bundles
 from .importer import ChannelImporter, describe_plan
 from .models import MediaRef
@@ -699,15 +699,28 @@ async def run_codex_staged_batches(
         if alexandria is None:
             alexandria = await _login(args)
         tracker.update_staged_status(bundle.bundle_key, status="uploading")
+
+        def record_committed(path: Path, result: dict[str, object]) -> None:
+            relative = str(path.resolve().relative_to(args.staging_dir.resolve()))
+            tracker.record_staged_committed_output(
+                bundle.bundle_key,
+                output_folder=relative,
+                result=result,
+            )
+
         try:
             upload_outcomes = await FolderUploader(
                 alexandria=alexandria,
                 work_root=work_root,
                 concurrency=args.concurrency,
                 progress=progress,
+                delete_completed=True,
+                on_committed=record_committed,
             ).run(args.staging_dir, include_paths=revalidation.paths)
         except Exception as error:  # noqa: BLE001 - record the bundle before aborting
-            tracker.update_staged_status(bundle.bundle_key, status="upload_failed")
+            current = tracker.get_staged(bundle.bundle_key)
+            if current is None or current.status != "committed_cleanup_pending":
+                tracker.update_staged_status(bundle.bundle_key, status="upload_failed")
             totals["upload_failed"] += 1
             log.error("Upload failed for %s: %s", label, error)
             return
@@ -716,12 +729,78 @@ async def run_codex_staged_batches(
         failed = upload_outcomes.get("failed", 0)
         totals["uploaded"] += completed
         totals["upload_failed"] += failed
-        tracker.update_staged_status(
-            bundle.bundle_key,
-            status="uploaded"
-            if completed == len(revalidation.paths) and not failed
-            else "upload_failed",
+        if completed == len(revalidation.paths) and not failed:
+            tracker.update_staged_status(bundle.bundle_key, status="uploaded")
+            return
+        current = tracker.get_staged(bundle.bundle_key)
+        if current is not None and current.status == "committed_cleanup_pending":
+            report = dict(current.cleanup_report or {})
+            report["uploadRecovery"] = (
+                "Some outputs committed before another output failed. Committed "
+                "identities are preserved; reconcile the remaining outputs manually."
+            )
+            tracker.update_staged_cleanup(
+                bundle.bundle_key,
+                status="needs_review",
+                output_folders=current.output_folders,
+                report=report,
+            )
+            totals["needs_review"] += 1
+        else:
+            tracker.update_staged_status(bundle.bundle_key, status="upload_failed")
+
+    def reconcile_committed_cleanup(item: StagedBundle) -> None:
+        report = dict(item.cleanup_report or {})
+        committed = report.get("committedOutputs")
+        errors: list[str] = []
+        if not isinstance(committed, dict) or not committed:
+            errors.append("Committed output identities are missing")
+            committed = {}
+        expected = set(item.output_folders)
+        committed_paths = set(committed)
+        if unexpected := committed_paths - expected:
+            errors.append(
+                "Committed outputs are outside the persisted allowlist: "
+                + ", ".join(sorted(unexpected))
+            )
+        for relative, result in committed.items():
+            if not isinstance(result, dict) or not all(
+                isinstance(result.get(key), str) and result[key]
+                for key in ("sessionId", "modelId")
+            ):
+                errors.append(f"Committed identity is incomplete for {relative}")
+                continue
+            if relative not in expected:
+                continue
+            try:
+                delete_committed(args.staging_dir / relative, args.staging_dir)
+            except (OSError, ValueError) as error:
+                errors.append(f"Could not delete committed output {relative}: {error}")
+        if errors:
+            report["cleanupRecoveryErrors"] = errors
+            tracker.update_staged_cleanup(
+                item.bundle_key,
+                status="needs_review",
+                output_folders=item.output_folders,
+                report=report,
+            )
+            totals["needs_review"] += 1
+            return
+        if committed_paths == expected:
+            tracker.update_staged_status(item.bundle_key, status="uploaded")
+            totals["uploaded"] += len(committed_paths)
+            return
+        report["uploadRecovery"] = (
+            "Only part of this split bundle committed before interruption. "
+            "Committed identities are preserved; reconcile remaining outputs manually."
         )
+        tracker.update_staged_cleanup(
+            item.bundle_key,
+            status="needs_review",
+            output_folders=item.output_folders,
+            report=report,
+        )
+        totals["needs_review"] += 1
 
     async def clean_and_upload(
         items: tuple[StagedBundle, ...],
@@ -743,6 +822,17 @@ async def run_codex_staged_batches(
             await upload_ready(bundle, label=label)
 
     try:
+        pending_cleanups = tracker.staged_by_status(
+            telegram.channel_id,
+            ("committed_cleanup_pending",),
+        )
+        for item in pending_cleanups:
+            batch_number += 1
+            print(
+                f"Batch {batch_number}: finishing local cleanup for {item.folder_name}"
+            )
+            reconcile_committed_cleanup(item)
+
         indeterminate_uploads = tracker.staged_by_status(
             telegram.channel_id,
             ("uploading",),

--- a/tools/telegram-importer/src/alexandria_telegram_importer/codex_cleanup.py
+++ b/tools/telegram-importer/src/alexandria_telegram_importer/codex_cleanup.py
@@ -65,7 +65,6 @@ CLEANUP_OUTPUT_SCHEMA: dict[str, Any] = {
         "outputFolders": {
             "type": "array",
             "items": {"type": "string"},
-            "uniqueItems": True,
         },
         "summary": {"type": "string"},
         "warnings": {"type": "array", "items": {"type": "string"}},

--- a/tools/telegram-importer/src/alexandria_telegram_importer/folder_upload.py
+++ b/tools/telegram-importer/src/alexandria_telegram_importer/folder_upload.py
@@ -7,7 +7,7 @@ import shutil
 import tempfile
 import zipfile
 from collections import Counter
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -172,7 +172,9 @@ def build_folder_archive(
     for image in images:
         members[str(Path(IMAGES_DIRNAME) / image.name)] = image
 
-    with zipfile.ZipFile(archive_path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+    with zipfile.ZipFile(
+        archive_path, "w", compression=zipfile.ZIP_DEFLATED
+    ) as archive:
         for name, path in sorted(members.items()):
             archive.write(path, arcname=name)
     return archive_path
@@ -244,6 +246,26 @@ def _prune_empty_containers(directory: Path, root: Path) -> None:
         directory = directory.parent
 
 
+def delete_committed(folder: Path, root: Path) -> bool:
+    """Delete one durably recorded committed folder and prune empty containers."""
+    root = root.resolve()
+    lexical = folder.absolute()
+    if lexical.is_symlink():
+        raise ValueError(f"Refusing to delete symlinked committed folder {lexical}")
+    resolved = lexical.resolve()
+    if not resolved.is_relative_to(root):
+        raise ValueError(f"Committed folder escapes the staging root: {resolved}")
+    if not resolved.exists():
+        return False
+    if not resolved.is_dir():
+        raise ValueError(f"Committed folder is not a directory: {resolved}")
+    parent = resolved.parent
+    shutil.rmtree(resolved)
+    _prune_empty_containers(parent, root)
+    log.info("Deleted committed local folder %s", resolved)
+    return True
+
+
 def _uploaded_at() -> dict[str, str]:
     return {"uploadedAt": datetime.now(UTC).isoformat()}
 
@@ -267,13 +289,21 @@ class FolderUploader:
         work_root: Path,
         concurrency: int = 1,
         progress: ProgressReporter | None = None,
+        delete_completed: bool = False,
+        on_committed: Callable[[Path, dict[str, Any]], None] | None = None,
     ) -> None:
         if concurrency < 1:
             raise ValueError("Upload concurrency must be at least 1")
+        if delete_completed and on_committed is None:
+            raise ValueError(
+                "Deleting completed folders requires a durable on_committed callback"
+            )
         self.alexandria = alexandria
         self.work_root = work_root
         self.concurrency = concurrency
         self.progress: ProgressReporter = progress or NullProgress()
+        self.delete_completed = delete_completed
+        self.on_committed = on_committed
 
     def image_paths(self, folder: ModelFolder) -> tuple[Path, ...]:
         """Every image to append, with the model's own file winning a name clash."""
@@ -299,7 +329,9 @@ class FolderUploader:
             }
             if missing := selected - discoverable:
                 joined = ", ".join(str(path) for path in sorted(missing))
-                raise ValueError(f"Selected staging folders are not uploadable: {joined}")
+                raise ValueError(
+                    f"Selected staging folders are not uploadable: {joined}"
+                )
             found = [folder for folder in found if folder.path.resolve() in selected]
             ambiguous = [
                 (path, reason)
@@ -362,9 +394,18 @@ class FolderUploader:
                 {"error": str(error), **session_out, **_failed_at()},
             )
             return "failed"
-        dispose(
-            folder.path, root, UPLOADED_DIRNAME, {"modelId": model_id, **_uploaded_at()}
-        )
+        if self.delete_completed:
+            result = {"modelId": model_id, **session_out, **_uploaded_at()}
+            assert self.on_committed is not None
+            self.on_committed(folder.path, result)
+            delete_committed(folder.path, root)
+        else:
+            dispose(
+                folder.path,
+                root,
+                UPLOADED_DIRNAME,
+                {"modelId": model_id, **_uploaded_at()},
+            )
         log.info("Uploaded %s as Alexandria model %s", folder.path.name, model_id)
         return "completed"
 
@@ -407,7 +448,9 @@ class FolderUploader:
                             on_progress=transfer.advance,
                         ),
                     )
-                session_id = await self.alexandria.complete_upload(upload_ids, multipart=False)
+                session_id = await self.alexandria.complete_upload(
+                    upload_ids, multipart=False
+                )
             except Exception:
                 await self.alexandria.abort_uploads(upload_ids)
                 raise
@@ -419,7 +462,9 @@ class FolderUploader:
                 session_id, {"ready_for_review"}
             )
             if session["status"] == "error":
-                raise RuntimeError(session.get("error") or "Alexandria ingestion failed")
+                raise RuntimeError(
+                    session.get("error") or "Alexandria ingestion failed"
+                )
 
             handle.phase("committing")
             await self.alexandria.commit(
@@ -428,7 +473,9 @@ class FolderUploader:
                 description=effective.get("description"),
                 batch_metadata=payload,
             )
-            committed = await self.alexandria.wait_for_session(session_id, {"committed"})
+            committed = await self.alexandria.wait_for_session(
+                session_id, {"committed"}
+            )
             if committed["status"] == "error":
                 raise RuntimeError(committed.get("error") or "Alexandria commit failed")
             return committed["modelId"]
@@ -448,7 +495,9 @@ def describe_staging(root: Path) -> str:
             lines.append(f"  SKIP  {folder.path.relative_to(root)}: {error}")
             continue
         images = sum(
-            1 for directory in folder.image_dirs for item in directory.iterdir()
+            1
+            for directory in folder.image_dirs
+            for item in directory.iterdir()
             if item.is_file()
         )
         lines.append(

--- a/tools/telegram-importer/src/alexandria_telegram_importer/tracker.py
+++ b/tools/telegram-importer/src/alexandria_telegram_importer/tracker.py
@@ -417,7 +417,12 @@ class ImportTracker:
         return staged
 
     def update_staged_status(self, bundle_key: str, *, status: str) -> StagedBundle:
-        allowed = {"uploading", "uploaded", "upload_failed"}
+        allowed = {
+            "uploading",
+            "committed_cleanup_pending",
+            "uploaded",
+            "upload_failed",
+        }
         if status not in allowed:
             raise ValueError(f"Unsupported staged status {status!r}")
         now = datetime.now(UTC).isoformat()
@@ -433,6 +438,42 @@ class ImportTracker:
         if staged is None:
             raise KeyError(bundle_key)
         return staged
+
+    def record_staged_committed_output(
+        self,
+        bundle_key: str,
+        *,
+        output_folder: str,
+        result: dict[str, Any],
+    ) -> StagedBundle:
+        """Persist remote commit identity before its local folder is deleted."""
+        staged = self.get_staged(bundle_key)
+        if staged is None:
+            raise KeyError(bundle_key)
+        report = dict(staged.cleanup_report or {})
+        committed = report.get("committedOutputs")
+        if not isinstance(committed, dict):
+            committed = {}
+        committed[output_folder] = dict(result)
+        report["committedOutputs"] = committed
+        now = datetime.now(UTC).isoformat()
+        with self._connection:
+            updated = self._connection.execute(
+                """
+                UPDATE staged_bundles
+                SET status = 'committed_cleanup_pending',
+                    cleanup_report = ?,
+                    updated_at = ?
+                WHERE bundle_key = ?
+                """,
+                (json.dumps(report), now, bundle_key),
+            )
+        if updated.rowcount != 1:
+            raise KeyError(bundle_key)
+        result_record = self.get_staged(bundle_key)
+        if result_record is None:
+            raise KeyError(bundle_key)
+        return result_record
 
     def staged_by_status(
         self,

--- a/tools/telegram-importer/tests/test_cli.py
+++ b/tools/telegram-importer/tests/test_cli.py
@@ -347,6 +347,7 @@ async def test_should_continue_with_the_next_codex_batch_after_upload(
     stage_calls: list[set[str]] = []
     uploads: list[tuple[Path, ...]] = []
     statuses: list[tuple[str, str]] = []
+    delete_modes: list[bool] = []
     logins: list[str] = []
     closes: list[str] = []
 
@@ -371,18 +372,52 @@ async def test_should_continue_with_the_next_codex_batch_after_upload(
 
     class FakeUploader:
         def __init__(self, **kwargs) -> None:
-            pass
+            delete_modes.append(kwargs["delete_completed"])
+            self.on_committed = kwargs["on_committed"]
 
         async def run(self, root, *, include_paths):
             uploads.append(tuple(include_paths))
+            for index, path in enumerate(include_paths, start=1):
+                self.on_committed(
+                    path,
+                    {"sessionId": f"session-{index}", "modelId": f"model-{index}"},
+                )
             return {"completed": len(include_paths)}
 
     class FakeTracker:
+        def __init__(self) -> None:
+            self.records = {
+                "first-key": item("first-key", "first"),
+                "second-key": item("second-key", "second"),
+            }
+
         def staged_by_status(self, channel_id, states):
             return ()
 
         def update_staged_status(self, bundle_key, *, status):
             statuses.append((bundle_key, status))
+            self.records[bundle_key] = replace(self.records[bundle_key], status=status)
+            return self.records[bundle_key]
+
+        def record_staged_committed_output(
+            self,
+            bundle_key,
+            *,
+            output_folder,
+            result,
+        ):
+            record = self.records[bundle_key]
+            report = dict(record.cleanup_report or {})
+            report["committedOutputs"] = {output_folder: result}
+            self.records[bundle_key] = replace(
+                record,
+                status="committed_cleanup_pending",
+                cleanup_report=report,
+            )
+            return self.records[bundle_key]
+
+        def get_staged(self, bundle_key):
+            return self.records[bundle_key]
 
     class FakeClient:
         async def close(self) -> None:
@@ -430,6 +465,7 @@ async def test_should_continue_with_the_next_codex_batch_after_upload(
     assert uploads == [((first_path.resolve()),), ((second_path.resolve()),)]
     assert logins == ["login"]
     assert closes == ["close"]
+    assert delete_modes == [True, True]
     assert statuses == [
         ("first-key", "uploading"),
         ("first-key", "uploaded"),
@@ -703,6 +739,159 @@ async def test_should_record_malformed_cleanup_and_continue_with_its_sibling(
     assert [bundle.bundle_key for bundle in result.ready_bundles] == ["good"]
     assert ("bad", "cleanup_failed") in transitions
     assert ("good", "ready") in transitions
+
+
+async def test_should_finish_pending_local_deletion_after_restart(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    from alexandria_telegram_importer import cli
+    from alexandria_telegram_importer.tracker import ImportTracker
+
+    staging_dir = tmp_path / "staging"
+    folder = staging_dir / "first"
+    folder.mkdir(parents=True)
+    (folder / "archive.7z").write_bytes(b"committed")
+    tracker = ImportTracker(tmp_path / "state.sqlite3")
+    try:
+        tracker.record_staged(
+            bundle_key="first-key",
+            source_channel_id=-100123,
+            folder_name="first",
+            model_message_ids=(1,),
+        )
+        tracker.update_staged_cleanup(
+            "first-key",
+            status="ready",
+            output_folders=("first",),
+            report={"status": "ready"},
+        )
+        tracker.update_staged_status("first-key", status="uploading")
+        tracker.record_staged_committed_output(
+            "first-key",
+            output_folder="first",
+            result={"sessionId": "session-1", "modelId": "model-1"},
+        )
+
+        class FakeRunner:
+            def __init__(self, **kwargs) -> None:
+                self.reference_folder = kwargs["reference_folder"]
+
+            def preflight(self) -> None:
+                return None
+
+        async def no_more_bundles(**kwargs):
+            return cli.StagingResult((), (), 0)
+
+        monkeypatch.setattr(cli, "CodexCleanupRunner", FakeRunner)
+        monkeypatch.setattr(cli, "stage_bundles", no_more_bundles)
+        monkeypatch.setattr(cli, "_login", lambda args: _fail("must not upload"))
+        args = SimpleNamespace(
+            cleanup_skill=tmp_path / "SKILL.md",
+            cleanup_reference=tmp_path / "reference",
+            codex_command="codex",
+            cleanup_timeout=60,
+            cleanup_concurrency=1,
+            concurrency=1,
+            stage=1,
+            staging_dir=staging_dir,
+        )
+
+        exit_code = await cli.run_codex_staged_batches(
+            args=args,
+            telegram=SimpleNamespace(channel_id=-100123),
+            tracker=tracker,
+            refs=[],
+            progress=None,
+            work_root=tmp_path / "work",
+        )
+
+        assert exit_code == 0
+        assert not folder.exists()
+        assert tracker.get_staged("first-key").status == "uploaded"
+    finally:
+        tracker.close()
+
+
+async def test_should_retain_uncommitted_split_outputs_after_restart(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    from alexandria_telegram_importer import cli
+    from alexandria_telegram_importer.tracker import ImportTracker
+
+    staging_dir = tmp_path / "staging"
+    committed_folder = staging_dir / "release" / "one"
+    remaining_folder = staging_dir / "release" / "two"
+    committed_folder.mkdir(parents=True)
+    remaining_folder.mkdir()
+    (committed_folder / "archive.7z").write_bytes(b"committed")
+    (remaining_folder / "archive.7z").write_bytes(b"not committed")
+    tracker = ImportTracker(tmp_path / "state.sqlite3")
+    try:
+        tracker.record_staged(
+            bundle_key="release-key",
+            source_channel_id=-100123,
+            folder_name="release",
+            model_message_ids=(1, 2),
+        )
+        tracker.update_staged_cleanup(
+            "release-key",
+            status="ready",
+            output_folders=("release/one", "release/two"),
+            report={"status": "ready"},
+        )
+        tracker.update_staged_status("release-key", status="uploading")
+        tracker.record_staged_committed_output(
+            "release-key",
+            output_folder="release/one",
+            result={"sessionId": "session-1", "modelId": "model-1"},
+        )
+
+        class FakeRunner:
+            def __init__(self, **kwargs) -> None:
+                self.reference_folder = kwargs["reference_folder"]
+
+            def preflight(self) -> None:
+                return None
+
+        async def no_more_bundles(**kwargs):
+            return cli.StagingResult((), (), 0)
+
+        monkeypatch.setattr(cli, "CodexCleanupRunner", FakeRunner)
+        monkeypatch.setattr(cli, "stage_bundles", no_more_bundles)
+        monkeypatch.setattr(cli, "_login", lambda args: _fail("must not upload"))
+        args = SimpleNamespace(
+            cleanup_skill=tmp_path / "SKILL.md",
+            cleanup_reference=tmp_path / "reference",
+            codex_command="codex",
+            cleanup_timeout=60,
+            cleanup_concurrency=1,
+            concurrency=1,
+            stage=2,
+            staging_dir=staging_dir,
+        )
+
+        exit_code = await cli.run_codex_staged_batches(
+            args=args,
+            telegram=SimpleNamespace(channel_id=-100123),
+            tracker=tracker,
+            refs=[],
+            progress=None,
+            work_root=tmp_path / "work",
+        )
+
+        staged = tracker.get_staged("release-key")
+        assert exit_code == 1
+        assert not committed_folder.exists()
+        assert remaining_folder.is_dir()
+        assert staged.status == "needs_review"
+        assert staged.cleanup_report["committedOutputs"]["release/one"] == {
+            "sessionId": "session-1",
+            "modelId": "model-1",
+        }
+    finally:
+        tracker.close()
 
 
 def _forbidden_telegram(**kwargs):

--- a/tools/telegram-importer/tests/test_codex_cleanup.py
+++ b/tools/telegram-importer/tests/test_codex_cleanup.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 
 from alexandria_telegram_importer.codex_cleanup import (
+    CLEANUP_OUTPUT_SCHEMA,
     CleanupReceipt,
     CodexCleanupRunner,
     sanitized_codex_environment,
@@ -79,6 +80,35 @@ def test_should_remove_importer_credentials_from_the_codex_environment() -> None
         "PATH": "/bin",
         "CODEX_HOME": "/codex",
     }
+
+
+def test_should_use_the_codex_supported_array_schema_subset() -> None:
+    assert CLEANUP_OUTPUT_SCHEMA["properties"]["outputFolders"] == {
+        "type": "array",
+        "items": {"type": "string"},
+    }
+
+
+def test_should_reject_duplicate_output_folders_after_parsing(tmp_path) -> None:
+    input_folder = tmp_path / "input"
+    input_folder.mkdir()
+    with pytest.raises(Exception, match="duplicate output folder"):
+        CleanupReceipt.from_payload(
+            {
+                "status": "ready",
+                "inputFolder": str(input_folder),
+                "outputFolders": [str(input_folder), str(input_folder)],
+                "summary": "prepared",
+                "warnings": [],
+                "checks": {
+                    "archivesTested": True,
+                    "metadataValid": True,
+                    "imagesFlat": True,
+                    "splitComplete": True,
+                },
+            },
+            input_folder=input_folder,
+        )
 
 
 def test_should_validate_one_ready_model_folder(tmp_path) -> None:

--- a/tools/telegram-importer/tests/test_folder_upload.py
+++ b/tools/telegram-importer/tests/test_folder_upload.py
@@ -88,7 +88,11 @@ def test_should_build_the_inheritance_chain_from_root_to_leaf(tmp_path) -> None:
     [folder], _ = discover(tmp_path)
 
     # chain[0] is the staging root itself; the release folder follows it.
-    assert [level.get("artist") for level in folder.chain] == [None, "Foo Studios", None]
+    assert [level.get("artist") for level in folder.chain] == [
+        None,
+        "Foo Studios",
+        None,
+    ]
     assert folder.chain[-1]["modelName"] == "Knight"
     assert folder.metadata["artist"] == "Foo Studios"
     assert folder.metadata["tags"] == ["dragon"]
@@ -118,7 +122,9 @@ def test_should_name_a_model_from_its_folder_when_metadata_is_absent(tmp_path) -
 
 def test_should_prefer_an_explicit_model_name_over_the_folder_name(tmp_path) -> None:
     make_folder(
-        tmp_path / "002501-dragon", models=["a.zip"], metadata={"modelName": "Real Name"}
+        tmp_path / "002501-dragon",
+        models=["a.zip"],
+        metadata={"modelName": "Real Name"},
     )
 
     [folder], _ = discover(tmp_path)
@@ -426,7 +432,12 @@ async def test_should_move_a_folder_to_failed_when_upload_raises(tmp_path) -> No
     alexandria = FakeAlexandria()
     alexandria.fail_commit = True
 
-    uploader = FolderUploader(alexandria=alexandria, work_root=tmp_path / "work")
+    uploader = FolderUploader(
+        alexandria=alexandria,
+        work_root=tmp_path / "work",
+        delete_completed=True,
+        on_committed=lambda path, result: None,
+    )
     outcomes = await uploader.run(tmp_path)
 
     assert outcomes["failed"] == 1
@@ -437,6 +448,30 @@ async def test_should_move_a_folder_to_failed_when_upload_raises(tmp_path) -> No
         ),
     )
     assert "commit exploded" in payload["result"]["error"]
+
+
+async def test_should_delete_a_committed_folder_when_requested(tmp_path) -> None:
+    folder = make_folder(tmp_path / "002501-dragon", models=["dragon.7z"])
+    alexandria = FakeAlexandria()
+    committed: list[dict] = []
+
+    def record_commit(path, result) -> None:
+        assert path.is_dir()
+        committed.append(result)
+
+    outcomes = await FolderUploader(
+        alexandria=alexandria,
+        work_root=tmp_path / "work",
+        delete_completed=True,
+        on_committed=record_commit,
+    ).run(tmp_path)
+
+    assert outcomes == {"completed": 1}
+    assert not folder.exists()
+    assert not (tmp_path / "uploaded").exists()
+    assert alexandria.commits[0]["modelName"] == "dragon"
+    assert committed[0]["sessionId"] == "session-1"
+    assert committed[0]["modelId"] == "model-1"
 
 
 async def test_should_move_an_ambiguous_folder_to_failed_without_uploading(

--- a/tools/telegram-importer/tests/test_tracker.py
+++ b/tools/telegram-importer/tests/test_tracker.py
@@ -363,7 +363,9 @@ def test_should_treat_recording_the_same_bundle_twice_as_idempotent(tmp_path) ->
         tracker.close()
 
 
-def test_should_add_the_staged_bundles_table_to_an_existing_state_file(tmp_path) -> None:
+def test_should_add_the_staged_bundles_table_to_an_existing_state_file(
+    tmp_path,
+) -> None:
     path = tmp_path / "state.sqlite3"
     legacy = sqlite3.connect(path)
     legacy.execute(
@@ -412,11 +414,26 @@ def test_should_persist_cleanup_lifecycle_and_outputs(tmp_path) -> None:
             output_folders=("002501-dragon-set/dragon",),
             report={"status": "ready"},
         )
+        committed = tracker.record_staged_committed_output(
+            "abc123",
+            output_folder="002501-dragon-set/dragon",
+            result={"sessionId": "session-1", "modelId": "model-1"},
+        )
         uploaded = tracker.update_staged_status("abc123", status="uploaded")
 
         assert cleaning.cleanup_attempts == 1
         assert ready.output_folders == ("002501-dragon-set/dragon",)
         assert ready.cleanup_report == {"status": "ready"}
+        assert committed.status == "committed_cleanup_pending"
+        assert committed.cleanup_report == {
+            "status": "ready",
+            "committedOutputs": {
+                "002501-dragon-set/dragon": {
+                    "sessionId": "session-1",
+                    "modelId": "model-1",
+                },
+            },
+        }
         assert uploaded.status == "uploaded"
         assert tracker.staged_by_status(-100987654, ("uploaded",)) == (uploaded,)
     finally:


### PR DESCRIPTION
## What changed

- delete automated Codex-staging output folders after Alexandria confirms each import is committed
- persist per-output session and model IDs before deletion through `committed_cleanup_pending`
- finish pending deletions safely after restart without replaying remote imports
- retain uncommitted split outputs for manual review
- remove the unsupported `uniqueItems` keyword from the Codex structured-output schema
- continue rejecting duplicate output folders in importer-side receipt validation
- normalize staged generic metadata according to Alexandria's configured field types
- validate the complete normalized metadata map through Alexandria before creating an archive or upload session
- reuse one in-flight metadata-field request across concurrent Codex upload workers

## Why

PR #106 merged before these follow-up commits were added to its branch. Automated channel drains need to release completed local staging storage, and Codex 0.145 rejects `uniqueItems` in `--output-schema` with `invalid_json_schema`.

An existing completed reference bundle also represented the text field `month-9g9z` as the JSON number `6`. That value reached the import-session commit endpoint and failed late with `400: Value must be a string` after the upload had already occurred.

## Impact

Automated mode now frees local disk only after a durable remote-commit record exists. Existing `cleanup_failed` bundles caused by the schema error can resume cleanup on the next run without being downloaded again. Manual staged uploads continue retaining completed folders beneath `uploaded/`.

Staged metadata is now normalized from live Alexandria field definitions (`6` becomes `"6"` for a text field) and checked by the backend's canonical validator before model bytes are packaged or uploaded. Invalid metadata therefore leaves the local bundle intact and fails early instead of surfacing as a commit-time type error.

## Validation

- importer test suite — 263 passed
- backend test suite — 1,027 passed
- shared and backend builds — passed
- repository lint — passed
- targeted Ruff checks — passed
- Python bytecode compilation — passed
- importer CLI help smoke test — passed
- `git diff --check` — passed
- targeted concurrency, data-loss, and crash-recovery review — passed
- live read-only verification against the configured Alexandria metadata definitions — passed
