### PR TITLE
feat: add archive entry downloads

### DIFF
--- a/apps/backend/src/routes/models.archive-browser.test.ts
+++ b/apps/backend/src/routes/models.archive-browser.test.ts
@@ -1,0 +1,127 @@
+import { Readable } from 'node:stream';
+import Fastify, { type FastifyInstance } from 'fastify';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { errorHandler } from '../middleware/error-handler.js';
+import { notFound } from '../utils/errors.js';
+
+const mocks = vi.hoisted(() => ({
+  requireAuth: vi.fn(async (request: { user?: unknown }) => {
+    request.user = { id: 'user-1' };
+  }),
+  requireLibrary: vi.fn(async (request: { libraryId?: string }) => {
+    request.libraryId = 'library-1';
+  }),
+  list: vi.fn(),
+  download: vi.fn(),
+}));
+
+vi.mock('../middleware/auth.js', () => ({ requireAuth: mocks.requireAuth }));
+vi.mock('../middleware/library.js', () => ({ requireLibrary: mocks.requireLibrary }));
+vi.mock('../services/archive-browser.service.js', () => ({
+  archiveBrowserService: { list: mocks.list, download: mocks.download },
+}));
+
+import { modelRoutes } from './models.js';
+
+describe('model archive browser routes', () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    app = Fastify();
+    app.decorateRequest('user', null);
+    app.decorateRequest('libraryId', null);
+    app.setErrorHandler(errorHandler);
+    await app.register(modelRoutes, { prefix: '/models' });
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('returns a safe archive manifest in the active library scope', async () => {
+    mocks.list.mockResolvedValue({
+      entries: [{ path: 'parts/body.stl', sizeBytes: 123, isDirectory: false }],
+    });
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/models/model-1/files/file-1/archive',
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      data: { entries: [{ path: 'parts/body.stl', sizeBytes: 123, isDirectory: false }] },
+      meta: null,
+      errors: null,
+    });
+    expect(mocks.list).toHaveBeenCalledWith('model-1', 'file-1', 'library-1');
+  });
+
+  it('streams an exact archive entry as an attachment', async () => {
+    mocks.download.mockResolvedValue({
+      filename: 'body.stl',
+      sizeBytes: 4,
+      stream: Readable.from([Buffer.from('mesh')]),
+    });
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/models/model-1/files/file-1/archive/download?path=parts%2Fbody.stl',
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toBe('mesh');
+    expect(response.headers['content-disposition']).toBe(
+      `attachment; filename="body.stl"; filename*=UTF-8''${encodeURIComponent('body.stl')}`,
+    );
+    expect(mocks.download).toHaveBeenCalledWith(
+      'model-1',
+      'file-1',
+      'library-1',
+      'parts/body.stl',
+    );
+  });
+
+  it('uses an ASCII fallback and UTF-8 filename parameter for Unicode entry names', async () => {
+    mocks.download.mockResolvedValue({
+      filename: '日本.stl',
+      sizeBytes: 4,
+      stream: Readable.from([Buffer.from('mesh')]),
+    });
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/models/model-1/files/file-1/archive/download?path=%E6%97%A5%E6%9C%AC.stl',
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.headers['content-disposition']).toBe(
+      `attachment; filename="__.stl"; filename*=UTF-8''${encodeURIComponent('日本.stl')}`,
+    );
+  });
+
+  it('rejects an invalid requested entry path before delegating', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/models/model-1/files/file-1/archive/download',
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json()).toMatchObject({ errors: [{ code: 'VALIDATION_ERROR' }] });
+    expect(mocks.download).not.toHaveBeenCalled();
+  });
+
+  it('conceals archives outside the active library', async () => {
+    mocks.list.mockRejectedValue(notFound('Model not found: model-1'));
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/models/model-1/files/file-1/archive',
+    });
+
+    expect(response.statusCode).toBe(404);
+    expect(response.json()).toMatchObject({ errors: [{ code: 'NOT_FOUND' }] });
+  });
+});

--- a/apps/backend/src/routes/models.ts
+++ b/apps/backend/src/routes/models.ts
@@ -41,6 +41,7 @@ import {
   commitImportSessionSchema,
   extractImportSessionArchiveSchema,
   importSessionIdParamsSchema,
+  archiveEntryQuerySchema,
 } from '@alexandria/shared';
 import { requireAuth } from '../middleware/auth.js';
 import { requireLibrary } from '../middleware/library.js';
@@ -55,7 +56,19 @@ import { storageService } from '../services/storage.service.js';
 import { uploadService } from '../services/upload.service.js';
 import { createModelArchive } from '../services/model-download.service.js';
 import { modelFolderArchiveService } from '../services/model-folder-archive.service.js';
+import { archiveBrowserService } from '../services/archive-browser.service.js';
 import { notFound, validationError } from '../utils/errors.js';
