### PR TITLE
feat: add Telegram cleanup model selection

### DIFF
--- a/tools/telegram-importer/README.md
+++ b/tools/telegram-importer/README.md
@@ -59,8 +59,9 @@ For automated staged cleanup, `TELEGRAM_STAGE_CLEANUP=codex` selects Codex,
 `TELEGRAM_CODEX_CLEANUP_CONCURRENCY` controls simultaneous Codex processes,
 and `TELEGRAM_CODEX_CLEANUP_TIMEOUT` limits each folder cleanup in seconds.
 `TELEGRAM_CODEX_CLEANUP_SKILL` overrides the repository-owned cleanup skill,
-and `TELEGRAM_CODEX_COMMAND` selects the executable. The matching command-line
-flags override these values.
+`TELEGRAM_CODEX_COMMAND` selects the executable, and `TELEGRAM_CODEX_MODEL`
+selects the cleanup model. The matching command-line flags override these
+values; omit `--codex-model` to use the Codex CLI default.
 
 By default, the reusable Telegram login session and SQLite import state live under `$XDG_DATA_HOME/alexandria-telegram-importer`, or `~/.local/share/alexandria-telegram-importer` when `XDG_DATA_HOME` is unset. Override them with `TELEGRAM_SESSION_PATH` and `TELEGRAM_IMPORT_STATE_PATH`, or with the `--session` and `--state` command-line options.
 
@@ -116,6 +117,7 @@ uv run alexandria-telegram-import \
   --stage 20 \
   --cleanup codex \
   --cleanup-reference ./completed-reference-model \
