### PR TITLE
feat: scan duplicate archive members

### DIFF
--- a/apps/backend/src/routes/tools.integration.test.ts
+++ b/apps/backend/src/routes/tools.integration.test.ts
@@ -331,6 +331,8 @@ describe('GET /tools/duplicates integration', () => {
       data: {
         scannedModelCount: 3,
         scannedFileCount: 6,
+        scannedArchiveFileCount: 0,
+        scannedArchiveEntryCount: 0,
         redundantModelCount: 1,
         redundantFileCount: 3,
         reclaimableBytes: 200,
@@ -418,6 +420,7 @@ describe('GET /tools/duplicates integration', () => {
             ],
           },
         ],
+        archiveFileGroups: [],
       },
       meta: null,
       errors: null,

--- a/apps/backend/src/services/duplicate-scanner.service.test.ts
+++ b/apps/backend/src/services/duplicate-scanner.service.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { Readable } from 'node:stream';
 import { ErrorCodes } from '@alexandria/shared';
 import type { SQL } from 'drizzle-orm';
 import { PgDialect } from 'drizzle-orm/pg-core';
@@ -27,7 +28,22 @@ interface ModelCandidateRow {
   hashes: string[];
 }
 
-function databaseReturning(rows: FileCandidateRow[], ignoredFingerprints: string[] = []) {
+interface ArchiveCandidateRow {
+  modelId: string;
+  modelName: string;
+  modelCreatedAt: Date;
+  archiveFileId: string;
+  archiveFilename: string;
+  archiveRelativePath: string;
+  archiveStoragePath: string;
+  archiveFileCreatedAt: Date;
+}
+
+function databaseReturning(
+  rows: FileCandidateRow[],
+  ignoredFingerprints: string[] = [],
+  archiveRows: ArchiveCandidateRow[] = [],
+) {
   const modelRows = [...rows.reduce((byModel, row) => {
     const existing = byModel.get(row.modelId);
     if (existing) existing.hashes.push(row.hash);
@@ -81,15 +97,36 @@ function databaseReturning(rows: FileCandidateRow[], ignoredFingerprints: string
     ignoredFingerprints.map((fingerprint) => ({ fingerprint })),
   );
 
+  const archiveQuery = {
+    from: vi.fn(),
+    innerJoin: vi.fn(),
+    where: vi.fn(),
+    orderBy: vi.fn(),
+  };
+  archiveQuery.from.mockReturnValue(archiveQuery);
+  archiveQuery.innerJoin.mockReturnValue(archiveQuery);
+  archiveQuery.where.mockReturnValue(archiveQuery);
+  archiveQuery.orderBy.mockResolvedValue(archiveRows);
+
+  const ignoredFileHashQuery = {
+    from: vi.fn(),
+    where: vi.fn(),
+  };
+  ignoredFileHashQuery.from.mockReturnValue(ignoredFileHashQuery);
+  ignoredFileHashQuery.where.mockResolvedValue([]);
+
   return {
     database: {
       select: vi.fn()
         .mockReturnValueOnce(modelQuery)
         .mockReturnValueOnce(fileQuery)
-        .mockReturnValueOnce(ignoredModelQuery),
+        .mockReturnValueOnce(ignoredModelQuery)
+        .mockReturnValueOnce(archiveQuery)
+        .mockReturnValueOnce(ignoredFileHashQuery),
     },
     modelQuery,
     fileQuery,
+    archiveQuery,
   };
 }
 
@@ -152,6 +189,24 @@ function fileRow(
   };
 }
 
+function archiveRow(
+  modelId: string,
+  archiveFileId: string,
+  options: Partial<ArchiveCandidateRow> = {},
+): ArchiveCandidateRow {
+  const modelCreatedAt = options.modelCreatedAt ?? new Date('2026-01-01T00:00:00.000Z');
+  return {
+    modelId,
+    modelName: options.modelName ?? modelId,
+    modelCreatedAt,
+    archiveFileId,
+    archiveFilename: options.archiveFilename ?? `${archiveFileId}.zip`,
+    archiveRelativePath: options.archiveRelativePath ?? `archives/${archiveFileId}.zip`,
+    archiveStoragePath: options.archiveStoragePath ?? `models/${modelId}/${archiveFileId}.zip`,
+    archiveFileCreatedAt: options.archiveFileCreatedAt ?? modelCreatedAt,
+  };
+}
+
 describe('DuplicateScannerService', () => {
   it('finds individual duplicate files and complete model hash multisets', async () => {
     const { database, modelQuery, fileQuery } = databaseReturning([
@@ -179,7 +234,7 @@ describe('DuplicateScannerService', () => {
 
     const result = await service.scanDuplicates('library-1');
 
-    expect(database.select).toHaveBeenCalledTimes(3);
+    expect(database.select).toHaveBeenCalledTimes(5);
     expect(modelQuery.groupBy).toHaveBeenCalledOnce();
     expect(fileQuery.where).toHaveBeenCalledOnce();
     expect(result.scannedModelCount).toBe(4);
@@ -251,7 +306,7 @@ describe('DuplicateScannerService', () => {
     ]);
 
     expect(first).toEqual(second);
-    expect(fixture.database.select).toHaveBeenCalledTimes(3);
+    expect(fixture.database.select).toHaveBeenCalledTimes(5);
   });
 
   it('does not scan or group models without files', async () => {
@@ -261,9 +316,90 @@ describe('DuplicateScannerService', () => {
       .resolves.toEqual({
         scannedModelCount: 0,
         scannedFileCount: 0,
+        scannedArchiveFileCount: 0,
+        scannedArchiveEntryCount: 0,
         groups: [],
         fileGroups: [],
+        archiveFileGroups: [],
       });
+  });
+
+  it('finds duplicate members across stored archives without making them actionable file groups', async () => {
+    const fixture = databaseReturning([], [], [
+      archiveRow('model-old', 'archive-old', {
+        archiveFileCreatedAt: new Date('2026-01-01T01:00:00.000Z'),
+      }),
+      archiveRow('model-new', 'archive-new', {
+        archiveFileCreatedAt: new Date('2026-02-01T01:00:00.000Z'),
+      }),
+    ]);
+    const storage = {
+      retrieveStream: vi.fn().mockResolvedValue(Readable.from([Buffer.from('archive')])),
+    };
+    const fileProcessing = {
+      processArchive: vi.fn().mockImplementation(async (archivePath: string) => ({
+        entries: [
+          {
+            filename: 'body.stl',
+            relativePath: 'meshes/body.stl',
+            sizeBytes: 12,
+            hash: 'member-hash',
+          },
+          ...(archivePath.includes('archive-old') ? [{
+            filename: 'unique.stl',
+            relativePath: 'unique.stl',
+            sizeBytes: 7,
+            hash: 'unique-hash',
+          }] : []),
+        ],
+      })),
+    };
+
+    const result = await new DuplicateScannerService(
+      fixture.database as never,
+      storage as never,
+      fileProcessing as never,
+    ).scanDuplicates('library-1');
+
+    expect(result.scannedArchiveFileCount).toBe(2);
+    expect(result.scannedArchiveEntryCount).toBe(3);
+    expect(result.fileGroups).toEqual([]);
+    expect(result.archiveFileGroups).toEqual([{
+      hash: 'member-hash',
+      files: [
+        expect.objectContaining({
+          id: 'archive-old:meshes/body.stl',
+          archiveFileId: 'archive-old',
+          modelId: 'model-old',
+          filename: 'body.stl',
+          relativePath: 'meshes/body.stl',
+        }),
+        expect.objectContaining({
+          id: 'archive-new:meshes/body.stl',
+          archiveFileId: 'archive-new',
+          modelId: 'model-new',
+        }),
+      ],
+    }]);
+  });
+
+  it('skips an unreadable archive without failing the ordinary duplicate scan', async () => {
+    const fixture = databaseReturning([], [], [archiveRow('model-1', 'broken-archive')]);
+    const storage = {
+      retrieveStream: vi.fn().mockRejectedValue(new Error('archive unavailable')),
+    };
+    const fileProcessing = { processArchive: vi.fn() };
+
+    await expect(new DuplicateScannerService(
+      fixture.database as never,
+      storage as never,
+      fileProcessing as never,
+    ).scanDuplicates('library-1')).resolves.toMatchObject({
+      scannedArchiveFileCount: 0,
+      scannedArchiveEntryCount: 0,
+      archiveFileGroups: [],
+    });
+    expect(fileProcessing.processArchive).not.toHaveBeenCalled();
   });
 
   it('excludes ignored whole-model fingerprints while retaining file-level candidates', async () => {

--- a/apps/backend/src/services/duplicate-scanner.service.ts
+++ b/apps/backend/src/services/duplicate-scanner.service.ts
@@ -1,4 +1,9 @@
 import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import fsPromises from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { pipeline } from 'node:stream/promises';
 import { and, asc, eq, sql } from 'drizzle-orm';
 import type { IgnoreDuplicatesResult, MarkDuplicatesResult } from '@alexandria/shared';
 import { db } from '../db/index.js';
@@ -9,12 +14,21 @@ import {
   modelFiles,
   models,
 } from '../db/schema/index.js';
+import { detectArchiveExtension } from '../utils/archive.js';
+import { mapWithConcurrency } from '../utils/concurrency.js';
 import { notFound } from '../utils/errors.js';
 import { createLogger } from '../utils/logger.js';
+import {
+  fileProcessingService,
+  type FileManifest,
+  type FileProcessingService,
+} from './file-processing.service.js';
+import { storageService, type IStorageService } from './storage.service.js';
 
 const logger = createLogger('DuplicateScannerService');
 const MAX_SERIALIZABLE_ATTEMPTS = 3;
 const RETRYABLE_TRANSACTION_CODES = new Set(['40001', '40P01']);
+const ARCHIVE_INSPECTION_CONCURRENCY = 4;
 
 export interface DuplicateScanCandidate {
   id: string;
@@ -46,11 +60,54 @@ export interface DuplicateFileScanGroup {
   files: DuplicateFileScanCandidate[];
 }
 
+export interface DuplicateArchiveMemberScanCandidate {
+  id: string;
+  modelId: string;
+  modelName: string;
+  filename: string;
+  relativePath: string;
+  archiveFileId: string;
+  archiveFilename: string;
+  archiveRelativePath: string;
+  sizeBytes: number;
+  createdAt: Date;
+  modelCreatedAt: Date;
+}
+
+export interface DuplicateArchiveFileScanGroup {
+  hash: string;
+  files: DuplicateArchiveMemberScanCandidate[];
+}
+
+interface ArchiveFileRow {
+  modelId: string;
+  modelName: string;
+  modelCreatedAt: Date;
+  archiveFileId: string;
+  archiveFilename: string;
+  archiveRelativePath: string;
+  archiveStoragePath: string;
+  archiveFileCreatedAt: Date;
+}
+
+interface ArchiveInspectionEntry {
+  hash: string;
+  candidate: DuplicateArchiveMemberScanCandidate;
+}
+
+interface ArchiveInspectionResult {
+  entries: ArchiveInspectionEntry[];
+  succeeded: boolean;
+}
+
 export interface DuplicateScan {
   scannedModelCount: number;
   scannedFileCount: number;
+  scannedArchiveFileCount: number;
+  scannedArchiveEntryCount: number;
   groups: DuplicateScanGroup[];
   fileGroups: DuplicateFileScanGroup[];
+  archiveFileGroups: DuplicateArchiveFileScanGroup[];
 }
 
 export interface IDuplicateScannerService {
@@ -72,7 +129,11 @@ export interface IDuplicateScannerService {
 export class DuplicateScannerService implements IDuplicateScannerService {
   private readonly inFlightByLibrary = new Map<string, Promise<DuplicateScan>>();
 
-  constructor(private readonly database: DatabaseExecutor = db) {}
+  constructor(
+    private readonly database: DatabaseExecutor = db,
+    private readonly storage: IStorageService = storageService,
+    private readonly fileProcessing: FileProcessingService = fileProcessingService,
+  ) {}
 
   /** Coalesce concurrent requests for the same library onto one database scan. */
   scanDuplicates(libraryId: string): Promise<DuplicateScan> {
@@ -102,7 +163,7 @@ export class DuplicateScannerService implements IDuplicateScannerService {
   /** Mark one current, non-ignored file group while preserving other current marks. */
   async markDuplicateFileGroup(libraryId: string, hash: string): Promise<MarkDuplicatesResult> {
     return this.withSerializableTransaction(async (tx) => {
-      const scan = await this.runScan(libraryId, tx);
+      const scan = await this.runScan(libraryId, tx, false);
       const group = scan.fileGroups.find((candidate) => candidate.hash === hash);
       if (!group) throw notFound('Duplicate file group not found');
 
@@ -113,7 +174,7 @@ export class DuplicateScannerService implements IDuplicateScannerService {
   /** Persist one current file-group key, then clear its review flags. */
   async ignoreDuplicateFileGroup(libraryId: string, hash: string): Promise<IgnoreDuplicatesResult> {
     const result = await this.withSerializableTransaction(async (tx) => {
-      const scan = await this.runScan(libraryId, tx);
+      const scan = await this.runScan(libraryId, tx, false);
       const group = scan.fileGroups.find((candidate) => candidate.hash === hash);
       if (!group) throw notFound('Duplicate file group not found');
 
@@ -151,6 +212,7 @@ export class DuplicateScannerService implements IDuplicateScannerService {
   private async runScan(
     libraryId: string,
     executor: DatabaseExecutor = this.database,
+    includeArchiveGroups = true,
   ): Promise<DuplicateScan> {
     // Keep the complete hash multiset aggregation in PostgreSQL so unique-file
     // detail does not cross the database boundary. The second query returns
@@ -214,10 +276,50 @@ export class DuplicateScannerService implements IDuplicateScannerService {
       .from(duplicateModelIgnores)
       .where(eq(duplicateModelIgnores.libraryId, libraryId));
 
-    const [modelRows, duplicateFileRows, ignoredModelRows] = await Promise.all([
+    const archiveFileRowsQuery = includeArchiveGroups
+      ? executor
+        .select({
+          modelId: models.id,
+          modelName: models.name,
+          modelCreatedAt: models.createdAt,
+          archiveFileId: modelFiles.id,
+          archiveFilename: modelFiles.filename,
+          archiveRelativePath: modelFiles.relativePath,
+          archiveStoragePath: modelFiles.storagePath,
+          archiveFileCreatedAt: modelFiles.createdAt,
+        })
+        .from(models)
+        .innerJoin(modelFiles, eq(modelFiles.modelId, models.id))
+        .where(and(
+          eq(models.libraryId, libraryId),
+          eq(models.status, 'ready'),
+          sql<boolean>`lower(${modelFiles.filename}) like '%.zip'
+            or lower(${modelFiles.filename}) like '%.rar'
+            or lower(${modelFiles.filename}) like '%.7z'
+            or lower(${modelFiles.filename}) like '%.tar.gz'
+            or lower(${modelFiles.filename}) like '%.tgz'`,
+        ))
+        .orderBy(asc(modelFiles.createdAt), asc(modelFiles.id))
+      : Promise.resolve([] as ArchiveFileRow[]);
+    const ignoredFileHashesQuery = includeArchiveGroups
+      ? executor
+        .select({ hash: duplicateFileIgnores.hash })
+        .from(duplicateFileIgnores)
+        .where(eq(duplicateFileIgnores.libraryId, libraryId))
+      : Promise.resolve([] as Array<{ hash: string }>);
+
+    const [
+      modelRows,
+      duplicateFileRows,
+      ignoredModelRows,
+      archiveFileRows,
+      ignoredFileHashes,
+    ] = await Promise.all([
       modelRowsQuery,
       duplicateFileRowsQuery,
       ignoredModelRowsQuery,
+      archiveFileRowsQuery,
+      ignoredFileHashesQuery,
     ]);
     const ignoredModelFingerprints = new Set(ignoredModelRows.map((row) => row.fingerprint));
 
@@ -273,10 +375,21 @@ export class DuplicateScannerService implements IDuplicateScannerService {
       .filter(([, files]) => files.length > 1)
       .map(([hash, files]) => ({ hash, files: [...files].sort(compareFileCandidates) }))
       .sort(compareFileGroups);
+    const archiveScan = includeArchiveGroups
+      ? await this.scanArchiveFiles(
+        archiveFileRows,
+        new Set(ignoredFileHashes.map((row) => row.hash)),
+      )
+      : {
+        scannedArchiveFileCount: 0,
+        scannedArchiveEntryCount: 0,
+        archiveFileGroups: [],
+      };
 
     const result: DuplicateScan = {
       scannedModelCount: modelRows.length,
       scannedFileCount: modelRows.reduce((sum, row) => sum + row.hashes.length, 0),
+      ...archiveScan,
       groups,
       fileGroups,
     };
@@ -287,13 +400,125 @@ export class DuplicateScannerService implements IDuplicateScannerService {
         libraryId,
         scannedModelCount: result.scannedModelCount,
         scannedFileCount: result.scannedFileCount,
+        scannedArchiveFileCount: result.scannedArchiveFileCount,
+        scannedArchiveEntryCount: result.scannedArchiveEntryCount,
         duplicateModelGroupCount: result.groups.length,
         duplicateFileGroupCount: result.fileGroups.length,
+        duplicateArchiveFileGroupCount: result.archiveFileGroups.length,
       },
       'Completed duplicate scan',
     );
 
     return result;
+  }
+
+  private async scanArchiveFiles(
+    rows: ArchiveFileRow[],
+    ignoredFileHashes: Set<string>,
+  ): Promise<{
+    scannedArchiveFileCount: number;
+    scannedArchiveEntryCount: number;
+    archiveFileGroups: DuplicateArchiveFileScanGroup[];
+  }> {
+    const archiveFiles = rows.filter((row) => Boolean(detectArchiveExtension(row.archiveFilename)));
+    const inspected = await mapWithConcurrency(
+      archiveFiles,
+      ARCHIVE_INSPECTION_CONCURRENCY,
+      (row) => this.inspectArchiveFile(row, ignoredFileHashes),
+    );
+    const successfulInspections = inspected.filter((inspection) => inspection.succeeded);
+    const entries = successfulInspections.flatMap((inspection) => inspection.entries);
+    const entriesByHash = new Map<string, DuplicateArchiveMemberScanCandidate[]>();
+
+    for (const entry of entries) {
+      const matchingEntries = entriesByHash.get(entry.hash);
+      if (matchingEntries) matchingEntries.push(entry.candidate);
+      else entriesByHash.set(entry.hash, [entry.candidate]);
+    }
+
+    const archiveFileGroups = [...entriesByHash.entries()]
+      .filter(([, candidates]) => new Set(candidates.map((candidate) => candidate.archiveFileId)).size > 1)
+      .map(([hash, files]) => ({ hash, files: [...files].sort(compareArchiveMemberCandidates) }))
+      .sort(compareArchiveFileGroups);
+
+    return {
+      scannedArchiveFileCount: successfulInspections.length,
+      scannedArchiveEntryCount: entries.length,
+      archiveFileGroups,
+    };
+  }
+
+  private async inspectArchiveFile(
+    row: ArchiveFileRow,
+    ignoredFileHashes: Set<string>,
+  ): Promise<ArchiveInspectionResult> {
+    let tempDir: string | undefined;
+    try {
+      tempDir = await fsPromises.mkdtemp(path.join(os.tmpdir(), 'alexandria-duplicate-archive-'));
+      const archiveFilename = path.posix.basename(row.archiveFilename.replaceAll('\\', '/'));
+      const archivePath = path.join(tempDir, archiveFilename);
+      const extractDir = path.join(tempDir, 'contents');
+
+      await pipeline(
+        await this.storage.retrieveStream(row.archiveStoragePath),
+        fs.createWriteStream(archivePath),
+      );
+      const manifest = await this.fileProcessing.processArchive(archivePath, extractDir);
+      return {
+        entries: this.archiveManifestEntries(row, manifest)
+          .filter((entry) => !ignoredFileHashes.has(entry.hash)),
+        succeeded: true,
+      };
+    } catch (error) {
+      logger.warn(
+        {
+          service: 'DuplicateScannerService',
+          archiveFileId: row.archiveFileId,
+          modelId: row.modelId,
+          archiveFilename: row.archiveFilename,
+          error: String(error),
+        },
+        'Skipped unreadable archive during duplicate scan',
+      );
+      return { entries: [], succeeded: false };
+    } finally {
+      if (tempDir) await this.cleanupArchiveInspection(tempDir);
+    }
+  }
+
+  private archiveManifestEntries(
+    row: ArchiveFileRow,
+    manifest: FileManifest,
+  ): ArchiveInspectionEntry[] {
+    return manifest.entries.map((entry) => ({
+      hash: entry.hash,
+      candidate: {
+        id: `${row.archiveFileId}:${entry.relativePath}`,
+        modelId: row.modelId,
+        modelName: row.modelName,
+        filename: entry.filename,
+        relativePath: entry.relativePath,
+        archiveFileId: row.archiveFileId,
+        archiveFilename: row.archiveFilename,
+        archiveRelativePath: row.archiveRelativePath,
+        sizeBytes: entry.sizeBytes,
+        createdAt: row.archiveFileCreatedAt,
+        modelCreatedAt: row.modelCreatedAt,
+      },
+    }));
+  }
+
+  private async cleanupArchiveInspection(tempDir: string): Promise<void> {
+    await fsPromises.rm(tempDir, { recursive: true, force: true }).catch((error: unknown) => {
+      logger.warn(
+        {
+          service: 'DuplicateScannerService',
+          tempDir,
+          error: String(error),
+        },
+        'Failed to remove duplicate archive inspection directory',
+      );
+    });
   }
 
   private async reconcileFlags(
@@ -417,6 +642,25 @@ function compareFileCandidates(
 }
 
 function compareFileGroups(left: DuplicateFileScanGroup, right: DuplicateFileScanGroup): number {
+  return left.files[0].createdAt.getTime() - right.files[0].createdAt.getTime()
+    || compareStrings(left.hash, right.hash)
+    || compareStrings(left.files[0].id, right.files[0].id);
+}
+
+function compareArchiveMemberCandidates(
+  left: DuplicateArchiveMemberScanCandidate,
+  right: DuplicateArchiveMemberScanCandidate,
+): number {
+  return left.createdAt.getTime() - right.createdAt.getTime()
+    || compareStrings(left.id, right.id)
+    || left.modelCreatedAt.getTime() - right.modelCreatedAt.getTime()
+    || compareStrings(left.modelId, right.modelId);
+}
+
+function compareArchiveFileGroups(
+  left: DuplicateArchiveFileScanGroup,
+  right: DuplicateArchiveFileScanGroup,
+): number {
   return left.files[0].createdAt.getTime() - right.files[0].createdAt.getTime()
     || compareStrings(left.hash, right.hash)
     || compareStrings(left.files[0].id, right.files[0].id);

--- a/apps/backend/src/services/presenter.service.test.ts
+++ b/apps/backend/src/services/presenter.service.test.ts
@@ -625,6 +625,8 @@ describe('buildDuplicateScanResult', () => {
     const result = presenterService.buildDuplicateScanResult({
       scannedModelCount: 3,
       scannedFileCount: 5,
+      scannedArchiveFileCount: 0,
+      scannedArchiveEntryCount: 0,
       groups: [
         {
           fingerprint: 'fingerprint',
@@ -674,11 +676,14 @@ describe('buildDuplicateScanResult', () => {
           ],
         },
       ],
+      archiveFileGroups: [],
     });
 
     expect(result).toEqual({
       scannedModelCount: 3,
       scannedFileCount: 5,
+      scannedArchiveFileCount: 0,
+      scannedArchiveEntryCount: 0,
       redundantModelCount: 1,
       redundantFileCount: 1,
       reclaimableBytes: 120,
@@ -732,6 +737,7 @@ describe('buildDuplicateScanResult', () => {
           ],
         },
       ],
+      archiveFileGroups: [],
     });
   });
 });

--- a/apps/backend/src/services/presenter.service.ts
+++ b/apps/backend/src/services/presenter.service.ts
@@ -133,15 +133,42 @@ export class PresenterService implements IPresenterService {
       };
     });
 
+    const archiveFileGroups = scan.archiveFileGroups.map((group) => {
+      const reclaimableBytes = group.files
+        .slice(1)
+        .reduce((sum, file) => sum + file.sizeBytes, 0);
+
+      return {
+        hash: group.hash,
+        sizeBytes: group.files[0].sizeBytes,
+        reclaimableBytes,
+        files: group.files.map((file) => ({
+          id: file.id,
+          modelId: file.modelId,
+          modelName: file.modelName,
+          filename: file.filename,
+          relativePath: file.relativePath,
+          archiveFileId: file.archiveFileId,
+          archiveFilename: file.archiveFilename,
+          archiveRelativePath: file.archiveRelativePath,
+          sizeBytes: file.sizeBytes,
+          createdAt: file.createdAt.toISOString(),
+        })),
+      };
+    });
+
     return {
       scannedModelCount: scan.scannedModelCount,
       scannedFileCount: scan.scannedFileCount,
+      scannedArchiveFileCount: scan.scannedArchiveFileCount,
+      scannedArchiveEntryCount: scan.scannedArchiveEntryCount,
       redundantModelCount: groups.reduce((sum, group) => sum + group.models.length - 1, 0),
       redundantFileCount: fileGroups.reduce((sum, group) => sum + group.files.length - 1, 0),
       reclaimableBytes: groups.reduce((sum, group) => sum + group.reclaimableBytes, 0),
       fileReclaimableBytes: fileGroups.reduce((sum, group) => sum + group.reclaimableBytes, 0),
       groups,
       fileGroups,
+      archiveFileGroups,
     };
   }
 

--- a/apps/frontend/src/api/tools.test.ts
+++ b/apps/frontend/src/api/tools.test.ts
@@ -22,12 +22,15 @@ describe('duplicate tools API', () => {
     const result = {
       scannedModelCount: 0,
       scannedFileCount: 0,
+      scannedArchiveFileCount: 0,
+      scannedArchiveEntryCount: 0,
       redundantModelCount: 0,
       redundantFileCount: 0,
       reclaimableBytes: 0,
       fileReclaimableBytes: 0,
       groups: [],
       fileGroups: [],
+      archiveFileGroups: [],
     };
     vi.mocked(get).mockResolvedValue(envelope(result));
 

--- a/apps/frontend/src/pages/ToolsPage.test.tsx
+++ b/apps/frontend/src/pages/ToolsPage.test.tsx
@@ -31,6 +31,8 @@ const mockConsolidateDuplicateModels = vi.mocked(consolidateDuplicateModels);
 const duplicateScanResult = {
   scannedModelCount: 2,
   scannedFileCount: 2,
+  scannedArchiveFileCount: 0,
+  scannedArchiveEntryCount: 0,
   redundantFileCount: 1,
   fileReclaimableBytes: 100,
   fileGroups: [
@@ -60,6 +62,7 @@ const duplicateScanResult = {
       ],
     },
   ],
+  archiveFileGroups: [],
   redundantModelCount: 0,
   reclaimableBytes: 0,
   groups: [],
@@ -68,9 +71,12 @@ const duplicateScanResult = {
 const emptyScanResult = {
   scannedModelCount: 2,
   scannedFileCount: 2,
+  scannedArchiveFileCount: 0,
+  scannedArchiveEntryCount: 0,
   redundantFileCount: 0,
   fileReclaimableBytes: 0,
   fileGroups: [],
+  archiveFileGroups: [],
   redundantModelCount: 0,
   reclaimableBytes: 0,
   groups: [],
@@ -146,6 +152,8 @@ describe('ToolsPage', () => {
     mockScanDuplicates.mockResolvedValue({
       scannedModelCount: 3,
       scannedFileCount: 8,
+      scannedArchiveFileCount: 2,
+      scannedArchiveEntryCount: 5,
       redundantFileCount: 1,
       fileReclaimableBytes: 1024,
       fileGroups: [
@@ -199,6 +207,39 @@ describe('ToolsPage', () => {
           ],
         },
       ],
+      archiveFileGroups: [
+        {
+          hash: 'matching-archive-member',
+          sizeBytes: 512,
+          reclaimableBytes: 512,
+          files: [
+            {
+              id: 'archive-entry-1',
+              modelId: 'model-1',
+              modelName: 'Dragon original',
+              filename: 'body.stl',
+              relativePath: 'meshes/body.stl',
+              archiveFileId: 'archive-file-1',
+              archiveFilename: 'dragon.zip',
+              archiveRelativePath: 'archives/dragon.zip',
+              sizeBytes: 512,
+              createdAt: '2025-01-01T00:00:00.000Z',
+            },
+            {
+              id: 'archive-entry-2',
+              modelId: 'model-2',
+              modelName: 'Dragon copy',
+              filename: 'body.stl',
+              relativePath: 'meshes/body.stl',
+              archiveFileId: 'archive-file-2',
+              archiveFilename: 'dragon-copy.zip',
+              archiveRelativePath: 'archives/dragon-copy.zip',
+              sizeBytes: 512,
+              createdAt: '2025-02-01T00:00:00.000Z',
+            },
+          ],
+        },
+      ],
     });
 
     render(<ToolsPage />, { wrapper: makeWrapper() });
@@ -206,12 +247,20 @@ describe('ToolsPage', () => {
 
     await waitFor(() => expect(screen.getByRole('heading', { name: 'Duplicate files' })).toBeTruthy());
     expect(screen.getByText('body-copy.stl')).toBeTruthy();
-    expect(screen.getByText('meshes/body.stl')).toBeTruthy();
+    expect(screen.getAllByText('meshes/body.stl')).toHaveLength(3);
     expect(
       screen.getAllByRole('link', { name: 'Dragon original' })[0].getAttribute('href'),
     ).toBe('/models/model-1');
     expect(screen.getByText('Suggested keep').parentElement?.textContent).toContain('body.stl');
     expect(screen.getByRole('heading', { name: 'Whole-model duplicates' })).toBeTruthy();
+    expect(screen.getByRole('heading', { name: 'Duplicate archive members' })).toBeTruthy();
+    expect(screen.getByText('archives/dragon.zip')).toBeTruthy();
+    expect(screen.getByText('archives/dragon-copy.zip')).toBeTruthy();
+    expect(screen.getByText('Informational only')).toBeTruthy();
+    expect(screen.queryByRole('button', { name: /mark duplicates in archive/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: /ignore duplicates in archive/i })).toBeNull();
+    expect(screen.getByText('Archive files scanned').nextElementSibling?.textContent).toBe('2');
+    expect(screen.getByText('Archive entries scanned').nextElementSibling?.textContent).toBe('5');
     expect(screen.getByText('Oldest copy')).toBeTruthy();
     expect(screen.getByText('Files scanned').nextElementSibling?.textContent).toBe('8');
     expect(screen.getByRole('button', { name: /mark duplicates in file set 1/i })).toBeTruthy();
@@ -279,6 +328,8 @@ describe('ToolsPage', () => {
     finishScan({
       scannedModelCount: 2,
       scannedFileCount: 5,
+      scannedArchiveFileCount: 0,
+      scannedArchiveEntryCount: 0,
       redundantFileCount: 1,
       fileReclaimableBytes: 100,
       fileGroups: [
@@ -311,6 +362,7 @@ describe('ToolsPage', () => {
       redundantModelCount: 0,
       reclaimableBytes: 0,
       groups: [],
+      archiveFileGroups: [],
     });
 
     await waitFor(() => {
@@ -324,18 +376,21 @@ describe('ToolsPage', () => {
     mockScanDuplicates.mockResolvedValue({
       scannedModelCount: 4,
       scannedFileCount: 12,
+      scannedArchiveFileCount: 0,
+      scannedArchiveEntryCount: 0,
       redundantFileCount: 0,
       fileReclaimableBytes: 0,
       fileGroups: [],
       redundantModelCount: 0,
       reclaimableBytes: 0,
       groups: [],
+      archiveFileGroups: [],
     });
 
     render(<ToolsPage />, { wrapper: makeWrapper() });
     fireEvent.click(screen.getByRole('button', { name: /scan library/i }));
 
-    await waitFor(() => expect(screen.getByText(/no duplicate files or models found/i)).toBeTruthy());
+    await waitFor(() => expect(screen.getByText(/no duplicate files, models, or archive members found/i)).toBeTruthy());
     expect(screen.getByText(/compared 12 files across 4 ready models/i)).toBeTruthy();
   });
 
@@ -344,18 +399,21 @@ describe('ToolsPage', () => {
       .mockResolvedValueOnce({
         scannedModelCount: 1,
         scannedFileCount: 1,
+        scannedArchiveFileCount: 0,
+        scannedArchiveEntryCount: 0,
         redundantFileCount: 0,
         fileReclaimableBytes: 0,
         fileGroups: [],
         redundantModelCount: 0,
         reclaimableBytes: 0,
         groups: [],
+        archiveFileGroups: [],
       })
       .mockRejectedValueOnce(new Error('scan failed'));
 
     render(<ToolsPage />, { wrapper: makeWrapper() });
     fireEvent.click(screen.getByRole('button', { name: /scan library/i }));
-    await waitFor(() => expect(screen.getByText(/no duplicate files or models found/i)).toBeTruthy());
+    await waitFor(() => expect(screen.getByText(/no duplicate files, models, or archive members found/i)).toBeTruthy());
 
     fireEvent.click(screen.getByRole('button', { name: /scan again/i }));
 
@@ -444,7 +502,7 @@ describe('ToolsPage', () => {
     });
     expect(mockIgnoreDuplicateFileGroup).toHaveBeenCalledWith('same-file');
     expect(mockScanDuplicates).toHaveBeenCalledTimes(2);
-    expect(screen.getByText(/no duplicate files or models found/i)).toBeTruthy();
+    expect(screen.getByText(/no duplicate files, models, or archive members found/i)).toBeTruthy();
   });
 
   it('announces an accessible error for the file set action that failed', async () => {

--- a/apps/frontend/src/pages/ToolsPage.tsx
+++ b/apps/frontend/src/pages/ToolsPage.tsx
@@ -2,18 +2,25 @@ import { useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
   ArrowLeft,
+  Archive,
   CheckCircle2,
   Combine,
   Copy,
   EyeOff,
   FileSearch,
+  Info,
   Loader2,
   RefreshCw,
   Tags,
   Wrench,
 } from 'lucide-react';
 import { Link } from 'react-router-dom';
-import type { DuplicateFile, DuplicateModel, DuplicateScanResult } from '@alexandria/shared';
+import type {
+  DuplicateArchiveFile,
+  DuplicateFile,
+  DuplicateModel,
+  DuplicateScanResult,
+} from '@alexandria/shared';
 import {
   ignoreDuplicateFileGroup,
   markDuplicateFileGroup,
@@ -281,8 +288,13 @@ function duplicateScanAnnouncement(result: DuplicateScanResult): string {
   const redundantFiles = countPhrase(result.redundantFileCount, 'redundant file');
   const modelGroups = countPhrase(result.groups.length, 'duplicate model group');
   const redundantModels = countPhrase(result.redundantModelCount, 'redundant model');
+  const archiveGroups = countPhrase(result.archiveFileGroups.length, 'duplicate archive group');
+  const archiveMembers = countPhrase(
+    result.archiveFileGroups.reduce((sum, group) => sum + group.files.length - 1, 0),
+    'redundant archive member',
+  );
 
-  return `Scan complete. Found ${fileGroups} with ${redundantFiles}, and ${modelGroups} with ${redundantModels}.`;
+  return `Scan complete. Found ${fileGroups} with ${redundantFiles}, ${modelGroups} with ${redundantModels}, and ${archiveGroups} with ${archiveMembers}.`;
 }
 
 function countPhrase(count: number, singular: string): string {
@@ -310,18 +322,27 @@ function DuplicateResults({
 }) {
   const hasDuplicateFiles = result.fileGroups.length > 0;
   const hasDuplicateModels = result.groups.length > 0;
+  const hasDuplicateArchiveFiles = result.archiveFileGroups.length > 0;
+  const hasArchiveScan =
+    hasDuplicateArchiveFiles ||
+    result.scannedArchiveFileCount > 0 ||
+    result.scannedArchiveEntryCount > 0;
 
-  if (!hasDuplicateFiles && !hasDuplicateModels) {
+  if (!hasDuplicateFiles && !hasDuplicateModels && !hasArchiveScan) {
     return (
       <div className="flex flex-col items-center justify-center gap-3 py-10 text-center">
         <CheckCircle2 className="h-9 w-9 text-emerald-600" />
         <div>
-          <p className="font-medium text-foreground">No duplicate files or models found</p>
+          <p className="font-medium text-foreground">No duplicate files, models, or archive members found</p>
           <p className="mt-1 text-sm text-muted-foreground">
             Compared {result.scannedFileCount.toLocaleString()}{' '}
             {result.scannedFileCount === 1 ? 'file' : 'files'} across{' '}
             {result.scannedModelCount.toLocaleString()}{' '}
-            {result.scannedModelCount === 1 ? 'ready model' : 'ready models'}.
+            {result.scannedModelCount === 1 ? 'ready model' : 'ready models'} and{' '}
+            {result.scannedArchiveEntryCount.toLocaleString()}{' '}
+            {result.scannedArchiveEntryCount === 1 ? 'archive entry' : 'archive entries'} from{' '}
+            {result.scannedArchiveFileCount.toLocaleString()}{' '}
+            {result.scannedArchiveFileCount === 1 ? 'archive file' : 'archive files'}.
           </p>
         </div>
       </div>
@@ -330,31 +351,33 @@ function DuplicateResults({
 
   return (
     <div className="flex flex-col gap-6">
-      <section
-        aria-labelledby="duplicate-actions-heading"
-        className="flex flex-col gap-4 rounded-lg border border-amber-500/30 bg-amber-500/5 p-4 sm:flex-row sm:items-center sm:justify-between"
-      >
-        <div>
-          <h2 id="duplicate-actions-heading" className="text-sm font-semibold text-foreground">
-            Review these duplicate results
-          </h2>
-          <p className="mt-1 max-w-2xl text-sm text-muted-foreground">
-            Marking adds a Duplicate indicator to every reported file and to any model whose every
-            file is duplicated. You can also mark or ignore one duplicate file set at a time below.
-            Ignoring a set clears its existing Duplicate indicators. No review action deletes files.
-          </p>
-        </div>
-        <div className="flex flex-shrink-0 flex-wrap gap-2">
-          <Button onClick={onMarkAll} disabled={actionsDisabled}>
-            {markingAll ? (
-              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-            ) : (
-              <Tags className="mr-2 h-4 w-4" />
-            )}
-            {markingAll ? 'Marking…' : 'Mark all duplicates'}
-          </Button>
-        </div>
-      </section>
+      {(hasDuplicateFiles || hasDuplicateModels) && (
+        <section
+          aria-labelledby="duplicate-actions-heading"
+          className="flex flex-col gap-4 rounded-lg border border-amber-500/30 bg-amber-500/5 p-4 sm:flex-row sm:items-center sm:justify-between"
+        >
+          <div>
+            <h2 id="duplicate-actions-heading" className="text-sm font-semibold text-foreground">
+              Review these duplicate results
+            </h2>
+            <p className="mt-1 max-w-2xl text-sm text-muted-foreground">
+              Marking adds a Duplicate indicator to every reported file and to any model whose every
+              file is duplicated. You can also mark or ignore one duplicate file set at a time below.
+              Ignoring a set clears its existing Duplicate indicators. No review action deletes files.
+            </p>
+          </div>
+          <div className="flex flex-shrink-0 flex-wrap gap-2">
+            <Button onClick={onMarkAll} disabled={actionsDisabled}>
+              {markingAll ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : (
+                <Tags className="mr-2 h-4 w-4" />
+              )}
+              {markingAll ? 'Marking…' : 'Mark all duplicates'}
+            </Button>
+          </div>
+        </section>
+      )}
 
       <section aria-labelledby="duplicate-files-heading" className="flex flex-col gap-4">
         <div>
@@ -460,6 +483,74 @@ function DuplicateResults({
           </p>
         )}
       </section>
+
+      {hasArchiveScan && (
+        <section
+          aria-labelledby="duplicate-archive-members-heading"
+          className="flex flex-col gap-4 border-t pt-6"
+        >
+          <div className="flex items-start gap-3">
+            <div className="rounded-lg bg-muted p-2 text-foreground">
+              <Archive className="h-5 w-5" />
+            </div>
+            <div>
+              <h2
+                id="duplicate-archive-members-heading"
+                className="text-base font-semibold text-foreground"
+              >
+                Duplicate archive members
+              </h2>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Matching entries found inside stored archive files. These results are informational
+                only; archive members do not have mark or ignore actions here.
+              </p>
+            </div>
+          </div>
+
+          <div className="flex items-start gap-2 rounded-lg border border-sky-500/30 bg-sky-500/5 p-3 text-sm text-foreground">
+            <Info className="mt-0.5 h-4 w-4 flex-shrink-0 text-sky-600" />
+            <p>
+              Archive members are nested content. Review the containing archive and model before
+              deciding whether any physical file needs attention.
+            </p>
+          </div>
+
+          <div className="grid grid-cols-2 gap-3 lg:grid-cols-3">
+            <ScanStat label="Archive files scanned" value={result.scannedArchiveFileCount.toLocaleString()} />
+            <ScanStat label="Archive entries scanned" value={result.scannedArchiveEntryCount.toLocaleString()} />
+            <ScanStat label="Duplicate archive groups" value={result.archiveFileGroups.length.toLocaleString()} />
+          </div>
+
+          {hasDuplicateArchiveFiles ? (
+            <div className="flex flex-col gap-4">
+              {result.archiveFileGroups.map((group, index) => (
+                <div key={group.hash} className="overflow-hidden rounded-lg border">
+                  <div className="flex flex-col gap-3 border-b bg-muted/30 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
+                    <div>
+                      <h3 className="text-sm font-semibold text-foreground">
+                        Duplicate archive member set {index + 1}
+                      </h3>
+                      <p className="text-xs text-muted-foreground">
+                        {group.files.length} identical members · {formatFileSize(group.sizeBytes)} each
+                      </p>
+                    </div>
+                    <Badge variant="outline">Informational only</Badge>
+                  </div>
+                  <div className="divide-y">
+                    {group.files.map((file) => (
+                      <DuplicateArchiveFileRow key={file.id} file={file} />
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p className="rounded-lg border bg-muted/20 px-4 py-3 text-sm text-muted-foreground">
+              No duplicate archive members were found.
+            </p>
+          )}
+        </section>
+      )}
 
       {hasDuplicateModels && (
         <section
@@ -567,6 +658,38 @@ function DuplicateFileRow({
         </Link>
         <span className="whitespace-nowrap text-xs text-muted-foreground">
           Added {formatDate(file.createdAt)}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function DuplicateArchiveFileRow({ file }: { file: DuplicateArchiveFile }) {
+  const libPath = useLibraryPath();
+
+  return (
+    <div className="flex flex-col gap-3 px-4 py-3 sm:flex-row sm:items-start sm:justify-between">
+      <div className="min-w-0">
+        <p className="truncate text-sm font-medium text-foreground">{file.filename}</p>
+        <p className="mt-0.5 truncate font-mono text-xs text-muted-foreground" title={file.relativePath}>
+          {file.relativePath}
+        </p>
+        <p className="mt-2 text-xs text-muted-foreground">
+          Archive: <span className="font-medium text-foreground">{file.archiveFilename}</span>
+        </p>
+        <p className="truncate font-mono text-xs text-muted-foreground" title={file.archiveRelativePath}>
+          {file.archiveRelativePath}
+        </p>
+      </div>
+      <div className="flex shrink-0 flex-col items-start gap-1 sm:items-end">
+        <Link
+          to={libPath(`/models/${file.modelId}`)}
+          className="text-sm font-medium text-foreground hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          {file.modelName}
+        </Link>
+        <span className="whitespace-nowrap text-xs text-muted-foreground">
+          {formatFileSize(file.sizeBytes)} · Added {formatDate(file.createdAt)}
         </span>
       </div>
     </div>

--- a/docs/API.md
+++ b/docs/API.md
@@ -1604,6 +1604,8 @@ Scan the active library for exact duplicate files and exact duplicate model cont
 
 Only `ready` models with at least one file are scanned. PostgreSQL aggregates each eligible model's file hashes into one model row and returns individual file detail only for hashes that occur more than once in the same library/status scope. Individual files are duplicates when their SHA-256 hashes match. Two models are duplicates only when their complete sorted multisets of per-file SHA-256 hashes match. Sorting makes file order irrelevant, while treating the hashes as a multiset preserves multiplicity: a model containing two copies of a file does not match a model containing one copy. Filenames and relative paths do not participate in either comparison. File hashes and whole-model fingerprints stored as ignored for the active library are excluded.
 
+Supported stored archives (`zip`, `rar`, `7z`, `tar.gz`, and `tgz`) are also inspected for duplicate members. Each archive is extracted in an isolated temporary directory through the existing `FileProcessingService` safeguards, including archive path and link protections; unreadable archives are skipped so they do not fail the physical-file scan. Matching archive members are reported separately in `archiveFileGroups` and are informational only.
+
 **Response (200):**
 
 ```json
@@ -1611,6 +1613,8 @@ Only `ready` models with at least one file are scanned. PostgreSQL aggregates ea
   "data": {
     "scannedModelCount": 3,
     "scannedFileCount": 6,
+    "scannedArchiveFileCount": 2,
+    "scannedArchiveEntryCount": 5,
     "redundantModelCount": 1,
     "redundantFileCount": 3,
     "reclaimableBytes": 1000,
@@ -1697,6 +1701,39 @@ Only `ready` models with at least one file are scanned. PostgreSQL aggregates ea
           }
         ]
       }
+    ],
+    "archiveFileGroups": [
+      {
+        "hash": "3333333333333333333333333333333333333333333333333333333333333333",
+        "sizeBytes": 500,
+        "reclaimableBytes": 500,
+        "files": [
+          {
+            "id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa4:meshes/dragon-body.stl",
+            "modelId": "11111111-1111-4111-8111-111111111111",
+            "modelName": "Dragon Bust",
+            "filename": "dragon-body.stl",
+            "relativePath": "meshes/dragon-body.stl",
+            "archiveFileId": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa4",
+            "archiveFilename": "dragon-bust.zip",
+            "archiveRelativePath": "archives/dragon-bust.zip",
+            "sizeBytes": 500,
+            "createdAt": "2026-01-15T10:33:00.000Z"
+          },
+          {
+            "id": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb3:parts/body.stl",
+            "modelId": "22222222-2222-4222-8222-222222222222",
+            "modelName": "Dragon Bust Copy",
+            "filename": "body.stl",
+            "relativePath": "parts/body.stl",
+            "archiveFileId": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb3",
+            "archiveFilename": "renamed-copy.zip",
+            "archiveRelativePath": "renamed-copy.zip",
+            "sizeBytes": 500,
+            "createdAt": "2026-02-01T12:03:00.000Z"
+          }
+        ]
+      }
     ]
   },
   "meta": null,
@@ -1707,6 +1744,8 @@ Only `ready` models with at least one file are scanned. PostgreSQL aggregates ea
 `data` is a `DuplicateScanResult`. Each member of `groups` is a `DuplicateGroup`, whose `models` are `DuplicateModel` values. The fingerprint is the SHA-256 digest of the encoded sorted file-hash multiset and should be treated as an opaque group identifier. Models within a group are oldest-first, with UUID as the equal-timestamp tie-breaker; groups are likewise ordered by their oldest model. `scannedModelCount` counts eligible models whether or not they belong to a duplicate group. `redundantModelCount` counts duplicate copies beyond the oldest model in each group. Group and scan `reclaimableBytes` sum the stored sizes of those later copies; `totalSizeBytes` is the oldest model's stored total.
 
 Each member of `fileGroups` is a `DuplicateFileGroup`, whose `files` are `DuplicateFile` values. `scannedFileCount` counts all files read from eligible models. Within a file group, candidates are ordered by file creation time and file UUID, with owning model creation time and model UUID as later tie-breakers. `sizeBytes` is the oldest candidate's stored size, while `reclaimableBytes` sums every later candidate's size. `redundantFileCount` and `fileReclaimableBytes` aggregate those later candidates across all file groups. File groups are ordered by their oldest file's creation time, then hash and oldest file UUID.
+
+`scannedArchiveFileCount` counts supported stored archive files that were successfully extracted, and `scannedArchiveEntryCount` counts their extracted manifest entries. Unreadable or otherwise rejected archives are skipped and do not contribute to either count. `archiveFileGroups` contains `DuplicateArchiveFileGroup` values for archive members with matching SHA-256 hashes in different stored archive files. Each member includes the physical model and archive context (`archiveFileId`, `archiveFilename`, and `archiveRelativePath`) in addition to its entry path, size, and timestamp. Archive-member groups are informational and read-only: they do not contribute to `redundantFileCount`, `fileReclaimableBytes`, or physical-file flags, and the existing physical file mark and ignore endpoints continue to operate only on `fileGroups`.
 
 The example's `Dragon Bust Variant` has one file identical to both whole-model copies but different remaining content, so it appears in a file group without joining the whole-model group. File-level savings are independent from and may overlap whole-model savings; do not add `fileReclaimableBytes` to `reclaimableBytes`. All byte values are estimates only—the decision and any deletion remain manual.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -390,11 +390,13 @@ On startup, S3 mode performs `HeadBucket` validation before database migration a
 
 ### DuplicateScannerService
 
-**Owns:** Detection and reporting of exact duplicate files and exact duplicate models within one authenticated user's active library, persisted duplicate-review flags, library-scoped ignored duplicate identities, and reconciliation of those flags after file membership changes.
+**Owns:** Detection and reporting of exact duplicate physical files, duplicate archive members, and exact duplicate models within one authenticated user's active library, persisted duplicate-review flags, library-scoped ignored duplicate identities, and reconciliation of those flags after file membership changes.
 
 **Does not own:** File hashing, model/file deletion, or model merging. ModelService performs structural mutations and then delegates duplicate-flag reconciliation back to DuplicateScannerService.
 
 **Behavior:** `scanDuplicates(libraryId)` considers only `ready` models that have at least one file. The route supplies the ownership-checked `request.libraryId` produced by `requireLibrary`, and concurrent requests for the same library share one in-flight scan. PostgreSQL aggregates every eligible model's complete sorted multiset of file hashes into one row per model; a second query returns file detail only for hashes that occur more than once in the same scope. Library-scoped ignored file hashes and whole-model fingerprints are removed from the report. This bounds transferred and retained detail to actual, non-ignored duplicate-file candidates instead of every stored file. Whole-model identity remains independent of file order while preserving repeated hashes: a model containing the same file twice does not match one containing it once. Filenames and relative paths participate in neither form of matching, and only file hashes or whole-model identities shared by at least two candidates are returned.
+
+The scan separately selects stored files with supported archive extensions (`zip`, `rar`, `7z`, `tar.gz`, and `tgz`) and extracts each one in an isolated temporary directory through `FileProcessingService.processArchive`. That reuses the existing archive path and link safeguards and produces the member manifest and hashes without creating `ModelFile` rows. Unreadable or rejected archives are logged and skipped. Matching members are grouped only when they occur in different archive files; `scannedArchiveFileCount`, `scannedArchiveEntryCount`, and `archiveFileGroups` are returned as informational, read-only data. They do not participate in physical-file mark/ignore actions, which continue to use the existing `fileGroups` report and persistence paths.
 
 File candidates are ordered by file creation time and file UUID, with owning-model creation time and model UUID as later tie-breakers. File groups are ordered by their oldest file's creation time, then hash and oldest file UUID. Whole-model candidates remain oldest-first by model creation time and UUID, and whole-model groups are ordered by their oldest model, with fingerprint as the final tie-breaker. PresenterService formats timestamps and assembles per-group and aggregate counts and two independent reclaimable-byte estimates. File-level savings can overlap whole-model savings, so clients must not add `fileReclaimableBytes` to `reclaimableBytes`.
 
@@ -818,7 +820,7 @@ All provider routes apply `requireAuth` and enforce provider ownership in `AiPro
 **Tools**
 | Method | Route | Purpose | Service Chain | Library-scoped |
 |--------|-------|---------|---------------|---------------|
-| GET | /tools/duplicates | Report exact duplicate files and ready models with identical complete file-hash multisets | DuplicateScannerService → PresenterService | Yes |
+| GET | /tools/duplicates | Report exact duplicate physical files, archive members, and ready models with identical complete file-hash multisets | DuplicateScannerService → PresenterService | Yes |
 | POST | /tools/duplicates/mark | Mark every file in the current non-ignored scan | DuplicateScannerService | Yes |
 | POST | /tools/duplicates/file-groups/:hash/mark | Mark one current duplicate file set | DuplicateScannerService | Yes |
 | POST | /tools/duplicates/file-groups/:hash/ignore | Ignore one current duplicate file set and clear its flags | DuplicateScannerService | Yes |

--- a/packages/shared/src/types/tools.ts
+++ b/packages/shared/src/types/tools.ts
@@ -30,15 +30,39 @@ export interface DuplicateFileGroup {
   files: DuplicateFile[];
 }
 
+/** A duplicate archive member reported for information only. */
+export interface DuplicateArchiveFile {
+  id: string;
+  modelId: string;
+  modelName: string;
+  filename: string;
+  relativePath: string;
+  archiveFileId: string;
+  archiveFilename: string;
+  archiveRelativePath: string;
+  sizeBytes: number;
+  createdAt: string;
+}
+
+export interface DuplicateArchiveFileGroup {
+  hash: string;
+  sizeBytes: number;
+  reclaimableBytes: number;
+  files: DuplicateArchiveFile[];
+}
+
 export interface DuplicateScanResult {
   scannedModelCount: number;
   scannedFileCount: number;
+  scannedArchiveFileCount: number;
+  scannedArchiveEntryCount: number;
   redundantModelCount: number;
   redundantFileCount: number;
   reclaimableBytes: number;
   fileReclaimableBytes: number;
   groups: DuplicateGroup[];
   fileGroups: DuplicateFileGroup[];
+  archiveFileGroups: DuplicateArchiveFileGroup[];
 }
 
 export interface MarkDuplicatesResult {


### PR DESCRIPTION
## Summary
- inspect supported stored archives during duplicate scans using existing safe extraction
- report matching archive members separately as informational-only results
- add shared API types, presenter mapping, UI display, tests, and docs

## Validation
- npm run build -w @alexandria/backend
- npm run build -w @alexandria/frontend
- focused backend and frontend tests
- tools duplicate integration suite
- npm run lint

The full repository test run reached 400 passing tests but encountered one unrelated timeout in `apps/frontend/src/components/models/FileTree.test.tsx`.