### PR TITLE
fix: allow optional cleanup metadata fields

### DIFF
--- a/tools/telegram-importer/README.md
+++ b/tools/telegram-importer/README.md
@@ -136,7 +136,9 @@ controls how many Codex cleanup processes run at once.
 `metadata.json`. Use a completed model folder from this staged workflow. Codex
 treats its metadata keys, key order, folder casing, and tag vocabulary as the
 target shape. The importer independently enforces the reference's exact
-top-level and nested `metadata` key sets before upload. The repository-owned
+top-level key set and rejects nested `metadata` keys that are absent from the
+reference; nested reference fields may be omitted when they do not apply. The
+repository-owned
 `$prepare-telegram-staging` skill performs the variable work: recursive archive
 inspection, character splitting, image classification, metadata research, LZMA2
 repacking, and archive verification. Override its path with `--cleanup-skill`
@@ -152,7 +154,8 @@ Codex returns one of three states per input bundle:
 
 Before upload, the importer verifies that reported paths stay inside the assigned
 bundle, every actual model folder was reported, the folder contains no symlinks,
-and metadata has the reference key sets, a non-empty model name, and a null
+and metadata has the reference's top-level keys and no unknown nested fields,
+a non-empty model name, and a null
 result. It also requires the original Telegram channel and bundle IDs, permits
 only original message IDs, and checks that the outputs collectively cover every
 original model message. Finally, `images/` must be flat and `models/` must contain

--- a/tools/telegram-importer/src/alexandria_telegram_importer/codex_cleanup.py
+++ b/tools/telegram-importer/src/alexandria_telegram_importer/codex_cleanup.py
@@ -467,9 +467,10 @@ def _model_folder_errors(
     reference_nested = reference_metadata.get("metadata")
     if not isinstance(nested, dict) or not isinstance(reference_nested, dict):
         errors.append(f"{metadata_path}: metadata must be an object")
-    elif set(nested) != set(reference_nested):
+    elif extra_keys := set(nested) - set(reference_nested):
         errors.append(
-            f"{metadata_path}: nested metadata keys do not match the reference"
+            f"{metadata_path}: nested metadata contains fields not in the reference: "
+            + ", ".join(sorted(extra_keys))
         )
     if (
         not isinstance(payload.get("modelName"), str)

--- a/tools/telegram-importer/tests/test_codex_cleanup.py
+++ b/tools/telegram-importer/tests/test_codex_cleanup.py
@@ -131,6 +131,49 @@ def test_should_validate_one_ready_model_folder(tmp_path) -> None:
     assert [folder.path for folder in validation.folders] == [model]
 
 
+def test_should_allow_nested_metadata_fields_missing_from_the_reference(tmp_path) -> None:
+    staging = tmp_path / "staging"
+    model = staging / "002501-dragon"
+    original = metadata()
+    cleaned = metadata()
+    del cleaned["metadata"]["year"]
+    make_ready_folder(model, cleaned)
+    reference = tmp_path / "reference"
+    reference.mkdir()
+    (reference / "metadata.json").write_text(json.dumps(original), encoding="utf-8")
+
+    validation = validate_cleanup_receipt(
+        receipt(model, model),
+        staging_root=staging,
+        original_metadata=original,
+        reference_folder=reference,
+    )
+
+    assert validation.ready
+
+
+def test_should_reject_nested_metadata_fields_absent_from_the_reference(tmp_path) -> None:
+    staging = tmp_path / "staging"
+    model = staging / "002501-dragon"
+    original = metadata()
+    cleaned = metadata()
+    cleaned["metadata"]["unconfigured"] = "value"
+    make_ready_folder(model, cleaned)
+    reference = tmp_path / "reference"
+    reference.mkdir()
+    (reference / "metadata.json").write_text(json.dumps(original), encoding="utf-8")
+
+    validation = validate_cleanup_receipt(
+        receipt(model, model),
+        staging_root=staging,
+        original_metadata=original,
+        reference_folder=reference,
+    )
+
+    assert not validation.ready
+    assert any("unconfigured" in error for error in validation.errors)
+
+
 def test_should_reject_unreported_split_outputs(tmp_path) -> None:
     staging = tmp_path / "staging"
     bundle = staging / "002501-dragons"


### PR DESCRIPTION
## Summary
- allow cleaned folders to omit nested metadata fields from the reference
- retain rejection of unknown nested fields and all existing top-level/provenance checks
- cover both optional and unknown nested-field behavior

## Validation
- uv run --extra test pytest tests/test_codex_cleanup.py