+  --codex-model gpt-5.4 \
   --staging-dir ./work
 ```
 

--- a/tools/telegram-importer/src/alexandria_telegram_importer/cli.py
+++ b/tools/telegram-importer/src/alexandria_telegram_importer/cli.py
@@ -238,6 +238,11 @@ def parser() -> argparse.ArgumentParser:
         default=os.getenv("TELEGRAM_CODEX_COMMAND", "codex"),
         help="Codex executable used by --cleanup codex (default codex)",
     )
+    result.add_argument(
+        "--codex-model",
+        default=os.getenv("TELEGRAM_CODEX_MODEL") or None,
+        help="Codex model used by --cleanup codex (uses the Codex default when omitted)",
+    )
     return result
 
 
@@ -660,6 +665,7 @@ async def run_codex_staged_batches(
         skill_path=skill_path,
         reference_folder=args.cleanup_reference,
         command=args.codex_command,
+        model=args.codex_model,
         timeout_seconds=args.cleanup_timeout,
     )
     try:

--- a/tools/telegram-importer/src/alexandria_telegram_importer/codex_cleanup.py
+++ b/tools/telegram-importer/src/alexandria_telegram_importer/codex_cleanup.py
@@ -232,6 +232,7 @@ class CodexCleanupRunner:
         skill_path: Path,
         reference_folder: Path,
         command: str = "codex",
+        model: str | None = None,
         timeout_seconds: int = DEFAULT_CLEANUP_TIMEOUT,
         environment: Mapping[str, str] | None = None,
     ) -> None:
@@ -240,6 +241,7 @@ class CodexCleanupRunner:
         self.skill_path = skill_path.resolve()
         self.reference_folder = reference_folder.resolve()
         self.command = command
+        self.model = model
         self.timeout_seconds = timeout_seconds
         self.environment = sanitized_codex_environment(environment)
 
@@ -283,7 +285,7 @@ class CodexCleanupRunner:
         receipt_path.unlink(missing_ok=True)
 
         prompt = self._prompt(input_folder)
-        command = (
+        command = [
             self.command,
             "exec",
             "--ephemeral",
@@ -298,8 +300,10 @@ class CodexCleanupRunner:
             str(schema_path),
             "--output-last-message",
             str(receipt_path),
-            prompt,
-        )
+        ]
+        if self.model:
+            command.extend(("--model", self.model))
+        command.append(prompt)
         log.info("Handing staged bundle %s to Codex", input_folder.name)
         try:
             process = await asyncio.create_subprocess_exec(

--- a/tools/telegram-importer/tests/test_cli.py
+++ b/tools/telegram-importer/tests/test_cli.py
@@ -167,6 +167,8 @@ def test_should_accept_codex_cleanup_for_a_staged_import(tmp_path) -> None:
             "codex",
             "--cleanup-reference",
             str(tmp_path / "reference"),
+            "--codex-model",
+            "gpt-5.4",
             "--staging-dir",
             str(tmp_path / "staging"),
         ],
@@ -175,6 +177,7 @@ def test_should_accept_codex_cleanup_for_a_staged_import(tmp_path) -> None:
     validate_staging_args(args)
     assert args.cleanup_concurrency == 1
     assert args.cleanup_timeout == 3600
+    assert args.codex_model == "gpt-5.4"
 
 
 def test_should_treat_a_closed_stdin_as_quitting_the_pause(monkeypatch) -> None:
@@ -442,6 +445,7 @@ async def test_should_continue_with_the_next_codex_batch_after_upload(
         cleanup_skill=tmp_path / "SKILL.md",
         cleanup_reference=tmp_path / "reference",
         codex_command="codex",
+        codex_model=None,
         cleanup_timeout=60,
         cleanup_concurrency=1,
         concurrency=1,
@@ -553,6 +557,7 @@ async def test_should_refuse_a_mutated_ready_bundle_on_resume(
         cleanup_skill=tmp_path / "SKILL.md",
         cleanup_reference=reference,
         codex_command="codex",
+        codex_model=None,
         cleanup_timeout=60,
         cleanup_concurrency=1,
         concurrency=1,
@@ -617,6 +622,7 @@ async def test_should_require_review_for_an_indeterminate_upload(
         cleanup_skill=tmp_path / "SKILL.md",
         cleanup_reference=tmp_path / "reference",
         codex_command="codex",
+        codex_model=None,
         cleanup_timeout=60,
         cleanup_concurrency=1,
         concurrency=1,
@@ -790,6 +796,7 @@ async def test_should_finish_pending_local_deletion_after_restart(
             cleanup_skill=tmp_path / "SKILL.md",
             cleanup_reference=tmp_path / "reference",
             codex_command="codex",
+            codex_model=None,
             cleanup_timeout=60,
             cleanup_concurrency=1,
             concurrency=1,
@@ -865,6 +872,7 @@ async def test_should_retain_uncommitted_split_outputs_after_restart(
             cleanup_skill=tmp_path / "SKILL.md",
             cleanup_reference=tmp_path / "reference",
             codex_command="codex",
+            codex_model=None,
             cleanup_timeout=60,
             cleanup_concurrency=1,
             concurrency=1,

--- a/tools/telegram-importer/tests/test_codex_cleanup.py
+++ b/tools/telegram-importer/tests/test_codex_cleanup.py
@@ -319,6 +319,7 @@ async def test_should_run_codex_with_a_schema_and_sanitized_environment(
         skill_path=skill,
         reference_folder=reference,
         command="python3",
+        model="gpt-5.4",
         environment={
             "PATH": "/usr/bin:/bin",
             "CODEX_HOME": "/codex",
@@ -335,6 +336,7 @@ async def test_should_run_codex_with_a_schema_and_sanitized_environment(
 
     assert result.status == "needs_review"
     assert "--ephemeral" in captured["command"]
+    assert captured["command"][captured["command"].index("--model") + 1] == "gpt-5.4"
     assert "--output-schema" in captured["command"]
     assert captured["environment"] == {
         "PATH": "/usr/bin:/bin",


### PR DESCRIPTION
## Summary
- add `--codex-model` and `TELEGRAM_CODEX_MODEL` for automated Telegram cleanup
- pass the selected model to `codex exec --model`
- document and test model selection

## Validation
- `uv run --project tools/telegram-importer --extra test pytest tools/telegram-importer/tests/test_cli.py tools/telegram-importer/tests/test_codex_cleanup.py`