### PR TITLE
fix: validate staged metadata before upload

### DIFF
--- a/apps/backend/src/routes/metadata.ts
+++ b/apps/backend/src/routes/metadata.ts
@@ -60,6 +60,17 @@ export async function metadataFieldRoutes(app: FastifyInstance): Promise<void> {
     },
   );
 
+  // POST /validate — validate metadata values without mutating a model
+  app.post(
+    '/validate',
+    { preHandler: [requireAuth, validate(setModelMetadataSchema)] },
+    async (request, reply) => {
+      const body = request.body as SetModelMetadataRequest;
+      const values = await metadataService.normalizeAndValidateValues(body);
+      return reply.status(200).send({ data: values, meta: null, errors: null });
+    },
+  );
+
   // GET /:slug/values — list known values for a field (scoped to the request library)
   app.get(
     '/:slug/values',

--- a/apps/backend/src/services/metadata.service.test.ts
+++ b/apps/backend/src/services/metadata.service.test.ts
@@ -5,6 +5,7 @@ import {
   beforeAll,
   afterAll,
   beforeEach,
+  vi,
 } from 'vitest';
 import { eq, and, inArray } from 'drizzle-orm';
 import { db } from '../db/index.js';
@@ -109,6 +110,29 @@ describe('MetadataService – configured value validation', () => {
       .toEqual(['x'.repeat(255)]);
     expect(() => service.normalizeAndValidateFieldValue(tagsField, ['   '])).toThrow();
     expect(() => service.normalizeAndValidateFieldValue(tagsField, ['x'.repeat(256)])).toThrow();
+  });
+
+  it('validates a complete metadata map without mutating a model', async () => {
+    vi.spyOn(service, 'getFieldBySlug').mockImplementation(async (slug) => {
+      if (slug === 'catalog-id') {
+        return field('text', { validationPattern: '^MODEL-[0-9]+$' });
+      }
+      return field('url');
+    });
+
+    await expect(service.normalizeAndValidateValues({
+      'catalog-id': 'MODEL-42',
+      url: 'https://example.com/model',
+    })).resolves.toEqual({
+      'catalog-id': 'MODEL-42',
+      url: 'https://example.com/model',
+    });
+    await expect(service.normalizeAndValidateValues({
+      'catalog-id': 'dragon',
+    })).rejects.toThrow(/does not match the required format/);
+    await expect(service.normalizeAndValidateValues({
+      url: 'https://example.com:bad',
+    })).rejects.toThrow(/HTTP or HTTPS URL/);
   });
 });
 

--- a/apps/backend/src/services/metadata.service.ts
+++ b/apps/backend/src/services/metadata.service.ts
@@ -189,6 +189,19 @@ export class MetadataService {
     return normalizedValue as string | string[] | number | boolean | null;
   }
 
+  /** Validate a complete metadata map without mutating a model. */
+  async normalizeAndValidateValues(
+    data: SetModelMetadataRequest,
+    executor: DatabaseExecutor = db,
+  ): Promise<SetModelMetadataRequest> {
+    const normalized: SetModelMetadataRequest = {};
+    for (const [fieldSlug, rawValue] of Object.entries(data)) {
+      const field = await this.getFieldBySlug(fieldSlug, executor);
+      normalized[fieldSlug] = this.normalizeAndValidateFieldValue(field, rawValue);
+    }
+    return normalized;
+  }
+
   // ---------------------------------------------------------------------------
   // Field Definition CRUD
   // ---------------------------------------------------------------------------

--- a/docs/API.md
+++ b/docs/API.md
@@ -2414,6 +2414,9 @@ Metadata is the system for attaching typed attributes to models. Field definitio
 
 List all metadata field definitions.
 
+Field definitions are global Alexandria configuration, not library-scoped.
+`X-Library-Id` does not change this response.
+
 **Auth required:** Yes
 
 **Response (200):**
@@ -2462,6 +2465,60 @@ List all metadata field definitions.
 | `url` | URL string |
 | `enum` | Single value from a predefined list (`config.enumOptions`) |
 | `multi_enum` | Multiple values from a predefined list; Tags uses this type |
