### PR TITLE
feat: add Telegram cleanup reasoning effort

### DIFF
--- a/tools/telegram-importer/README.md
+++ b/tools/telegram-importer/README.md
@@ -60,8 +60,9 @@ For automated staged cleanup, `TELEGRAM_STAGE_CLEANUP=codex` selects Codex,
 and `TELEGRAM_CODEX_CLEANUP_TIMEOUT` limits each folder cleanup in seconds.
 `TELEGRAM_CODEX_CLEANUP_SKILL` overrides the repository-owned cleanup skill,
 `TELEGRAM_CODEX_COMMAND` selects the executable, and `TELEGRAM_CODEX_MODEL`
-selects the cleanup model. The matching command-line flags override these
-values; omit `--codex-model` to use the Codex CLI default.
+selects the cleanup model. `TELEGRAM_CODEX_REASONING_EFFORT` selects its
+reasoning effort, such as `high`. The matching command-line flags override
+these values; omit either option to use the Codex CLI default.
 
 By default, the reusable Telegram login session and SQLite import state live under `$XDG_DATA_HOME/alexandria-telegram-importer`, or `~/.local/share/alexandria-telegram-importer` when `XDG_DATA_HOME` is unset. Override them with `TELEGRAM_SESSION_PATH` and `TELEGRAM_IMPORT_STATE_PATH`, or with the `--session` and `--state` command-line options.
 
@@ -118,6 +119,7 @@ uv run alexandria-telegram-import \
   --cleanup codex \
   --cleanup-reference ./completed-reference-model \
   --codex-model gpt-5.4 \