+
+function archiveEntryContentDisposition(filename: string): string {
+  const fallback = filename
+    .normalize('NFKD')
+    .replace(/[^\x20-\x7e]/g, '_')
+    .replace(/["\\\r\n]/g, '_');
+  const utf8Filename = encodeURIComponent(filename).replace(/[!'()*]/g, (character) => (
+    `%${character.charCodeAt(0).toString(16).toUpperCase()}`
+  ));
+  return `attachment; filename="${fallback || 'download'}"; filename*=UTF-8''${utf8Filename}`;
+}
 
 export async function modelRoutes(app: FastifyInstance): Promise<void> {
   // GET / — browse/search models with filters, sorting, pagination
@@ -582,6 +595,43 @@ export async function modelRoutes(app: FastifyInstance): Promise<void> {
       const tree = presenterService.buildFileTree(files, folders);
 
       return reply.status(200).send({ data: tree, meta: null, errors: null });
+    },
+  );
+
+  // GET /:id/files/:fileId/archive — list safe entries in a stored archive
+  app.get(
+    '/:id/files/:fileId/archive',
+    { preHandler: [requireAuth, requireLibrary] },
+    async (request, reply) => {
+      const { id, fileId } = request.params as { id: string; fileId: string };
+      const contents = await archiveBrowserService.list(id, fileId, request.libraryId!);
+      return reply.status(200).send({ data: contents, meta: null, errors: null });
+    },
+  );
+
+  // GET /:id/files/:fileId/archive/download?path=... — download one listed archive entry
+  app.get(
+    '/:id/files/:fileId/archive/download',
+    { preHandler: [requireAuth, requireLibrary] },
+    async (request, reply) => {
+      const parsed = archiveEntryQuerySchema.safeParse(request.query);
+      if (!parsed.success) {
+        const issue = parsed.error.issues[0];
+        throw validationError(issue?.message ?? 'Validation failed', issue?.path.join('.') ?? 'path');
+      }
+      const { id, fileId } = request.params as { id: string; fileId: string };
+      const entry = await archiveBrowserService.download(
+        id,
+        fileId,
+        request.libraryId!,
+        parsed.data.path,
+      );
+      return reply
+        .header('Content-Type', 'application/octet-stream')
+        .header('Content-Length', entry.sizeBytes)
+        .header('Content-Disposition', archiveEntryContentDisposition(entry.filename))
+        .header('Cache-Control', 'private, no-store')
+        .send(entry.stream);
     },
   );
 

--- a/apps/backend/src/services/archive-browser.service.test.ts
+++ b/apps/backend/src/services/archive-browser.service.test.ts
@@ -1,0 +1,100 @@
+import fs from 'node:fs/promises';
+import { Readable } from 'node:stream';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { ModelFile } from '../db/schema/model-file.js';
+import { AppError } from '../utils/errors.js';
+import { ArchiveBrowserService } from './archive-browser.service.js';
+
+const createdDirectories: string[] = [];
+
+function fileRow(overrides: Partial<ModelFile> = {}): ModelFile {
+  return {
+    id: 'file-id',
+    modelId: 'model-id',
+    filename: 'parts.7z',
+    relativePath: 'parts.7z',
+    fileType: 'other',
+    mimeType: 'application/x-7z-compressed',
+    sizeBytes: 1,
+    storagePath: 'models/model-id/parts.7z',
+    hash: 'a'.repeat(64),
+    isDuplicate: false,
+    createdAt: new Date(),
+    ...overrides,
+  };
+}
+
+function createService(files: ModelFile[] = [fileRow()]) {
+  const models = {
+    requireModelInLibrary: vi.fn().mockResolvedValue({ id: 'model-id' }),
+    getModelFiles: vi.fn().mockResolvedValue(files),
+  };
+  const storage = {
+    retrieveStream: vi.fn().mockResolvedValue(Readable.from([Buffer.from('archive')])),
+  };
+  const processing = {
+    processArchive: vi.fn(async (_archivePath: string, extractDir: string) => {
+      createdDirectories.push(extractDir);
+      await fs.mkdir(extractDir, { recursive: true });
+      await fs.mkdir(`${extractDir}/nested`, { recursive: true });
+      await fs.writeFile(`${extractDir}/nested/part.stl`, 'mesh');
+      return {
+        entries: [{ relativePath: 'nested/part.stl', sizeBytes: 4 }],
+        totalSizeBytes: 4,
+      };
+    }),
+  };
+  return {
+    service: new ArchiveBrowserService(models as never, storage as never, processing as never),
+    models,
+  };
+}
+
+afterEach(async () => {
+  await Promise.all(createdDirectories.splice(0).map((directory) => fs.rm(directory, {
+    recursive: true,
+    force: true,
+  })));
+});
+
+describe('ArchiveBrowserService', () => {
+  it('returns files and inferred directories for an owned archive', async () => {
+    const { service, models } = createService();
+
+    await expect(service.list('model-id', 'file-id', 'library-id')).resolves.toEqual({
+      entries: [
+        { path: 'nested', sizeBytes: 0, isDirectory: true },
+        { path: 'nested/part.stl', sizeBytes: 4, isDirectory: false },
+      ],
+    });
+    expect(models.requireModelInLibrary).toHaveBeenCalledWith('model-id', 'library-id');
+  });
+
+  it('rejects a requested path that is not in the freshly extracted manifest', async () => {
+    const { service } = createService();
+
+    await expect(service.download('model-id', 'file-id', 'library-id', 'nested/missing.stl'))
+      .rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+
+  it('rejects traversal before looking up an archive entry', async () => {
+    const { service } = createService();
+
+    await expect(service.download('model-id', 'file-id', 'library-id', '../secret.stl'))
+      .rejects.toBeInstanceOf(AppError);
+  });
+
+  it('streams one freshly validated entry', async () => {
+    const { service } = createService();
+    const entry = await service.download('model-id', 'file-id', 'library-id', 'nested/part.stl');
+
+    await expect(read(entry.stream)).resolves.toEqual('mesh');
+    expect(entry).toMatchObject({ filename: 'part.stl', sizeBytes: 4 });
+  });
+});
+
+async function read(stream: Readable): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream) chunks.push(Buffer.from(chunk));
+  return Buffer.concat(chunks).toString();
+}

--- a/apps/backend/src/services/archive-browser.service.ts
+++ b/apps/backend/src/services/archive-browser.service.ts
@@ -1,0 +1,150 @@
+import fs from 'node:fs';
+import fsPromises from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { pipeline } from 'node:stream/promises';
+import type { Readable } from 'node:stream';
+import type { ArchiveContents, ArchiveEntry } from '@alexandria/shared';
+import { detectArchiveExtension } from '../utils/archive.js';
+import { notFound, validationError } from '../utils/errors.js';
+import { createLogger } from '../utils/logger.js';
+import { FileProcessingService, fileProcessingService } from './file-processing.service.js';
+import { ModelService, modelService } from './model.service.js';
+import { type IStorageService, storageService } from './storage.service.js';
+
+const logger = createLogger('ArchiveBrowserService');
+
+export interface ArchiveEntryDownload {
+  filename: string;
+  sizeBytes: number;
+  stream: Readable;
+}
+
+/**
+ * Reads stored archives without persisting their contents. FileProcessingService
+ * remains authoritative for safe archive extraction; this service only composes
+ * model authorization, managed storage, and temporary lifecycle cleanup.
+ */
+export class ArchiveBrowserService {
+  constructor(
+    private readonly models: ModelService = modelService,
+    private readonly storage: IStorageService = storageService,
+    private readonly fileProcessing: FileProcessingService = fileProcessingService,
+  ) {}
+
+  async list(modelId: string, fileId: string, libraryId: string): Promise<ArchiveContents> {
+    const prepared = await this.prepare(modelId, fileId, libraryId);
+    try {
+      return { entries: this.buildEntries(prepared.manifest.entries) };
+    } finally {
+      await this.cleanup(prepared.tempDir);
+    }
+  }
+
+  async download(
+    modelId: string,
+    fileId: string,
+    libraryId: string,
+    requestedPath: string,
+  ): Promise<ArchiveEntryDownload> {
+    const normalizedPath = this.normalizeEntryPath(requestedPath);
+    const prepared = await this.prepare(modelId, fileId, libraryId);
+    const entry = prepared.manifest.entries.find(
+      (candidate) => this.toArchivePath(candidate.relativePath) === normalizedPath,
+    );
+    if (!entry) {
+      await this.cleanup(prepared.tempDir);
+      throw notFound(`Archive entry not found: ${normalizedPath}`);
+    }
+
+    const sourcePath = path.resolve(prepared.extractDir, ...normalizedPath.split('/'));
+    if (!sourcePath.startsWith(`${prepared.extractDir}${path.sep}`)) {
+      await this.cleanup(prepared.tempDir);
+      throw validationError('Archive entry path is unsafe', 'path');
+    }
+
+    const stream = fs.createReadStream(sourcePath);
+    let cleaned = false;
+    const cleanup = (): void => {
+      if (cleaned) return;
+      cleaned = true;
+      void this.cleanup(prepared.tempDir);
+    };
+    stream.once('close', cleanup);
+    stream.once('error', cleanup);
+
+    return {
+      filename: path.posix.basename(normalizedPath),
+      sizeBytes: entry.sizeBytes,
+      stream,
+    };
+  }
+
+  private async prepare(modelId: string, fileId: string, libraryId: string): Promise<{
+    tempDir: string;
+    extractDir: string;
+    manifest: Awaited<ReturnType<FileProcessingService['processArchive']>>;
+  }> {
+    await this.models.requireModelInLibrary(modelId, libraryId);
+    const file = (await this.models.getModelFiles(modelId)).find((candidate) => candidate.id === fileId);
+    if (!file) throw notFound(`Model file not found: ${fileId}`);
+    const archiveFilename = path.basename(file.filename.replaceAll('\\', '/'));
+    if (!detectArchiveExtension(archiveFilename)) {
+      throw validationError('Model file is not a supported archive');
+    }
+
+    const tempDir = await fsPromises.mkdtemp(path.join(os.tmpdir(), 'alexandria-archive-'));
+    const archivePath = path.join(tempDir, archiveFilename);
+    const extractDir = path.join(tempDir, 'contents');
+    try {
+      await pipeline(await this.storage.retrieveStream(file.storagePath), fs.createWriteStream(archivePath));
+      const manifest = await this.fileProcessing.processArchive(archivePath, extractDir);
+      return { tempDir, extractDir: path.resolve(extractDir), manifest };
+    } catch (error) {
+      await this.cleanup(tempDir);
+      throw error;
+    }
+  }
+
+  private buildEntries(files: Array<{ relativePath: string; sizeBytes: number }>): ArchiveEntry[] {
+    const entries = new Map<string, ArchiveEntry>();
+    for (const file of files) {
+      const filePath = this.toArchivePath(file.relativePath);
+      entries.set(filePath, { path: filePath, sizeBytes: file.sizeBytes, isDirectory: false });
+      const parts = filePath.split('/');
+      for (let index = 1; index < parts.length; index += 1) {
+        const directoryPath = parts.slice(0, index).join('/');
+        entries.set(directoryPath, { path: directoryPath, sizeBytes: 0, isDirectory: true });
+      }
+    }
+    return [...entries.values()].sort((a, b) => (
+      a.path.localeCompare(b.path, undefined, { sensitivity: 'base' }) || Number(b.isDirectory) - Number(a.isDirectory)
+    ));
+  }
+
+  private normalizeEntryPath(input: string): string {
+    const normalized = input.replaceAll('\\', '/').trim();
+    const segments = normalized.split('/');
+    if (
+      !normalized
+      || normalized.startsWith('/')
+      || /^[a-z]:\//i.test(normalized)
+      || segments.some((segment) => !segment || segment === '.' || segment === '..' || /[\0-\x1f]/.test(segment))
+    ) {
+      throw validationError('Archive entry path is invalid', 'path');
+    }
+    return normalized;
+  }
+
+  private toArchivePath(relativePath: string): string {
+    return relativePath.replaceAll('\\', '/').split(path.sep).join('/');
+  }
+
+  private async cleanup(tempDir: string): Promise<void> {
+    await fsPromises.rm(tempDir, { recursive: true, force: true }).catch((error: unknown) => {
+      logger.warn({ tempDir, error: String(error) }, 'Failed to remove archive preview temporary directory');
+    });
+  }
+}
+
+export const archiveBrowserService = new ArchiveBrowserService();

--- a/apps/frontend/src/api/client.test.ts
+++ b/apps/frontend/src/api/client.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { postForLibrary, putRaw, setActiveLibraryId } from './client';
+import { getBlob, postForLibrary, putRaw, setActiveLibraryId } from './client';
 
 describe('upload API client cancellation', () => {
   afterEach(() => {
@@ -32,5 +32,20 @@ describe('upload API client cancellation', () => {
     const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
     expect(init.headers).toEqual(expect.objectContaining({ 'X-Library-Id': 'library-a' }));
     expect(init.signal).toBeUndefined();
+  });
+
+  it('sends the active library header when downloading a binary response', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      blob: async () => new Blob(['mesh']),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    setActiveLibraryId('library-b');
+
+    await getBlob('/models/model-1/files/file-1/archive/download?path=body.stl');
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(init.headers).toEqual(expect.objectContaining({ 'X-Library-Id': 'library-b' }));
+    expect(init.credentials).toBe('include');
   });
 });

--- a/apps/frontend/src/api/client.ts
+++ b/apps/frontend/src/api/client.ts
@@ -70,8 +70,39 @@ async function request<T>(
   return body;
 }
 
-export async function get<T>(path: string): Promise<ApiResponse<T>> {
-  return request<T>(path, { method: 'GET' });
+export async function get<T>(path: string, signal?: AbortSignal): Promise<ApiResponse<T>> {
+  return request<T>(path, { method: 'GET', signal });
+}
+
+/** Fetch a binary response while preserving the active library scope. */
+export async function getBlob(path: string, signal?: AbortSignal): Promise<Blob> {
+  const headers: Record<string, string> = {};
+  if (activeLibraryId) headers[LIBRARY_HEADER] = activeLibraryId;
+
+  const response = await fetch(`${BASE_URL}${path}`, {
+    method: 'GET',
+    credentials: 'include',
+    headers,
+    signal,
+  });
+
+  if (!response.ok) {
+    let body: ApiResponse<unknown> | null = null;
+    try {
+      body = await response.json() as ApiResponse<unknown>;
+    } catch {
+      // Keep the generic status error when a proxy did not return the API envelope.
+    }
+    const firstError = body?.errors?.[0];
+    throw new ApiRequestError(
+      response.status,
+      firstError?.code ?? 'UNKNOWN_ERROR',
+      firstError?.message ?? `Request failed with status ${response.status}`,
+      firstError?.field ?? null,
+    );
+  }
+
+  return response.blob();
 }
 
 export async function post<T>(

--- a/apps/frontend/src/api/models.ts
+++ b/apps/frontend/src/api/models.ts
@@ -20,8 +20,9 @@ import type {
   SplitModelFolderRequest,
   SplitModelFolderResponse,
   CompressFolderResponse,
+  ArchiveContents,
 } from '@alexandria/shared';
-import { get, post, postForLibrary, patch, del, putRaw, postForm } from './client';
+import { get, getBlob, post, postForLibrary, patch, del, putRaw, postForm } from './client';
 import { buildQueryString } from '../lib/query';
 
 export async function getModels(params: ModelSearchParams): Promise<ApiResponse<ModelCard[]>> {
@@ -101,6 +102,25 @@ export async function extractModelArchive(
 ): Promise<ExtractArchiveResponse> {
   const response = await post<ExtractArchiveResponse>(`/models/${id}/files/${fileId}/extract`);
   return response.data;
+}
+
+export async function getModelArchiveContents(
+  id: string,
+  fileId: string,
+  signal?: AbortSignal,
+): Promise<ArchiveContents> {
+  const response = await get<ArchiveContents>(`/models/${id}/files/${fileId}/archive`, signal);
+  return response.data;
+}
+
+export async function downloadModelArchiveEntry(
+  id: string,
+  fileId: string,
+  path: string,
+): Promise<Blob> {
+  return getBlob(
+    `/models/${encodeURIComponent(id)}/files/${encodeURIComponent(fileId)}/archive/download?path=${encodeURIComponent(path)}`,
+  );
 }
 
 export async function updateModelFolder(

--- a/apps/frontend/src/components/models/ArchivePreviewModal.test.tsx
+++ b/apps/frontend/src/components/models/ArchivePreviewModal.test.tsx
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { ArchivePreviewModal } from './ArchivePreviewModal';
+import { downloadModelArchiveEntry, getModelArchiveContents } from '../../api/models';
+
+vi.mock('../../api/models', () => ({
+  downloadModelArchiveEntry: vi.fn(),
+  getModelArchiveContents: vi.fn(),
+}));
+
+describe('ArchivePreviewModal', () => {
+  it('lists archive entries and provides a download for individual files', async () => {
+    vi.mocked(getModelArchiveContents).mockResolvedValue({
+      entries: [
+        { path: 'parts', sizeBytes: 0, isDirectory: true },
+        { path: 'parts/body.stl', sizeBytes: 1024, isDirectory: false },
+      ],
+    });
+
+    render(
+      <ArchivePreviewModal
+        modelId="model-1"
+        open
+        onOpenChange={vi.fn()}
+        archive={{ fileId: 'archive-1', name: 'parts.7z' }}
+      />,
+    );
+
+    expect(await screen.findByRole('list', { name: 'Archive contents' })).toBeVisible();
+    expect(screen.getByText('parts')).toBeVisible();
+    expect(screen.getByText('body.stl')).toBeVisible();
+    expect(screen.getByRole('button', { name: 'Download parts/body.stl' })).toBeVisible();
+    expect(downloadModelArchiveEntry).not.toHaveBeenCalled();
+    await waitFor(() => expect(getModelArchiveContents).toHaveBeenCalledWith(
+      'model-1',
+      'archive-1',
+      expect.any(AbortSignal),
+    ));
+  });
+});

--- a/apps/frontend/src/components/models/ArchivePreviewModal.tsx
+++ b/apps/frontend/src/components/models/ArchivePreviewModal.tsx
@@ -1,0 +1,171 @@
+import * as React from 'react';
+import { AlertTriangle, Archive, Download, File, Folder, Loader2 } from 'lucide-react';
+import type { ArchiveEntry } from '@alexandria/shared';
+import { downloadModelArchiveEntry, getModelArchiveContents } from '../../api/models';
+import { formatFileSize } from '../../lib/format';
+import { Dialog, DialogContent, DialogTitle } from '../ui/dialog';
+
+interface ArchivePreviewTarget {
+  fileId: string;
+  name: string;
+}
+
+interface ArchivePreviewModalProps {
+  modelId: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  archive: ArchivePreviewTarget | null;
+}
+
+type PreviewState =
+  | { status: 'idle'; entries: [] }
+  | { status: 'loading'; entries: [] }
+  | { status: 'loaded'; entries: ArchiveEntry[] }
+  | { status: 'error'; entries: []; message: string };
+
+function entryName(entryPath: string): string {
+  const segments = entryPath.split('/');
+  return segments[segments.length - 1] ?? entryPath;
+}
+
+export function ArchivePreviewModal({
+  modelId,
+  open,
+  onOpenChange,
+  archive,
+}: ArchivePreviewModalProps) {
+  const [state, setState] = React.useState<PreviewState>({ status: 'idle', entries: [] });
+  const [downloadingPath, setDownloadingPath] = React.useState<string | null>(null);
+  const [downloadError, setDownloadError] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    if (!open || !archive) {
+      setState({ status: 'idle', entries: [] });
+      setDownloadingPath(null);
+      setDownloadError(null);
+      return;
+    }
+
+    const controller = new AbortController();
+    setState({ status: 'loading', entries: [] });
+
+    getModelArchiveContents(modelId, archive.fileId, controller.signal)
+      .then((contents) => setState({ status: 'loaded', entries: contents.entries }))
+      .catch((error) => {
+        if (error instanceof DOMException && error.name === 'AbortError') return;
+        setState({
+          status: 'error',
+          entries: [],
+          message: error instanceof Error ? error.message : 'Archive preview failed',
+        });
+      });
+
+    return () => controller.abort();
+  }, [archive, modelId, open]);
+
+  async function downloadEntry(entryPath: string): Promise<void> {
+    if (!archive) return;
+    setDownloadingPath(entryPath);
+    setDownloadError(null);
+    try {
+      const blob = await downloadModelArchiveEntry(modelId, archive.fileId, entryPath);
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = entryName(entryPath);
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      window.setTimeout(() => URL.revokeObjectURL(url), 0);
+    } catch (error) {
+      setDownloadError(error instanceof Error ? error.message : 'Download failed');
+    } finally {
+      setDownloadingPath(null);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="flex h-[82vh] w-[92vw] max-w-3xl flex-col gap-0 overflow-hidden p-0">
+        <div className="flex min-w-0 items-center gap-2 border-b border-border px-5 py-3 pr-12">
+          <Archive className="h-4 w-4 flex-shrink-0 text-muted-foreground" />
+          <DialogTitle className="min-w-0 flex-1 truncate text-sm font-semibold text-foreground">
+            {archive?.name ?? 'Archive contents'}
+          </DialogTitle>
+          {state.status === 'loaded' && (
+            <span className="flex-shrink-0 text-xs text-muted-foreground">
+              {state.entries.filter((entry) => !entry.isDirectory).length} files
+            </span>
+          )}
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-auto bg-background">
+          {downloadError && (
+            <p className="border-b border-destructive/30 bg-destructive/5 px-5 py-2 text-xs text-destructive">
+              Couldn&apos;t download file: {downloadError}
+            </p>
+          )}
+          {state.status === 'loading' && (
+            <div className="flex h-full flex-col items-center justify-center gap-3 text-muted-foreground">
+              <Loader2 className="h-7 w-7 animate-spin" />
+              <span className="text-sm">Reading archive contents...</span>
+            </div>
+          )}
+
+          {state.status === 'error' && (
+            <div className="flex h-full flex-col items-center justify-center gap-3 px-6 text-center text-muted-foreground">
+              <AlertTriangle className="h-8 w-8 text-destructive/70" />
+              <p className="text-sm font-medium text-foreground">Couldn&apos;t read this archive</p>
+              <p className="max-w-md text-xs">{state.message}</p>
+            </div>
+          )}
+
+          {state.status === 'loaded' && state.entries.length === 0 && (
+            <p className="p-5 text-sm text-muted-foreground">This archive is empty.</p>
+          )}
+
+          {state.status === 'loaded' && state.entries.length > 0 && (
+            <ul className="p-2" aria-label="Archive contents">
+              {state.entries.map((entry) => {
+                const depth = entry.path.split('/').length - 1;
+                return (
+                  <li
+                    key={entry.path}
+                    className="group flex min-w-0 items-center gap-2 rounded px-2 py-1.5 text-sm hover:bg-muted/50"
+                    style={{ paddingLeft: `${depth * 16 + 8}px` }}
+                  >
+                    {entry.isDirectory ? (
+                      <Folder className="h-4 w-4 flex-shrink-0 text-muted-foreground" />
+                    ) : (
+                      <File className="h-4 w-4 flex-shrink-0 text-muted-foreground" />
+                    )}
+                    <span className="min-w-0 flex-1 truncate" title={entry.path}>{entryName(entry.path)}</span>
+                    {!entry.isDirectory && (
+                      <>
+                        <span className="flex-shrink-0 text-xs text-muted-foreground">
+                          {formatFileSize(entry.sizeBytes)}
+                        </span>
+                        {archive && (
+                          <button
+                            type="button"
+                            onClick={() => void downloadEntry(entry.path)}
+                            disabled={downloadingPath !== null}
+                            className="flex h-7 flex-shrink-0 items-center gap-1.5 rounded px-2 text-xs font-medium opacity-0 transition-opacity hover:bg-accent focus:opacity-100 group-hover:opacity-100 disabled:opacity-50"
+                            aria-label={`Download ${entry.path}`}
+                          >
+                            <Download className="h-3.5 w-3.5" />
+                            {downloadingPath === entry.path ? 'Downloading…' : 'Download'}
+                          </button>
+                        )}
+                      </>
+                    )}
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/frontend/src/components/models/FileTree.test.tsx
+++ b/apps/frontend/src/components/models/FileTree.test.tsx
@@ -167,6 +167,29 @@ describe('FileTree', () => {
     expect(onExtractArchive).toHaveBeenCalledWith('a1', archiveName);
   });
 
+  it('offers archive browsing without changing the extraction action', () => {
+    const onBrowseArchive = vi.fn();
+    const onExtractArchive = vi.fn();
+    render(
+      <FileTree
+        tree={[{
+          name: 'parts.7z',
+          type: 'file',
+          fileType: 'other',
+          id: 'a1',
+          isDuplicate: false,
+        }]}
+        modelId="m1"
+        onBrowseArchive={onBrowseArchive}
+        onExtractArchive={onExtractArchive}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Browse parts.7z' }));
+    expect(onBrowseArchive).toHaveBeenCalledWith('a1', 'parts.7z');
+    expect(onExtractArchive).not.toHaveBeenCalled();
+  });
+
   it('fires onOpenText with the reconstructed relative path for a text file', () => {
     const onOpenText = vi.fn();
     render(<FileTree tree={TREE} modelId="m1" onOpenText={onOpenText} />);

--- a/apps/frontend/src/components/models/FileTree.tsx
+++ b/apps/frontend/src/components/models/FileTree.tsx
@@ -71,6 +71,7 @@ interface FileNodeProps {
   onRenameFile?: (fileId: string, filename: string) => void;
   onMoveFile?: (fileId: string, parentPath: string) => Promise<void>;
   onDeleteFile?: (fileId: string, name: string) => void;
+  onBrowseArchive?: (fileId: string, name: string) => void;
   onExtractArchive?: (fileId: string, name: string) => void;
   onRenameFolder?: (path: string, name: string) => void;
   onMoveFolder?: (path: string, parentPath: string) => Promise<void>;
@@ -346,6 +347,7 @@ function FileNode({
   onRenameFile,
   onMoveFile,
   onDeleteFile,
+  onBrowseArchive,
   onExtractArchive,
   onRenameFolder,
   onMoveFolder,
@@ -476,6 +478,7 @@ function FileNode({
                 onRenameFile={onRenameFile}
                 onMoveFile={onMoveFile}
                 onDeleteFile={onDeleteFile}
+                onBrowseArchive={onBrowseArchive}
                 onExtractArchive={onExtractArchive}
                 onRenameFolder={onRenameFolder}
                 onMoveFolder={onMoveFolder}
@@ -497,6 +500,7 @@ function FileNode({
   const parentPath = joinPath(pathPrefix);
   const fileSegments = [...pathPrefix, node.name];
   const canPreviewText = !selectionMode && Boolean(onOpenText) && isTextPreviewFileName(node.name);
+  const canBrowseArchive = !selectionMode && Boolean(node.id) && Boolean(onBrowseArchive) && isArchiveFileName(node.name);
   const canExtractArchive = !selectionMode && Boolean(node.id) && isArchiveFileName(node.name);
   const isImage = node.fileType === 'image' && Boolean(node.id);
   const isSelectedImage = isImage && node.id === selectedImageFileId;
@@ -602,6 +606,22 @@ function FileNode({
           Preview
         </button>
       )}
+      {canBrowseArchive && (
+        <button
+          type="button"
+          onClick={(event) => {
+            event.stopPropagation();
+            onBrowseArchive?.(node.id!, node.name);
+          }}
+          disabled={disabled}
+          className="flex flex-shrink-0 items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium text-primary opacity-0 transition-all hover:bg-primary/10 focus:opacity-100 group-hover:opacity-100 disabled:opacity-50"
+          aria-label={`Browse ${node.name}`}
+          title={`Browse ${node.name}`}
+        >
+          <Archive className="h-3.5 w-3.5" />
+          Browse
+        </button>
+      )}
       {canExtractArchive && (
         <button
           type="button"
@@ -638,6 +658,12 @@ function FileNode({
             </button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end" className="w-36">
+            {canBrowseArchive && (
+              <DropdownMenuItem onClick={() => onBrowseArchive?.(node.id!, node.name)}>
+                <Archive className="mr-2 h-3.5 w-3.5" />
+                Browse
+              </DropdownMenuItem>
+            )}
             {canExtractArchive && (
               <DropdownMenuItem onClick={() => onExtractArchive?.(node.id!, node.name)}>
                 <PackageOpen className="mr-2 h-3.5 w-3.5" />
@@ -740,6 +766,7 @@ interface FileTreeProps {
   onRenameFile?: (fileId: string, filename: string) => void;
   onMoveFile?: (fileId: string, parentPath: string) => Promise<void>;
   onDeleteFile?: (fileId: string, name: string) => void;
+  onBrowseArchive?: (fileId: string, name: string) => void;
   onExtractArchive?: (fileId: string, name: string) => void;
   onMoveFiles?: (fileIds: string[], parentPath: string) => Promise<void>;
   onDeleteFiles?: (fileIds: string[]) => void;
@@ -764,6 +791,7 @@ export function FileTree({
   onRenameFile,
   onMoveFile,
   onDeleteFile,
+  onBrowseArchive,
   onExtractArchive,
   onMoveFiles,
   onDeleteFiles,
@@ -1086,6 +1114,7 @@ export function FileTree({
               onRenameFile={onRenameFile}
               onMoveFile={onMoveFile}
               onDeleteFile={onDeleteFile}
+              onBrowseArchive={onBrowseArchive}
               onExtractArchive={onExtractArchive}
               onRenameFolder={onRenameFolder}
               onMoveFolder={onMoveFolder}

--- a/apps/frontend/src/components/models/ModelDetailPanel.tsx
+++ b/apps/frontend/src/components/models/ModelDetailPanel.tsx
@@ -27,6 +27,7 @@ interface ModelDetailPanelProps {
   onRenameFile?: (fileId: string, filename: string) => void;
   onMoveFile?: (fileId: string, parentPath: string) => Promise<void>;
   onDeleteFile?: (fileId: string, name: string) => void;
+  onBrowseArchive?: (fileId: string, name: string) => void;
   onExtractArchive?: (fileId: string, name: string) => void;
   onMoveFiles?: (fileIds: string[], parentPath: string) => Promise<void>;
   onDeleteFiles?: (fileIds: string[]) => void;
@@ -61,6 +62,7 @@ export function ModelDetailPanel({
   onRenameFile,
   onMoveFile,
   onDeleteFile,
+  onBrowseArchive,
   onExtractArchive,
   onMoveFiles,
   onDeleteFiles,
@@ -127,6 +129,7 @@ export function ModelDetailPanel({
           onRenameFile={onRenameFile}
           onMoveFile={onMoveFile}
           onDeleteFile={onDeleteFile}
+          onBrowseArchive={onBrowseArchive}
           onExtractArchive={onExtractArchive}
           onMoveFiles={onMoveFiles}
           onDeleteFiles={onDeleteFiles}

--- a/apps/frontend/src/pages/ModelDetailPage.test.tsx
+++ b/apps/frontend/src/pages/ModelDetailPage.test.tsx
@@ -51,6 +51,10 @@ vi.mock('../components/models/TextFilePreviewModal', () => ({
   TextFilePreviewModal: () => null,
 }));
 
+vi.mock('../components/models/ArchivePreviewModal', () => ({
+  ArchivePreviewModal: () => null,
+}));
+
 vi.mock('../components/models/ModelDetailSkeleton', () => ({
   ModelDetailSkeleton: () => <div>Loading model</div>,
 }));

--- a/apps/frontend/src/pages/ModelDetailPage.tsx
+++ b/apps/frontend/src/pages/ModelDetailPage.tsx
@@ -26,6 +26,7 @@ import { SplitFolderDialog } from '../components/models/SplitFolderDialog';
 import { ModelBreadcrumb } from '../components/models/ModelBreadcrumb';
 import { ModelViewer3DModal } from '../components/models/ModelViewer3DModal';
 import { TextFilePreviewModal } from '../components/models/TextFilePreviewModal';
+import { ArchivePreviewModal } from '../components/models/ArchivePreviewModal';
 import { ModelDetailSkeleton } from '../components/models/ModelDetailSkeleton';
 import { collectStlFiles, type StlFileRef, type TextFileRef } from '../lib/model-files';
 import { useLibraryPath } from '../hooks/use-libraries';
@@ -158,6 +159,8 @@ export function ModelDetailPage() {
   const [activeStl, setActiveStl] = React.useState<StlFileRef | null>(null);
   const [textPreviewOpen, setTextPreviewOpen] = React.useState(false);
   const [activeTextFile, setActiveTextFile] = React.useState<TextFileRef | null>(null);
+  const [archivePreviewOpen, setArchivePreviewOpen] = React.useState(false);
+  const [activeArchive, setActiveArchive] = React.useState<{ fileId: string; name: string } | null>(null);
   const [uploadDialogOpen, setUploadDialogOpen] = React.useState(false);
   const [mergeDialogOpen, setMergeDialogOpen] = React.useState(false);
   const [splitTarget, setSplitTarget] = React.useState<
@@ -396,6 +399,10 @@ export function ModelDetailPage() {
               onRenameFile={(fileId, filename) => fileMutation.mutate({ type: 'rename-file', fileId, filename })}
               onMoveFile={(fileId, parentPath) => runFileAction({ type: 'move-file', fileId, parentPath })}
               onDeleteFile={(fileId, name) => fileMutation.mutate({ type: 'delete-file', fileId, name })}
+              onBrowseArchive={(fileId, name) => {
+                setActiveArchive({ fileId, name });
+                setArchivePreviewOpen(true);
+              }}
               onExtractArchive={(fileId, name) => fileMutation.mutate({ type: 'extract-archive', fileId, name })}
               onMoveFiles={(fileIds, parentPath) => runFileAction({ type: 'move-files', fileIds, parentPath })}
               onDeleteFiles={(fileIds) => fileMutation.mutate({ type: 'delete-files', fileIds })}
@@ -429,6 +436,14 @@ export function ModelDetailPage() {
         onOpenChange={setTextPreviewOpen}
         file={activeTextFile}
       />
+      {id && (
+        <ArchivePreviewModal
+          modelId={id}
+          open={archivePreviewOpen}
+          onOpenChange={setArchivePreviewOpen}
+          archive={activeArchive}
+        />
+      )}
       <SplitFolderDialog
         open={Boolean(splitTarget)}
         folderPath={splitTarget?.type === 'folder' ? splitTarget.path : undefined}

--- a/docs/API.md
+++ b/docs/API.md
@@ -1315,6 +1315,43 @@ Retrieve the file tree for a model. The flat list of `ModelFile` records is asse
 
 ---
 
+### GET /models/:id/files/:fileId/archive
+
+List the safe entries in one stored archive model file without adding its contents to the model.
+
+**Auth required:** Yes. The model must belong to the active library.
+
+**Path parameters:** `id` — model UUID; `fileId` — archive `ModelFile` UUID belonging to that model.
+
+**Response (200):**
+
+```json
+{
+  "data": {
+    "entries": [
+      { "path": "parts", "sizeBytes": 0, "isDirectory": true },
+      { "path": "parts/body.stl", "sizeBytes": 2097152, "isDirectory": false }
+    ]
+  },
+  "meta": null,
+  "errors": null
+}
+```
+
+`entries` includes files and inferred parent directories, sorted case-insensitively by path. The server validates archive paths and link entries using the same extraction safeguards as ingestion. Unsupported archive files return `400 VALIDATION_ERROR`; a missing model/file or a model outside the active library returns `404 NOT_FOUND`.
+
+---
+
+### GET /models/:id/files/:fileId/archive/download?path=...
+
+Download exactly one file listed by the archive endpoint as an attachment. `path` is the archive-relative forward-slash path and must be 1–1,000 characters.
+
+**Auth required:** Yes. The model must belong to the active library.
+
+The server extracts to an isolated temporary directory, revalidates the requested path against a freshly generated archive manifest, streams the file, and removes temporary data after streaming. It does not create a `ModelFile` or modify the model. Invalid paths return `400 VALIDATION_ERROR`; entries not present in the current archive manifest return `404 NOT_FOUND`.
+
+---
+
 ### POST /models/:id/files/delete
 
 Delete a selected set of files from one model. The model must belong to the authenticated user and the active library selected by `X-Library-Id`, or the user's default library when the header is omitted.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -54,7 +54,7 @@ The `runSeed` function is also exported for use as a standalone CLI script (`npm
 │                                                          │
 │   ModelDetailPage: ModelBreadcrumb + ModelHero +         │
 │     ModelDetailPanel (Info/Collections/Files tabs)       │
-│     + SplitFolderDialog for folder or file extraction    │
+│     + ArchivePreviewModal + SplitFolderDialog            │
 │   ToolsPage: library maintenance tools + duplicate scan  │
 │   ModelViewer3DModal → lazy ModelViewer3DScene (three.js)│
 │   lib/model-files.ts: STL path helpers (pure)           │
@@ -424,6 +424,14 @@ For a derived folder archive, `createModelFileAndRecalculateStats` inserts the `
 
 **Behavior:** Normalizes the requested and derived archive paths, serializes concurrent requests for the same model and folder, and admits at most one compression process at a time per backend instance. It resolves descendant files and explicit empty folders and rejects a missing folder. Before reading source objects, it rejects any file, folder namespace, or storage object already occupying `<folder-path>.7z`. It streams source objects through StorageService into an isolated temporary directory, delegates explicit LZMA2 archive creation to FileProcessingService, and stores and verifies the result through the configured storage backend. ModelService then records the archive as `application/x-7z-compressed` and updates model totals transactionally. The source folder is never changed. Failures before database persistence trigger best-effort deletion of the newly written archive object, and temporary data is always removed.
 
+### ArchiveBrowserService
+
+**Owns:** Read-only listing and single-entry download preparation for one stored archive model file.
+
+**Does not own:** Model ownership and library scope (delegates to ModelService), archive format parsing or extraction safeguards (FileProcessingService), managed object access (StorageService), or persistence of extracted files.
+
+**Behavior:** Resolves an archive file only after ModelService verifies the requested model belongs to the active library. It streams the managed archive into an isolated temporary directory and delegates extraction to FileProcessingService, so all existing ZIP, TAR.GZ, RAR, and 7z traversal/link protections apply. Listing returns safe files plus inferred parent directories. A requested download path is normalized, rejected when unsafe, then checked against a fresh manifest before opening the extracted file stream; a client cannot download an arbitrary temporary path. The temporary directory is removed after listing, on preparation failure, or when the download stream closes/errors. Neither operation writes `ModelFile` rows or changes the model.
+
 ### MetadataService
 
 **Owns:** Metadata field definitions, metadata values on models, optimized storage routing for performance-critical field types.
@@ -713,6 +721,8 @@ Because `ModelViewer3DScene` is lazy-loaded, Vite emits three.js as a separate a
 | GET | /models | Browse/search with filters | SearchService → PresenterService | Yes |
 | GET | /models/:id | Model detail | ModelService → PresenterService | Yes |
 | GET | /models/:id/files | File tree | ModelService → PresenterService | Yes |
+| GET | /models/:id/files/:fileId/archive | List a stored archive's safe contents | ArchiveBrowserService → ModelService + StorageService + FileProcessingService | Yes |
+| GET | /models/:id/files/:fileId/archive/download | Stream one validated archive entry | ArchiveBrowserService → ModelService + StorageService + FileProcessingService | Yes |
 | POST | /models/:id/folders/compress | Create a non-destructive sibling 7z archive | ModelFolderArchiveService → ModelService + FileProcessingService + StorageService | Yes |
 | POST | /models/upload | Upload archive → scan (returns sessionId) | IngestionService → ImportSessionService → JobService | Yes |
 | POST | /models/upload/init | Initiate chunked upload session | UploadService | No |

--- a/docs/TYPES.md
+++ b/docs/TYPES.md
@@ -522,6 +522,16 @@ interface FileTreeNode {
   children?: FileTreeNode[]; // present for directories only
 }
 
+interface ArchiveEntry {
+  path: string;              // safe archive-relative path using forward slashes
+  sizeBytes: number;         // zero for inferred directories
+  isDirectory: boolean;
+}
+
+interface ArchiveContents {
+  entries: ArchiveEntry[];
+}
+
 interface CompressModelFolderRequest {
   path: string; // relative path of the folder within the model; 1–1,000 characters
 }

--- a/packages/shared/src/types/model.ts
+++ b/packages/shared/src/types/model.ts
@@ -102,6 +102,17 @@ export interface FileTreeNode {
   children?: FileTreeNode[];
 }
 
+/** One safe, display-ready entry discovered inside a stored archive. */
+export interface ArchiveEntry {
+  path: string;
+  sizeBytes: number;
+  isDirectory: boolean;
+}
+
+export interface ArchiveContents {
+  entries: ArchiveEntry[];
+}
+
 export interface CreateModelFolderRequest {
   path: string;
 }

--- a/packages/shared/src/validation/model.ts
+++ b/packages/shared/src/validation/model.ts
@@ -83,3 +83,7 @@ export const splitModelFolderSchema = z.object({
 export const compressModelFolderSchema = z.object({
   path: relativePathSchema,
 });
+
+export const archiveEntryQuerySchema = z.object({
+  path: z.string().min(1).max(1000),
+});


### PR DESCRIPTION
## Summary
- add a read-only archive browser in the model file explorer
- allow downloading one validated archive entry without modifying the model
- preserve selected-library scope and handle Unicode download names safely

## Validation
- git diff --check
- targeted tests could not run because this worktree has no installed dependencies (vitest and tsc are unavailable)