+
+---
+
+### POST /metadata/fields/validate
+
+Validate a metadata-value map against the current configured field definitions
+without changing a model. This uses the same field lookup, tag normalization,
+type checks, enum options, URL parser, date parser, and RE2 text-pattern checks
+as model writes and import-session commits.
+
+Like the field-definition list, validation is global rather than library-scoped;
+`X-Library-Id` is ignored. The route performs no model lookup or mutation.
+
+**Auth required:** Yes
+
+**Request body:** A `SetModelMetadataRequest` JSON object keyed by metadata
+field slug. Slugs must be 1–255 characters. Each value is `null`, a string of
+at most 10,000 characters, an array of at most 100 such strings, a finite
+number, or a boolean. The configured field definition then applies the semantic
+type rules described under `PATCH /models/:id/metadata`.
+
+```json
+{
+  "year": 2026,
+  "nsfw": false,
+  "url": "https://example.com/model"
+}
+```
+
+**Response (200):** The standard envelope containing the validated metadata
+map. Non-Tag values are unchanged. In addition to `null`, the default Tags
+field accepts a string or string array, trims names, enforces the 255-character
+name and generated-slug limits, rejects blanks, and removes case-insensitive
+duplicates while preserving first occurrence order.
+
+```json
+{
+  "data": {
+    "year": 2026,
+    "nsfw": false,
+    "url": "https://example.com/model"
+  },
+  "meta": null,
+  "errors": null
+}
+```
+
+**Error cases:**
+
+| Code | Status | When |
+|------|--------|------|
+| `VALIDATION_ERROR` | 400 | The request body is malformed or a configured field rejects the supplied value |
+| `UNAUTHORIZED` | 401 | No valid session cookie |
+| `NOT_FOUND` | 404 | A field slug is not configured |
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -136,10 +136,20 @@ Alexandria, and direct Codex API credentials; gives Codex write access to only o
 requires a structured receipt; and independently validates the claimed output allowlist, absence of
 symlinks, exact reference metadata key sets, Telegram provenance and complete model-message
 coverage, flat images, and the single supported archive's integrity. Only the validated path
-allowlist reaches the uploader. Automated mode drains the channel in bounded batches, skips staging
-failures for the rest of the current invocation, and persists cleanup attempts, receipts, output
-paths, and lifecycle states in the importer's SQLite database. `ready` records are fully revalidated
-against their persisted receipt and current files before upload resumes; an interrupted `uploading`
+allowlist reaches the uploader. Before creating an upload session, FolderUploader reads Alexandria's
+globally configured metadata field definitions. Cold concurrent reads share one in-flight request,
+and the successful result is cached on the Alexandria client for later folders. FolderUploader
+normalizes only deterministic generic-field conversions: finite numbers and booleans to text,
+numeric strings to numbers, `true`/`false` strings to booleans, and scalars to multi-enum lists;
+arrays are rejected for scalar fields and null remains null for a configured field. A non-empty
+normalized map is then checked through the authoritative, non-mutating
+`POST /metadata/fields/validate` route, which shares the import commit's Tags, URL, date,
+enum-option, RE2 pattern, value-count, and length validation. Unknown fields, unsupported types,
+and ambiguous or invalid values fail without transferring model bytes. Automated mode drains the
+channel in bounded batches, skips staging failures for the rest of the current invocation, and
+persists cleanup attempts, receipts, output paths, and lifecycle states in the importer's SQLite
+database. `ready` records are fully revalidated against their persisted receipt and current files
+before upload resumes; an interrupted `uploading`
 record becomes `needs_review` because replaying an indeterminate remote commit could create a
 duplicate. `downloaded`, `cleaning`, and `cleanup_failed` records resume cleanup before any new
 downloads. `needs_review` and `upload_failed` remain for operator intervention. Codex never receives
