### PR TITLE
feat: move models between libraries

### DIFF
--- a/apps/backend/src/routes/models.move.test.ts
+++ b/apps/backend/src/routes/models.move.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import Fastify, { type FastifyInstance } from 'fastify';
+
+const USER_ID = '11111111-1111-4111-8111-111111111111';
+const MODEL_ID = '33333333-3333-4333-8333-333333333333';
+const TARGET_LIBRARY_ID = '22222222-2222-4222-8222-222222222222';
+
+const mocks = vi.hoisted(() => ({
+  requireAuth: vi.fn(async (request: { user?: unknown }) => {
+    request.user = { id: USER_ID };
+  }),
+  moveModel: vi.fn(),
+}));
+
+vi.mock('../middleware/auth.js', () => ({ requireAuth: mocks.requireAuth }));
+vi.mock('../services/model.service.js', () => ({
+  modelService: { moveModel: mocks.moveModel },
+}));
+
+import { modelRoutes } from './models.js';
+
+describe('Model move route', () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mocks.moveModel.mockResolvedValue({
+      modelId: MODEL_ID,
+      libraryId: TARGET_LIBRARY_ID,
+      removedCollectionCount: 2,
+    });
+    app = Fastify();
+    await app.register(modelRoutes, { prefix: '/models' });
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('moves an owned model to the requested library', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: `/models/${MODEL_ID}/move`,
+      payload: { targetLibraryId: TARGET_LIBRARY_ID },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(mocks.moveModel).toHaveBeenCalledWith(MODEL_ID, USER_ID, TARGET_LIBRARY_ID);
+    expect(response.json()).toEqual({
+      data: {
+        modelId: MODEL_ID,
+        libraryId: TARGET_LIBRARY_ID,
+        removedCollectionCount: 2,
+      },
+      meta: null,
+      errors: null,
+    });
+  });
+
+  it('rejects an invalid destination before calling the service', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: `/models/${MODEL_ID}/move`,
+      payload: { targetLibraryId: 'not-a-uuid' },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(mocks.moveModel).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/routes/models.ts
+++ b/apps/backend/src/routes/models.ts
@@ -20,6 +20,7 @@ import type {
   CompressModelFolderRequest,
   ExtractImportSessionArchiveRequest,
   CompleteMultipartUploadRequest,
+  MoveModelRequest,
 } from '@alexandria/shared';
 import {
   createModelFolderSchema,
@@ -33,6 +34,7 @@ import {
   updateModelFileSchema,
   updateModelFolderSchema,
   updateModelSchema,
+  moveModelSchema,
   uploadInitSchema,
   multipartUploadInitSchema,
   completeMultipartUploadSchema,
@@ -854,6 +856,19 @@ export async function modelRoutes(app: FastifyInstance): Promise<void> {
       const detail = await presenterService.buildModelDetail(id);
 
       return reply.status(200).send({ data: detail, meta: null, errors: null });
+    },
+  );
+
+  // POST /:id/move — move an owned model to another owned library
+  app.post(
+    '/:id/move',
+    { preHandler: [requireAuth, validate(moveModelSchema)] },
+    async (request, reply) => {
+      const { id } = request.params as { id: string };
+      const body = request.body as MoveModelRequest;
+      const result = await modelService.moveModel(id, request.user!.id, body.targetLibraryId);
+
+      return reply.status(200).send({ data: result, meta: null, errors: null });
     },
   );
 

--- a/apps/backend/src/services/model.service.ts
+++ b/apps/backend/src/services/model.service.ts
@@ -12,6 +12,7 @@ import type {
   UpdateModelFolderRequest,
   ConsolidateDuplicateModelsPreview,
   ConsolidateDuplicateModelsResult,
+  MoveModelResponse,
 } from '@alexandria/shared';
 import { MAX_MODEL_FILE_SELECTION_COUNT } from '@alexandria/shared';
 import { db } from '../db/index.js';
@@ -26,6 +27,7 @@ import {
   modelTags,
   metadataFieldDefinitions,
   collections,
+  libraries,
   tags,
 } from '../db/schema/index.js';
 import { conflict, notFound, validationError } from '../utils/errors.js';
@@ -477,6 +479,72 @@ export class ModelService {
       .returning();
 
     return updated;
+  }
+
+  /**
+   * Move an owned model to another owned library. Collection memberships are
+   * library-scoped, so they are removed as part of the move rather than
+   * leaving the destination model linked to collections in the old library.
+   */
+  async moveModel(
+    id: string,
+    userId: string,
+    targetLibraryId: string,
+  ): Promise<MoveModelResponse> {
+    await libraryService.requireOwnedLibrary(userId, targetLibraryId);
+
+    return db.transaction(async (tx) => {
+      const model = await this.lockModelById(id, tx);
+      if (model.userId !== userId) {
+        throw notFound(`Model not found: ${id}`);
+      }
+      if (model.libraryId === targetLibraryId) {
+        throw conflict('Model is already in that library');
+      }
+
+      // Re-check inside the transaction so a concurrently deleted library
+      // cannot become a dangling destination between the ownership check and
+      // the model update.
+      const [targetLibrary] = await tx
+        .select({ id: libraries.id })
+        .from(libraries)
+        .where(and(eq(libraries.id, targetLibraryId), eq(libraries.userId, userId)))
+        .limit(1);
+      if (!targetLibrary) {
+        throw notFound('Library not found');
+      }
+
+      const removedCollections = await tx
+        .delete(collectionModels)
+        .where(eq(collectionModels.modelId, id))
+        .returning({ collectionId: collectionModels.collectionId });
+
+      await tx
+        .update(models)
+        .set({ libraryId: targetLibraryId, updatedAt: new Date() })
+        .where(eq(models.id, id));
+
+      await duplicateScannerService.reconcileDuplicateFlags(model.libraryId, tx);
+      await duplicateScannerService.reconcileDuplicateFlags(targetLibraryId, tx);
+
+      logger.info(
+        {
+          service: 'ModelService',
+          modelId: id,
+          userId,
+          sourceLibraryId: model.libraryId,
+          targetLibraryId,
+          removedCollectionCount: removedCollections.length,
+        },
+        'Model moved to another library',
+      );
+
+      return {
+        modelId: id,
+        libraryId: targetLibraryId,
+        removedCollectionCount: removedCollections.length,
+      };
+    });
   }
 
   async getModelFiles(

--- a/apps/frontend/src/api/models.ts
+++ b/apps/frontend/src/api/models.ts
@@ -21,6 +21,7 @@ import type {
   SplitModelFolderResponse,
   CompressFolderResponse,
   ArchiveContents,
+  MoveModelResponse,
 } from '@alexandria/shared';
 import { get, getBlob, post, postForLibrary, patch, del, putRaw, postForm } from './client';
 import { buildQueryString } from '../lib/query';
@@ -56,6 +57,11 @@ export async function getModelStatus(id: string): Promise<JobStatus> {
 
 export async function updateModel(id: string, data: UpdateModelRequest): Promise<ModelDetail> {
   const response = await patch<ModelDetail>(`/models/${id}`, data);
+  return response.data;
+}
+
+export async function moveModel(id: string, targetLibraryId: string): Promise<MoveModelResponse> {
+  const response = await post<MoveModelResponse>(`/models/${id}/move`, { targetLibraryId });
   return response.data;
 }
 

--- a/apps/frontend/src/components/models/MoveModelDialog.tsx
+++ b/apps/frontend/src/components/models/MoveModelDialog.tsx
@@ -1,0 +1,96 @@
+import * as React from 'react';
+import type { LibrarySummary } from '@alexandria/shared';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '../ui/dialog';
+import { Button } from '../ui/button';
+import { Label } from '../ui/label';
+import { Select } from '../ui/select';
+
+interface MoveModelDialogProps {
+  modelName: string;
+  libraries: LibrarySummary[];
+  currentLibraryId: string | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: (targetLibraryId: string) => Promise<void>;
+}
+
+export function MoveModelDialog({
+  modelName,
+  libraries,
+  currentLibraryId,
+  open,
+  onOpenChange,
+  onConfirm,
+}: MoveModelDialogProps) {
+  const destinations = React.useMemo(
+    () => libraries.filter((library) => library.id !== currentLibraryId),
+    [libraries, currentLibraryId],
+  );
+  const [targetLibraryId, setTargetLibraryId] = React.useState('');
+  const [isPending, setIsPending] = React.useState(false);
+
+  React.useEffect(() => {
+    if (open) setTargetLibraryId(destinations[0]?.id ?? '');
+  }, [open, destinations]);
+
+  async function handleSubmit(event: React.FormEvent) {
+    event.preventDefault();
+    if (!targetLibraryId || isPending) return;
+
+    setIsPending(true);
+    try {
+      await onConfirm(targetLibraryId);
+      onOpenChange(false);
+    } finally {
+      setIsPending(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+          <DialogHeader>
+            <DialogTitle>Move model</DialogTitle>
+            <DialogDescription>
+              Move “{modelName}” to another library. Its current collection memberships will be
+              removed because collections belong to their library.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="move-model-destination">Destination library</Label>
+            <Select
+              id="move-model-destination"
+              value={targetLibraryId}
+              onChange={(event) => setTargetLibraryId(event.target.value)}
+              disabled={isPending || destinations.length === 0}
+            >
+              {destinations.map((library) => (
+                <option key={library.id} value={library.id}>
+                  {library.name}
+                </option>
+              ))}
+            </Select>
+          </div>
+
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={isPending}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={!targetLibraryId || isPending}>
+              {isPending ? 'Moving…' : 'Move model'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/frontend/src/hooks/use-libraries.tsx
+++ b/apps/frontend/src/hooks/use-libraries.tsx
@@ -117,6 +117,15 @@ export function useLibraries(): LibrariesContextValue {
 }
 
 /**
+ * Read library context when available without requiring a provider. This is
+ * useful for pages that have isolated tests or can render outside the library
+ * workspace; those callers simply hide library-specific actions.
+ */
+export function useLibrariesOptional(): LibrariesContextValue | null {
+  return useContext(LibrariesContext);
+}
+
+/**
  * Returns the route-scoped library id without requiring a provider in isolated
  * component tests. Components that retain local library-scoped state use this
  * to guard that state across route transitions.

--- a/apps/frontend/src/pages/ModelDetailPage.tsx
+++ b/apps/frontend/src/pages/ModelDetailPage.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useParams, useNavigate, Link } from 'react-router-dom';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { ChevronLeft, AlertTriangle, Download, GitMerge, Loader2, Upload, X } from 'lucide-react';
+import { ChevronLeft, AlertTriangle, ArrowRightLeft, Download, GitMerge, Loader2, Upload, X } from 'lucide-react';
 import type { ModelCard, ModelDetail, SplitModelFolderRequest } from '@alexandria/shared';
 import { addModelsToCollection, getCollections } from '../api/collections';
 import {
@@ -15,6 +15,7 @@ import {
   getModelFiles,
   getModels,
   mergeModels,
+  moveModel,
   splitModelFolder,
   updateModelFile,
   updateModelFolder,
@@ -23,13 +24,14 @@ import {
 import { ModelHero } from '../components/models/ModelHero';
 import { ModelDetailPanel } from '../components/models/ModelDetailPanel';
 import { SplitFolderDialog } from '../components/models/SplitFolderDialog';
+import { MoveModelDialog } from '../components/models/MoveModelDialog';
 import { ModelBreadcrumb } from '../components/models/ModelBreadcrumb';
 import { ModelViewer3DModal } from '../components/models/ModelViewer3DModal';
 import { TextFilePreviewModal } from '../components/models/TextFilePreviewModal';
 import { ArchivePreviewModal } from '../components/models/ArchivePreviewModal';
 import { ModelDetailSkeleton } from '../components/models/ModelDetailSkeleton';
 import { collectStlFiles, type StlFileRef, type TextFileRef } from '../lib/model-files';
-import { useLibraryPath } from '../hooks/use-libraries';
+import { useLibrariesOptional, useLibraryPath } from '../hooks/use-libraries';
 import { Button, buttonVariants } from '../components/ui/button';
 import {
   Dialog,
@@ -80,6 +82,9 @@ export function ModelDetailPage() {
   const { id } = useParams<{ id: string }>();
   useAssistantTarget({ modelIds: id ? [id] : [] });
   const libPath = useLibraryPath();
+  const librariesContext = useLibrariesOptional();
+  const libraries = librariesContext?.libraries ?? [];
+  const currentLibraryId = librariesContext?.currentLibraryId ?? null;
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const { toast } = useToast();
@@ -163,12 +168,38 @@ export function ModelDetailPage() {
   const [activeArchive, setActiveArchive] = React.useState<{ fileId: string; name: string } | null>(null);
   const [uploadDialogOpen, setUploadDialogOpen] = React.useState(false);
   const [mergeDialogOpen, setMergeDialogOpen] = React.useState(false);
+  const [moveDialogOpen, setMoveDialogOpen] = React.useState(false);
   const [splitTarget, setSplitTarget] = React.useState<
     | { type: 'folder'; path: string; name: string }
     | { type: 'files'; fileIds: string[]; name: string }
     | null
   >(null);
   const [selectedImageFileId, setSelectedImageFileId] = React.useState<string | null>(null);
+
+  const moveMutation = useMutation({
+    mutationFn: async (targetLibraryId: string) => {
+      if (!id) throw new Error('Model id is required');
+      return moveModel(id, targetLibraryId);
+    },
+    onSuccess: async (result) => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['libraries'] }),
+        queryClient.invalidateQueries({ queryKey: ['models'] }),
+        queryClient.invalidateQueries({ queryKey: ['search'] }),
+        queryClient.invalidateQueries({ queryKey: ['collections'] }),
+        queryClient.invalidateQueries({ queryKey: ['smart-collections'] }),
+      ]);
+      toast({ title: 'Model moved' });
+      navigate(`/lib/${result.libraryId}/models/${result.modelId}`);
+    },
+    onError: (error) => {
+      toast({
+        title: 'Could not move model',
+        description: error instanceof Error ? error.message : undefined,
+        variant: 'destructive',
+      });
+    },
+  });
 
   const fileMutation = useMutation({
     mutationFn: async (action: FileAction) => {
@@ -330,6 +361,20 @@ export function ModelDetailPage() {
                 <GitMerge className="h-4 w-4" />
                 <span className="hidden sm:inline">Merge</span>
               </Button>
+              {libraries.length > 1 && (
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="gap-2"
+                  onClick={() => setMoveDialogOpen(true)}
+                  aria-label="Move model"
+                  title="Move model"
+                >
+                  <ArrowRightLeft className="h-4 w-4" />
+                  <span className="hidden sm:inline">Move</span>
+                </Button>
+              )}
               <a
                 href={`/api/models/${model.id}/download`}
                 className={cn(buttonVariants({ variant: 'outline', size: 'sm' }), 'gap-2')}
@@ -475,6 +520,14 @@ export function ModelDetailPage() {
             targetModel={model}
             open={mergeDialogOpen}
             onOpenChange={setMergeDialogOpen}
+          />
+          <MoveModelDialog
+            modelName={model.name}
+            libraries={libraries}
+            currentLibraryId={currentLibraryId}
+            open={moveDialogOpen}
+            onOpenChange={setMoveDialogOpen}
+            onConfirm={(targetLibraryId) => moveMutation.mutateAsync(targetLibraryId).then(() => undefined)}
           />
         </>
       )}

--- a/docs/API.md
+++ b/docs/API.md
@@ -45,7 +45,7 @@ Every model, collection, smart collection, and import session belongs to exactly
 - If the request carries an **`X-Library-Id`** header, that library is used — but only after an ownership check. An unknown or un-owned id returns `404 NOT_FOUND` (same response whether it does not exist or belongs to another user, so ids cannot be enumerated).
 - If the header is absent, the request falls back to the user's **default library**.
 
-Clients never pass `libraryId` in a query string or body; scoping rides on the header only. The frontend mirrors its `/lib/:id` route segment into this header. Library membership itself is managed through the `Libraries` endpoints below.
+Clients never pass the active `libraryId` in a query string or body; scoping rides on the header only. The model-move endpoint intentionally accepts a separately validated `targetLibraryId` body field. The frontend mirrors its `/lib/:id` route segment into this header. Library membership itself is managed through the `Libraries` endpoints below.
 
 > Note: the per-endpoint "Library scope" notes throughout this document predate P5 and say "default library". They now mean **the active library** (the `X-Library-Id` header when present, otherwise the default).
 
@@ -1531,6 +1531,40 @@ Update a model's name, description, or cover image.
 | `previewImageFileId` | string or null (optional) | UUID of a `ModelFile` with `fileType: "image"` to use as the model's cover image. Pass `null` to clear the pinned cover and revert to the first-image fallback. |
 
 **Response (200):** Returns the full `ModelDetail` for the updated model, in the same shape as `GET /models/:id`.
+
+---
+
+### POST /models/:id/move
+
+Move an owned model to another library owned by the authenticated user.
+
+**Auth required:** Yes
+
+**Path parameter:** `id` — model UUID
+
+**Request body:**
+
+```json
+{
+  "targetLibraryId": "uuid-of-destination-library"
+}
+```
+
+The operation is atomic. Existing collection memberships are removed because collections belong to their original library; metadata and tags remain attached to the model. Moving to the current library returns `409 CONFLICT`. A destination library not owned by the user returns `404 NOT_FOUND`.
+
+**Response (200):**
+
+```json
+{
+  "data": {
+    "modelId": "model-uuid",
+    "libraryId": "destination-library-uuid",
+    "removedCollectionCount": 1
+  },
+  "meta": null,
+  "errors": null
+}
+```
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -222,7 +222,7 @@ This index makes the enforcement race-safe: the database rejects a second `is_de
 
 `requireLibrary` (`apps/backend/src/middleware/library.ts`) is a Fastify preHandler that runs after `requireAuth` on every route that reads or writes library-scoped data. It reads an optional **`X-Library-Id`** header and calls `LibraryService.resolveLibraryId(userId, header)`, storing the result on `request.libraryId`. Absent header → the user's default library (preserving pre-P5 single-library behavior).
 
-**Security invariant:** `libraryId` is never trusted from untrusted input. The header is accepted only after `resolveLibraryId` confirms the user owns that library; an unknown or un-owned id returns `NOT_FOUND` (same error either way, so ids cannot be enumerated). No route accepts a `libraryId` in the query string, path, or body. The frontend mirrors its `/lib/:id` route segment into the header; the `/libraries` management routes do **not** use `requireLibrary` (they manage the scope itself, keyed by URL `:id` + `userId`).
+**Security invariant:** the active `libraryId` is never trusted from untrusted input. The header is accepted only after `resolveLibraryId` confirms the user owns that library; an unknown or un-owned id returns `NOT_FOUND` (same error either way, so ids cannot be enumerated). The model-move endpoint is the one intentional exception: it accepts a `targetLibraryId` body field and independently verifies that the destination belongs to the authenticated user. The frontend mirrors its `/lib/:id` route segment into the header; the `/libraries` management routes do **not** use `requireLibrary` (they manage the scope itself, keyed by URL `:id` + `userId`).
 
 Routes that apply `requireLibrary` (as of P5):
 
@@ -237,7 +237,9 @@ Routes that apply `requireLibrary` (as of P5):
 - All `/bulk/*` routes
 - `POST /ai/chat`, `POST /ai/proposals/:id/apply`
 
-P5 added library-scope guards to the read/detail routes above via `ModelService.requireModelInLibrary` / `CollectionService.requireCollectionInLibrary` (the entity must belong to `request.libraryId`, else `NOT_FOUND`), so a stale deep link to another library's item 404s after switching. By-id **mutation** routes (`PATCH`/`DELETE /models/:id`, `PATCH`/`DELETE /collections/:id`) remain `userId`-owned only — they are same-user operations and were intentionally left out of the minimal P5 sweep.
+`POST /models/:id/move` is an authenticated, cross-library mutation. It locks and ownership-checks the model, verifies the destination library belongs to the same user, moves the model atomically, removes collection memberships that point into the source library, and reconciles duplicate flags in both libraries. Metadata and tags remain attached because their definitions are global rather than library-scoped.
+
+P5 added library-scope guards to the read/detail routes above via `ModelService.requireModelInLibrary` / `CollectionService.requireCollectionInLibrary` (the entity must belong to `request.libraryId`, else `NOT_FOUND`), so a stale deep link to another library's item 404s after switching. By-id **mutation** routes (`PATCH`/`DELETE /models/:id`, `PATCH`/`DELETE /collections/:id`) remain `userId`-owned only — they are same-user operations and were intentionally left out of the minimal P5 sweep. The cross-library model move is also user-owned, but uses an explicit destination ownership check and transaction because it changes library scope.
 
 ### P4: Smart Collections (shipped)
 

--- a/docs/TYPES.md
+++ b/docs/TYPES.md
@@ -1082,6 +1082,16 @@ interface UpdateModelRequest {
   previewImageFileId?: string | null; // set to a ModelFile UUID to pin cover; null to revert to fallback
 }
 
+interface MoveModelRequest {
+  targetLibraryId: string;
+}
+
+interface MoveModelResponse {
+  modelId: string;
+  libraryId: string;
+  removedCollectionCount: number;
+}
+
 interface DeleteModelFilesRequest {
   fileIds: string[]; // 1–500 unique ModelFile UUIDs owned by the target model
 }

--- a/packages/shared/src/types/model.ts
+++ b/packages/shared/src/types/model.ts
@@ -176,6 +176,16 @@ export interface UpdateModelRequest {
   previewCropScale?: number | null;
 }
 
+export interface MoveModelRequest {
+  targetLibraryId: string;
+}
+
+export interface MoveModelResponse {
+  modelId: string;
+  libraryId: string;
+  removedCollectionCount: number;
+}
+
 export interface MergeModelsRequest {
   sourceModelIds: string[];
 }

--- a/packages/shared/src/validation/model.ts
+++ b/packages/shared/src/validation/model.ts
@@ -17,6 +17,10 @@ export const updateModelSchema = z.object({
   previewCropScale: z.number().min(1).max(10).nullable().optional(),
 });
 
+export const moveModelSchema = z.object({
+  targetLibraryId: z.string().uuid(),
+});
+
 export const bulkDeleteSchema = z.object({
   modelIds: z.array(z.string().uuid()).min(1).max(500)
     .refine((ids) => new Set(ids).size === ids.length, {


### PR DESCRIPTION
## Summary
- add a transactional API to move an owned model into another owned library
- remove incompatible source-library collection memberships and reconcile duplicate flags
- add a model-detail move dialog with destination navigation
- document the new endpoint and shared contract

## Validation
- npm run build -w @alexandria/shared
- npm run build -w @alexandria/backend
- npm run build -w @alexandria/frontend
- npm test -w @alexandria/backend (66 files, 1041 tests)
- npm test -w @alexandria/frontend -- --run src/pages/ModelDetailPage.test.tsx
- npm test -w @alexandria/frontend (400/401; existing FileTree 500-file selection timeout)
- npm run lint

Please review the collection-membership behavior for moved models.