+  --codex-reasoning-effort high \
   --staging-dir ./work
 ```
 

--- a/tools/telegram-importer/src/alexandria_telegram_importer/cli.py
+++ b/tools/telegram-importer/src/alexandria_telegram_importer/cli.py
@@ -243,6 +243,12 @@ def parser() -> argparse.ArgumentParser:
         default=os.getenv("TELEGRAM_CODEX_MODEL") or None,
         help="Codex model used by --cleanup codex (uses the Codex default when omitted)",
     )
+    result.add_argument(
+        "--codex-reasoning-effort",
+        default=os.getenv("TELEGRAM_CODEX_REASONING_EFFORT") or None,
+        metavar="EFFORT",
+        help="Codex reasoning effort used by --cleanup codex (for example high)",
+    )
     return result
 
 
@@ -666,6 +672,7 @@ async def run_codex_staged_batches(
         reference_folder=args.cleanup_reference,
         command=args.codex_command,
         model=args.codex_model,
+        reasoning_effort=args.codex_reasoning_effort,
         timeout_seconds=args.cleanup_timeout,
     )
     try:

--- a/tools/telegram-importer/src/alexandria_telegram_importer/codex_cleanup.py
+++ b/tools/telegram-importer/src/alexandria_telegram_importer/codex_cleanup.py
@@ -233,6 +233,7 @@ class CodexCleanupRunner:
         reference_folder: Path,
         command: str = "codex",
         model: str | None = None,
+        reasoning_effort: str | None = None,
         timeout_seconds: int = DEFAULT_CLEANUP_TIMEOUT,
         environment: Mapping[str, str] | None = None,
     ) -> None:
@@ -242,6 +243,7 @@ class CodexCleanupRunner:
         self.reference_folder = reference_folder.resolve()
         self.command = command
         self.model = model
+        self.reasoning_effort = reasoning_effort
         self.timeout_seconds = timeout_seconds
         self.environment = sanitized_codex_environment(environment)
 
@@ -303,6 +305,10 @@ class CodexCleanupRunner:
         ]
         if self.model:
             command.extend(("--model", self.model))
+        if self.reasoning_effort:
+            command.extend(
+                ("--config", f'model_reasoning_effort="{self.reasoning_effort}"')
+            )
         command.append(prompt)
         log.info("Handing staged bundle %s to Codex", input_folder.name)
         try:

--- a/tools/telegram-importer/tests/test_cli.py
+++ b/tools/telegram-importer/tests/test_cli.py
@@ -169,6 +169,8 @@ def test_should_accept_codex_cleanup_for_a_staged_import(tmp_path) -> None:
             str(tmp_path / "reference"),
             "--codex-model",
             "gpt-5.4",
+            "--codex-reasoning-effort",
+            "high",
             "--staging-dir",
             str(tmp_path / "staging"),
         ],
@@ -178,6 +180,7 @@ def test_should_accept_codex_cleanup_for_a_staged_import(tmp_path) -> None:
     assert args.cleanup_concurrency == 1
     assert args.cleanup_timeout == 3600
     assert args.codex_model == "gpt-5.4"
+    assert args.codex_reasoning_effort == "high"
 
 
 def test_should_treat_a_closed_stdin_as_quitting_the_pause(monkeypatch) -> None:
@@ -446,6 +449,7 @@ async def test_should_continue_with_the_next_codex_batch_after_upload(
         cleanup_reference=tmp_path / "reference",
         codex_command="codex",
         codex_model=None,
+        codex_reasoning_effort=None,
         cleanup_timeout=60,
         cleanup_concurrency=1,
         concurrency=1,
@@ -558,6 +562,7 @@ async def test_should_refuse_a_mutated_ready_bundle_on_resume(
         cleanup_reference=reference,
         codex_command="codex",
         codex_model=None,
+        codex_reasoning_effort=None,
         cleanup_timeout=60,
         cleanup_concurrency=1,
         concurrency=1,
@@ -623,6 +628,7 @@ async def test_should_require_review_for_an_indeterminate_upload(
         cleanup_reference=tmp_path / "reference",
         codex_command="codex",
         codex_model=None,
+        codex_reasoning_effort=None,
         cleanup_timeout=60,
         cleanup_concurrency=1,
         concurrency=1,
@@ -797,6 +803,7 @@ async def test_should_finish_pending_local_deletion_after_restart(
             cleanup_reference=tmp_path / "reference",
             codex_command="codex",
             codex_model=None,
+            codex_reasoning_effort=None,
             cleanup_timeout=60,
             cleanup_concurrency=1,
             concurrency=1,
@@ -873,6 +880,7 @@ async def test_should_retain_uncommitted_split_outputs_after_restart(
             cleanup_reference=tmp_path / "reference",
             codex_command="codex",
             codex_model=None,
+            codex_reasoning_effort=None,
             cleanup_timeout=60,
             cleanup_concurrency=1,
             concurrency=1,

--- a/tools/telegram-importer/tests/test_codex_cleanup.py
+++ b/tools/telegram-importer/tests/test_codex_cleanup.py
@@ -320,6 +320,7 @@ async def test_should_run_codex_with_a_schema_and_sanitized_environment(
         reference_folder=reference,
         command="python3",
         model="gpt-5.4",
+        reasoning_effort="high",
         environment={
             "PATH": "/usr/bin:/bin",
             "CODEX_HOME": "/codex",
@@ -337,6 +338,9 @@ async def test_should_run_codex_with_a_schema_and_sanitized_environment(
     assert result.status == "needs_review"
     assert "--ephemeral" in captured["command"]
     assert captured["command"][captured["command"].index("--model") + 1] == "gpt-5.4"
+    assert captured["command"][captured["command"].index("--config") + 1] == (
+        'model_reasoning_effort="high"'
+    )
     assert "--output-schema" in captured["command"]
     assert captured["environment"] == {
         "PATH": "/usr/bin:/bin",


### PR DESCRIPTION
## Summary
- add `--codex-reasoning-effort` and `TELEGRAM_CODEX_REASONING_EFFORT`
- pass the selected effort to Codex via `model_reasoning_effort`
- document and test the model/effort invocation

## Validation
- `uv run --project tools/telegram-importer --extra test pytest tools/telegram-importer/tests/test_cli.py tools/telegram-importer/tests/test_codex_cleanup.py`