@@ -755,6 +765,7 @@ All smart-collection by-id routes enforce ownership via `requireOwnedSmartCollec
 | Method | Route | Purpose | Service Chain | Library-scoped |
 |--------|-------|---------|---------------|---------------|
 | GET | /metadata/fields | List all field definitions | MetadataService → PresenterService | No |
+| POST | /metadata/fields/validate | Validate and normalize a metadata map without mutation | MetadataService | No |
 | POST | /metadata/fields | Create custom field | MetadataService | No |
 | PATCH | /metadata/fields/:id | Update field definition | MetadataService | No |
 | DELETE | /metadata/fields/:id | Delete (not defaults) | MetadataService | No |

--- a/tools/telegram-importer/README.md
+++ b/tools/telegram-importer/README.md
@@ -221,7 +221,7 @@ missing `models/` directories move the folder to `failed/`.
 
 ### metadata.json
 
-Its top level mirrors Alexandria's commit `batchMetadata` field for field, so it is passed through untranslated:
+Its top level mirrors Alexandria's commit `batchMetadata` field for field:
 
 ```json
 {
@@ -236,6 +236,32 @@ Its top level mirrors Alexandria's commit `batchMetadata` field for field, so it
 ```
 
 `source` records where the bundle came from; the upload phase ignores it, and it survives renaming and splitting. `result` is filled on disposal. `description` is composed from the bundle's captions and source link, so it is edited rather than written from scratch. A folder with no `metadata.json` still uploads, taking its name from its folder name.
+
+Before creating an upload session, the importer fetches Alexandria's globally
+configured metadata field definitions. Concurrent folders share one in-flight
+fetch, and the Alexandria client caches the successful response for later
+folders handled by that client. The importer then normalizes values in the
+nested `metadata` object without rewriting `metadata.json`:
+
+| Configured type | Accepted local normalization |
+|---|---|
+| `text` | Keep a string; stringify a finite number or boolean; reject arrays |
+| `number` | Keep a finite number or parse a numeric string |
+| `boolean` | Keep a boolean or parse a case-insensitive `"true"` or `"false"` string |
+| `enum` | Convert a scalar as text, reject arrays, then require a configured option when the field defines options |
+| `multi_enum` | Wrap a scalar in a list or keep a list, convert each value as text, enforce the 100-value limit, then validate configured options |
+| `date` | Convert a scalar as text, reject arrays, then require an ISO date or datetime, `YYYY`, or `YYYY-MM` |
+| `url` | Convert a scalar as text, reject arrays, then require an HTTP or HTTPS URL with a host |
+
+Null remains null for a configured field, and each resulting string is limited
+to 10,000 characters. Unknown fields, unsupported field types, non-finite
+numbers, invalid URLs or dates, disallowed enum values, and values without one
+of the conversions above fail locally before any model bytes are uploaded. A
+non-empty normalized map is then sent to the authoritative, non-mutating
+`POST /metadata/fields/validate` route, which applies the same Tags, URL, date,
+enum, and configured RE2 text-pattern checks used by import commits. This
+prevents a Codex-prepared folder from reaching commit with metadata Alexandria
+will reject.
 
 Because you edit this file by hand, a JSON syntax error is treated as an error rather than as "no metadata": a **model folder** whose own `metadata.json` will not parse moves to `failed/` without uploading, and the unreadable file is never rewritten — its result is written to a sibling `result.json` instead, so your hand-typed values survive. Fix the typo and re-run. A **container's** unparseable file is still skipped leniently, since a container commits nothing.
 

--- a/tools/telegram-importer/src/alexandria_telegram_importer/alexandria.py
+++ b/tools/telegram-importer/src/alexandria_telegram_importer/alexandria.py
@@ -58,6 +58,10 @@ class AlexandriaClient:
             follow_redirects=False,
         )
         self.poll_interval = poll_interval
+        self._metadata_fields_cache: tuple[dict[str, Any], ...] | None = None
+        self._metadata_fields_task: asyncio.Task[tuple[dict[str, Any], ...]] | None = (
+            None
+        )
 
     async def close(self) -> None:
         await self._client.aclose()
@@ -89,6 +93,45 @@ class AlexandriaClient:
         )
         user = self._data(response)
         log.info("Logged into Alexandria as %s", user.get("email", email))
+
+    async def metadata_fields(self) -> tuple[dict[str, Any], ...]:
+        """Configured metadata definitions for commit-payload normalization."""
+        if self._metadata_fields_cache is not None:
+            return self._metadata_fields_cache
+        if self._metadata_fields_task is None:
+            self._metadata_fields_task = asyncio.create_task(
+                self._fetch_metadata_fields()
+            )
+        try:
+            self._metadata_fields_cache = await self._metadata_fields_task
+        except BaseException:
+            self._metadata_fields_task = None
+            raise
+        return self._metadata_fields_cache
+
+    async def _fetch_metadata_fields(self) -> tuple[dict[str, Any], ...]:
+        response = await self._request("GET", "/metadata/fields")
+        fields = self._data(response)
+        if not isinstance(fields, list) or not all(
+            isinstance(field, dict) for field in fields
+        ):
+            raise AlexandriaError("Alexandria returned invalid metadata fields")
+        return tuple(fields)
+
+    async def validate_metadata(
+        self,
+        values: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Apply Alexandria's authoritative semantic metadata validation."""
+        response = await self._request(
+            "POST",
+            "/metadata/fields/validate",
+            json=values,
+        )
+        normalized = self._data(response)
+        if not isinstance(normalized, dict):
+            raise AlexandriaError("Alexandria returned invalid normalized metadata")
+        return normalized
 
     async def _upload_part(
         self,

--- a/tools/telegram-importer/src/alexandria_telegram_importer/folder_metadata.py
+++ b/tools/telegram-importer/src/alexandria_telegram_importer/folder_metadata.py
@@ -2,10 +2,13 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import re
 from collections.abc import Sequence
+from datetime import date, datetime
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlsplit
 
 log = logging.getLogger(__name__)
 
@@ -102,7 +105,127 @@ def merge_chain(chain: Sequence[dict[str, Any]]) -> dict[str, Any]:
 
 def batch_metadata(effective: dict[str, Any]) -> dict[str, Any]:
     """Reduce merged metadata to the fields the commit endpoint accepts."""
-    return {key: effective[key] for key in COMMIT_FIELDS if effective.get(key) is not None}
+    return {
+        key: effective[key] for key in COMMIT_FIELDS if effective.get(key) is not None
+    }
+
+
+def normalize_batch_metadata(
+    payload: dict[str, Any],
+    field_definitions: Sequence[dict[str, Any]],
+) -> dict[str, Any]:
+    """Match generic metadata values to Alexandria's configured field types."""
+    normalized = dict(payload)
+    values = payload.get("metadata")
+    if values is None:
+        return normalized
+    if not isinstance(values, dict):
+        raise TypeError("metadata must be an object")
+    fields = {
+        field["slug"]: field
+        for field in field_definitions
+        if isinstance(field, dict) and isinstance(field.get("slug"), str)
+    }
+    normalized["metadata"] = {
+        slug: _normalize_metadata_value(slug, value, fields.get(slug))
+        for slug, value in values.items()
+    }
+    return normalized
+
+
+def _normalize_metadata_value(
+    slug: str,
+    value: Any,
+    field: dict[str, Any] | None,
+) -> Any:
+    if field is None:
+        raise ValueError(f"metadata.{slug} is not configured in Alexandria")
+    if value is None:
+        return None
+    field_type = field.get("type")
+    config = field.get("config") if isinstance(field.get("config"), dict) else {}
+
+    if field_type == "number":
+        if isinstance(value, bool):
+            raise ValueError(f"metadata.{slug} must be a number")
+        if isinstance(value, (int, float)):
+            if not math.isfinite(value):
+                raise ValueError(f"metadata.{slug} must be a finite number")
+            return value
+        if isinstance(value, str):
+            try:
+                parsed = float(value.strip())
+            except ValueError as error:
+                raise ValueError(f"metadata.{slug} must be a number") from error
+            if not math.isfinite(parsed):
+                raise ValueError(f"metadata.{slug} must be a finite number")
+            return int(parsed) if parsed.is_integer() else parsed
+        raise ValueError(f"metadata.{slug} must be a number")
+
+    if field_type == "boolean":
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str) and value.strip().casefold() in {"true", "false"}:
+            return value.strip().casefold() == "true"
+        raise ValueError(f"metadata.{slug} must be a boolean")
+
+    if field_type == "multi_enum":
+        source = value if isinstance(value, list) else [value]
+        strings = [_metadata_string(slug, item) for item in source]
+        if len(strings) > 100:
+            raise ValueError(f"metadata.{slug} must contain at most 100 values")
+        _validate_enum_options(slug, strings, config)
+        return strings
+
+    if field_type not in {"text", "date", "url", "enum"}:
+        raise ValueError(f"metadata.{slug} has unsupported field type {field_type!r}")
+    string = _metadata_string(slug, value)
+    if field_type == "url":
+        parsed_url = urlsplit(string)
+        if parsed_url.scheme not in {"http", "https"} or not parsed_url.netloc:
+            raise ValueError(f"metadata.{slug} must be an HTTP or HTTPS URL")
+    elif field_type == "date" and not _is_iso_date(string):
+        raise ValueError(f"metadata.{slug} must be a valid ISO date")
+    elif field_type == "enum":
+        _validate_enum_options(slug, [string], config)
+    return string
+
+
+def _metadata_string(slug: str, value: Any) -> str:
+    if isinstance(value, str):
+        result = value
+    elif isinstance(value, bool):
+        result = "true" if value else "false"
+    elif isinstance(value, (int, float)) and math.isfinite(value):
+        result = str(value)
+    else:
+        raise ValueError(f"metadata.{slug} cannot be converted to a string")
+    if len(result) > 10_000:
+        raise ValueError(f"metadata.{slug} must be at most 10000 characters")
+    return result
+
+
+def _validate_enum_options(
+    slug: str,
+    values: Sequence[str],
+    config: dict[str, Any],
+) -> None:
+    options = config.get("enumOptions")
+    if isinstance(options, list) and any(value not in options for value in values):
+        raise ValueError(f"metadata.{slug} contains a value not allowed by Alexandria")
+
+
+def _is_iso_date(value: str) -> bool:
+    try:
+        date.fromisoformat(value)
+        return True
+    except ValueError:
+        pass
+    try:
+        datetime.fromisoformat(value)
+        return True
+    except ValueError:
+        return bool(re.fullmatch(r"\d{4}(?:-(?:0[1-9]|1[0-2]))?", value))
 
 
 def model_name_from_folder(name: str) -> str:

--- a/tools/telegram-importer/src/alexandria_telegram_importer/folder_upload.py
+++ b/tools/telegram-importer/src/alexandria_telegram_importer/folder_upload.py
@@ -19,6 +19,7 @@ from .folder_metadata import (
     merge_chain,
     metadata_error,
     model_name_from_folder,
+    normalize_batch_metadata,
     read_metadata,
     write_metadata,
 )
@@ -417,7 +418,14 @@ class FolderUploader:
     ) -> str:
         handle = handle or NullModelProgress()
         effective = folder.metadata
-        payload = batch_metadata(effective)
+        payload = normalize_batch_metadata(
+            batch_metadata(effective),
+            await self.alexandria.metadata_fields(),
+        )
+        if generic_metadata := payload.get("metadata"):
+            payload["metadata"] = await self.alexandria.validate_metadata(
+                generic_metadata
+            )
         payload["modelName"] = folder.model_name
 
         # upload() is public and callable without run(), so it owns creating

--- a/tools/telegram-importer/tests/test_alexandria.py
+++ b/tools/telegram-importer/tests/test_alexandria.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import asyncio
+
 import httpx
 import pytest
 
@@ -49,6 +51,69 @@ def test_should_collect_session_filenames_from_nested_folder_structure() -> None
 
 def test_should_return_no_filenames_when_session_detection_is_absent() -> None:
     assert session_filenames({"detected": None}) == set()
+
+
+@pytest.mark.asyncio
+async def test_should_fetch_and_cache_metadata_field_definitions(monkeypatch) -> None:
+    client = AlexandriaClient("http://127.0.0.1:3000")
+    calls: list[tuple[str, str]] = []
+
+    async def fake_request(method: str, url: str, **_kwargs):
+        calls.append((method, url))
+        return httpx.Response(
+            200,
+            json={
+                "data": [
+                    {"slug": "year", "type": "number", "config": None},
+                ],
+            },
+            request=httpx.Request(method, url),
+        )
+
+    monkeypatch.setattr(client, "_request", fake_request)
+    try:
+        first, second = await asyncio.gather(
+            client.metadata_fields(),
+            client.metadata_fields(),
+        )
+        third = await client.metadata_fields()
+    finally:
+        await client.close()
+
+    assert (
+        first
+        == second
+        == third
+        == ({"slug": "year", "type": "number", "config": None},)
+    )
+    assert calls == [("GET", "/metadata/fields")]
+
+
+@pytest.mark.asyncio
+async def test_should_use_authoritative_metadata_validation(monkeypatch) -> None:
+    client = AlexandriaClient("http://127.0.0.1:3000")
+    captured: dict = {}
+
+    async def fake_request(method: str, url: str, **kwargs):
+        captured.update(method=method, url=url, json=kwargs["json"])
+        return httpx.Response(
+            200,
+            json={"data": kwargs["json"]},
+            request=httpx.Request(method, url),
+        )
+
+    monkeypatch.setattr(client, "_request", fake_request)
+    try:
+        result = await client.validate_metadata({"catalog-id": "MODEL-42"})
+    finally:
+        await client.close()
+
+    assert result == {"catalog-id": "MODEL-42"}
+    assert captured == {
+        "method": "POST",
+        "url": "/metadata/fields/validate",
+        "json": {"catalog-id": "MODEL-42"},
+    }
 
 
 def upload_client(monkeypatch, *, failures: int = 0) -> AlexandriaClient:

--- a/tools/telegram-importer/tests/test_folder_metadata.py
+++ b/tools/telegram-importer/tests/test_folder_metadata.py
@@ -2,11 +2,14 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
 from alexandria_telegram_importer.folder_metadata import (
     SCHEMA_VERSION,
     batch_metadata,
     merge_chain,
     model_name_from_folder,
+    normalize_batch_metadata,
     read_metadata,
     write_metadata,
 )
@@ -107,6 +110,57 @@ def test_should_strip_non_commit_keys_from_batch_metadata() -> None:
     )
 
     assert payload == {"modelName": "Dragon", "tags": ["a"]}
+
+
+def test_should_normalize_metadata_to_alexandria_field_types() -> None:
+    payload = normalize_batch_metadata(
+        {
+            "modelName": "Catwoman",
+            "metadata": {
+                "character-6erm": "Catwoman",
+                "month-9g9z": 6,
+                "year": "2026",
+                "has-archive-edm5": True,
+                "nsfw": "false",
+                "url": "https://example.com/model",
+            },
+        },
+        (
+            {"slug": "character-6erm", "type": "text", "config": None},
+            {"slug": "month-9g9z", "type": "text", "config": None},
+            {"slug": "year", "type": "number", "config": None},
+            {"slug": "has-archive-edm5", "type": "text", "config": None},
+            {"slug": "nsfw", "type": "boolean", "config": None},
+            {"slug": "url", "type": "url", "config": None},
+        ),
+    )
+
+    assert payload["metadata"] == {
+        "character-6erm": "Catwoman",
+        "month-9g9z": "6",
+        "year": 2026,
+        "has-archive-edm5": "true",
+        "nsfw": False,
+        "url": "https://example.com/model",
+    }
+
+
+def test_should_reject_unknown_or_ambiguous_metadata_values() -> None:
+    with pytest.raises(ValueError, match="not configured"):
+        normalize_batch_metadata(
+            {"metadata": {"missing": "value"}},
+            (),
+        )
+    with pytest.raises(ValueError, match="must be a boolean"):
+        normalize_batch_metadata(
+            {"metadata": {"nsfw": "sometimes"}},
+            ({"slug": "nsfw", "type": "boolean", "config": None},),
+        )
+    with pytest.raises(ValueError, match="cannot be converted to a string"):
+        normalize_batch_metadata(
+            {"metadata": {"character": ["June", "July"]}},
+            ({"slug": "character", "type": "text", "config": None},),
+        )
 
 
 def test_should_report_an_error_for_an_unparseable_metadata_file(tmp_path) -> None:

--- a/tools/telegram-importer/tests/test_folder_upload.py
+++ b/tools/telegram-importer/tests/test_folder_upload.py
@@ -296,6 +296,16 @@ class FakeAlexandria:
         self.commits: list[dict] = []
         self.session = {"id": "session-1", "status": "ready_for_review"}
         self.fail_commit = False
+        self.fields: list[dict] = []
+        self.metadata_validation_error: str | None = None
+
+    async def metadata_fields(self):
+        return tuple(self.fields)
+
+    async def validate_metadata(self, values):
+        if self.metadata_validation_error:
+            raise ValueError(self.metadata_validation_error)
+        return values
 
     async def upload_file(self, path, upload_name, *, multipart, on_progress=None):
         self.uploads.append((upload_name, multipart))
@@ -333,9 +343,18 @@ async def test_should_upload_a_folder_and_return_its_model_id(tmp_path) -> None:
         tmp_path / "002501-dragon",
         models=["dragon.7z"],
         images=["render.jpg"],
-        metadata={"modelName": "Dragon", "artist": "Foo", "tags": ["dragon"]},
+        metadata={
+            "modelName": "Dragon",
+            "artist": "Foo",
+            "tags": ["dragon"],
+            "metadata": {"month-9g9z": 6, "has-archive-edm5": True},
+        },
     )
     alexandria = FakeAlexandria()
+    alexandria.fields = [
+        {"slug": "month-9g9z", "type": "text", "config": None},
+        {"slug": "has-archive-edm5", "type": "text", "config": None},
+    ]
     [folder], _ = discover(tmp_path)
 
     model_id = await FolderUploader(
@@ -358,6 +377,10 @@ async def test_should_upload_a_folder_and_return_its_model_id(tmp_path) -> None:
     assert alexandria.commits[0]["modelName"] == "Dragon"
     assert alexandria.commits[0]["batch_metadata"]["artist"] == "Foo"
     assert alexandria.commits[0]["batch_metadata"]["tags"] == ["dragon"]
+    assert alexandria.commits[0]["batch_metadata"]["metadata"] == {
+        "month-9g9z": "6",
+        "has-archive-edm5": "true",
+    }
 
 
 async def test_should_include_container_images_in_every_descendant_folder_archive(
@@ -448,6 +471,54 @@ async def test_should_move_a_folder_to_failed_when_upload_raises(tmp_path) -> No
         ),
     )
     assert "commit exploded" in payload["result"]["error"]
+
+
+async def test_should_reject_invalid_metadata_before_creating_an_upload(
+    tmp_path,
+) -> None:
+    make_folder(
+        tmp_path / "002501-dragon",
+        models=["dragon.7z"],
+        metadata={"metadata": {"unknown-field": 6}},
+    )
+    alexandria = FakeAlexandria()
+
+    outcomes = await FolderUploader(
+        alexandria=alexandria,
+        work_root=tmp_path / "work",
+    ).run(tmp_path)
+
+    assert outcomes == {"failed": 1}
+    assert alexandria.uploads == []
+    failed = tmp_path / "failed" / "002501-dragon" / "metadata.json"
+    assert "not configured" in json.loads(failed.read_text())["result"]["error"]
+
+
+async def test_should_apply_backend_metadata_validation_before_upload(tmp_path) -> None:
+    make_folder(
+        tmp_path / "002501-dragon",
+        models=["dragon.7z"],
+        metadata={"metadata": {"catalog-id": "wrong"}},
+    )
+    alexandria = FakeAlexandria()
+    alexandria.fields = [
+        {
+            "slug": "catalog-id",
+            "type": "text",
+            "config": {"validationPattern": "^MODEL-[0-9]+$"},
+        },
+    ]
+    alexandria.metadata_validation_error = "Value does not match the required format"
+
+    outcomes = await FolderUploader(
+        alexandria=alexandria,
+        work_root=tmp_path / "work",
+    ).run(tmp_path)
+
+    assert outcomes == {"failed": 1}
+    assert alexandria.uploads == []
+    failed = tmp_path / "failed" / "002501-dragon" / "metadata.json"
+    assert "required format" in json.loads(failed.read_text())["result"]["error"]
 
 
 async def test_should_delete_a_committed_folder_when_requested(tmp_path) -> None:


### PR DESCRIPTION
## What changed

- normalize staged generic metadata according to Alexandria's configured field types
- validate the complete normalized metadata map through Alexandria before creating an archive or upload session
- reuse one in-flight metadata-field request across concurrent Codex upload workers
- document the preflight validation endpoint and importer behavior

## Why

An existing completed reference bundle represented the text field `month-9g9z` as the JSON number `6`. That value reached the import-session commit endpoint and failed late with `400: Value must be a string` after the upload had already occurred.

This follow-up commit was pushed after PR #107 had already merged, so it is being submitted separately from an up-to-date `main` branch.

## Impact

Staged metadata is normalized from live Alexandria field definitions (`6` becomes `"6"` for a text field) and checked by the backend's canonical validator before model bytes are packaged or uploaded. Invalid metadata leaves the local bundle intact and fails early instead of surfacing as a commit-time type error.

## Validation

- importer test suite — 263 passed
- backend test suite — 1,027 passed
- shared and backend builds — passed
- repository lint — passed
- targeted Ruff checks — passed
- Python bytecode compilation — passed
- importer CLI help smoke test — passed
- `git diff --check` — passed
- targeted concurrency, data-loss, and crash-recovery review — passed
- live read-only verification against the configured Alexandria metadata definitions — passed
