### PR TITLE
feat: add Telegram message-link download mode

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -115,17 +115,18 @@ PostgreSQL stores metadata and application state, not model-file bytes. Moving o
 
 ### Companion utilities
 
-`tools/telegram-importer/` is an optional, separately installed Python userbot CLI. It reads
-Telegram channel history with Telethon and drives Alexandria exclusively through the existing
-authenticated staged-upload API. It is not part of the backend runtime and does not write to the
-database or storage adapter directly. Complete archives use the normal chunked upload path, split
-ZIP/RAR sets use multipart `split` mode, and preceding Telegram media is appended to the staged
-session before commit. The utility owns its SQLite restart and duplicate state and short-lived local
-downloads; Alexandria continues to own all committed files through its configured local or S3
-storage backend. On an interactive terminal it renders a live progress dashboard on stderr — the
-reason it carries `rich`, its only presentation dependency — and falls back to periodic log lines
-when output is captured. That display is strictly observational: it is injected into the importer
-and cannot alter, delay, or fail an import.
+`tools/telegram-importer/` is an optional, separately installed Python userbot CLI. With Telethon,
+it can either scan one Telegram channel's history or resolve the exact messages in a multi-channel
+link file without scanning intervening history. It drives Alexandria exclusively through the
+existing authenticated staged-upload API; it is not part of the backend runtime and does not write
+to the database or storage adapter directly. Complete archives use the normal chunked upload path,
+split ZIP/RAR sets use multipart `split` mode, and preceding Telegram media is appended to the
+staged session before commit. The utility owns its SQLite restart and duplicate state and
+short-lived local downloads; Alexandria continues to own all committed files through its configured
+local or S3 storage backend. On an interactive terminal it renders a live progress dashboard on
+stderr — the reason it carries `rich`, its only presentation dependency — and falls back to periodic
+log lines when output is captured. That display is strictly observational: it is injected into the
+importer and cannot alter, delay, or fail an import.
 
 The staged path remains manual by default, including its existing operator pause, and can optionally
 orchestrate Codex as a non-interactive, per-bundle cleanup worker. Automated cleanup requires a

--- a/tools/telegram-importer/README.md
+++ b/tools/telegram-importer/README.md
@@ -107,6 +107,9 @@ The default run sends every model straight to Alexandria. A staged import splits
 # Stage 20 bundles as folders and exit
 uv run alexandria-telegram-import --download-only 20 --staging-dir ./work
 
+# Stage only the messages named in a link file and exit
+uv run alexandria-telegram-import --download-only ./message-links.txt --staging-dir ./work
+
 # Upload every model folder currently in ./work and exit
 uv run alexandria-telegram-import --upload-only --staging-dir ./work
 
@@ -124,6 +127,49 @@ uv run alexandria-telegram-import \
 ```
 
 All three require `--staging-dir`, and `--staging-dir` requires one of them. `TELEGRAM_STAGING_DIR` sets the default directory. `--concurrency` applies to both phases: N bundles stage at once, and N folders upload at once. `--upload-only` is entirely local — it needs no Telegram credentials and opens no Telegram session — and combining it with `--dry-run` prints what would be uploaded without contacting Alexandria. Manual cleanup remains the default: `--stage N` without `--cleanup codex` prints one staging summary and waits for Enter before uploading exactly as before. Enter `q` to leave the folders for a later `--upload-only`; a non-interactive standard input is treated as quitting rather than hanging. Automated cleanup skips this pause and drains batches continuously.
+
+### Downloading selected message links
+
+Pass a text file instead of a number to `--download-only` to stage an exact
+selection without scanning the rest of a channel:
+
+```text
+# message-links.txt — blank lines and whole-line comments are allowed
+https://t.me/public_channel/2501
+https://t.me/public_channel/2502?single
+https://t.me/c/2050123456/901
+```
+
+```bash
+uv run alexandria-telegram-import \
+  --download-only ./message-links.txt \
+  --staging-dir ./work
+```
+
+Public channel links, public preview links using `/s/`, and private channel
+links using `/c/` are accepted. Duplicate links are downloaded once, and one
+file may select messages from several channels visible to the signed-in
+Telegram account. The links select the source channels, so `--channel`,
+`TELEGRAM_CHANNEL`, and `--from-message-id` do not affect this mode.
+
+Only the linked messages are fetched. They are ordered by message ID within
+each channel and passed through the normal grouping rules, then written in the
+same staging-folder layout as numeric `--download-only`. A gap containing an
+unlisted message starts a new grouping run, so distant selected model posts do
+not get merged just because the messages between them were filtered out.
+Include every model archive part and any immediately preceding attachments you
+want in the staged bundle; the importer does not fetch unlisted neighboring
+messages. A missing message, a text-only message, or selected attachment media
+with no following selected model is reported and makes the command exit with
+status 1. Use `--dry-run` with the same arguments to inspect the selected
+grouping without downloading.
+
+Staged state records the attachment message IDs assigned to each model bundle,
+so rerunning the same selection safely skips bundles already staged. If a rerun
+assigns different attachments to the same bundle, or an older state row has an
+unknown attachment selection, the command exits with status 1. Reconcile or
+remove the existing staged folder and matching state before retrying; the
+importer will not silently replace it.
 
 ### Automated Codex cleanup
 
@@ -425,7 +471,7 @@ The importer uploads these through Alexandria's multipart endpoints in `split` m
 
 A standalone model file such as an STL is wrapped in a temporary ZIP before upload. Existing archives are uploaded as-is. Uploads use Alexandria's 10 MB chunk protocol and retry each failed chunk up to three times.
 
-The committed model name comes from the logical filename with its recognized extension removed and underscores and hyphens changed to spaces. Its description contains unique captions from the assigned attachments and the model's own message or parts, the related-model note when applicable, the channel ID and model message IDs, and a `t.me` source link when the channel has a public username. Descriptions are limited to Alexandria's 2,000-character request limit.
+The committed model name comes from the logical filename with its recognized extension removed and underscores and hyphens changed to spaces. Its description contains unique captions from the assigned attachments and the model's own message or parts, the related-model note when applicable, the channel ID and model message IDs, and a `t.me` source link for public or private channels. Descriptions are limited to Alexandria's 2,000-character request limit.
 
 ## Duplicate detection
 

--- a/tools/telegram-importer/src/alexandria_telegram_importer/cli.py
+++ b/tools/telegram-importer/src/alexandria_telegram_importer/cli.py
@@ -25,6 +25,7 @@ from .folder_metadata import read_metadata
 from .folder_upload import FolderUploader, delete_committed, describe_staging
 from .grouping import build_bundles
 from .importer import ChannelImporter, describe_plan
+from .message_links import group_message_links, read_message_links
 from .models import MediaRef
 from .parallel_download import DEFAULT_CONNECTIONS, MAX_CONNECTIONS
 from .progress import (
@@ -66,6 +67,17 @@ def _positive(value: str) -> int:
         raise argparse.ArgumentTypeError(
             f"count must be an integer, got {value!r}"
         ) from error
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("count must be at least 1")
+    return parsed
+
+
+def _download_selection(value: str) -> int | Path:
+    """Accept the legacy bundle count or a file containing exact message links."""
+    try:
+        parsed = int(value)
+    except ValueError:
+        return Path(value)
     if parsed < 1:
         raise argparse.ArgumentTypeError("count must be at least 1")
     return parsed
@@ -173,9 +185,12 @@ def parser() -> argparse.ArgumentParser:
     staging_mode = result.add_mutually_exclusive_group()
     staging_mode.add_argument(
         "--download-only",
-        type=_positive,
-        metavar="N",
-        help="Stage up to N new Telegram bundles as folders, then exit",
+        type=_download_selection,
+        metavar="N|FILE",
+        help=(
+            "Stage up to N new Telegram bundles, or stage only messages listed "
+            "as Telegram links in FILE, then exit"
+        ),
     )
     staging_mode.add_argument(
         "--upload-only",
@@ -436,6 +451,9 @@ async def stage_bundles(
                     model_message_ids=tuple(
                         part.message_id for unit in bundle.models for part in unit.parts
                     ),
+                    attachment_message_ids=tuple(
+                        ref.message_id for ref in bundle.attachments
+                    ),
                 ),
             )
             staged_bytes += size
@@ -635,6 +653,132 @@ def _cleanup_summary(outcomes: dict[str, int]) -> str:
     return "Cleanup state: " + ", ".join(
         f"{status}={count}" for status, count in sorted(outcomes.items())
     )
+
+
+def _contiguous_refs(refs: list[MediaRef]) -> tuple[list[MediaRef], ...]:
+    """Split exact selections where an unlisted Telegram message creates a gap."""
+    runs: list[list[MediaRef]] = []
+    for ref in sorted(refs, key=lambda item: item.message_id):
+        if not runs or ref.message_id != runs[-1][-1].message_id + 1:
+            runs.append([])
+        runs[-1].append(ref)
+    return tuple(runs)
+
+
+async def download_linked_messages(
+    *,
+    args: argparse.Namespace,
+    telegram: TelegramSource,
+    tracker: ImportTracker | None,
+    progress: ProgressReporter,
+) -> int:
+    """Stage only media explicitly named by a message-link file."""
+    try:
+        links = read_message_links(args.download_only)
+    except ValueError as error:
+        raise SystemExit(str(error)) from error
+
+    groups = group_message_links(links)
+    staged = 0
+    staged_bytes = 0
+    failed = 0
+    selected = 0
+    plans: list[str] = []
+
+    for index, (channel, message_ids) in enumerate(groups):
+        if index == 0:
+            await telegram.connect(channel)
+        else:
+            await telegram.select_channel(channel)
+        refs, unavailable = await telegram.collect_media_by_ids(message_ids)
+        selected += len(message_ids)
+        for message_id in unavailable:
+            log.error(
+                "Telegram message %s has no downloadable media or is unavailable",
+                telegram.message_link(message_id) or message_id,
+            )
+
+        runs = _contiguous_refs(refs)
+        run_bundles = [
+            (run, list(build_bundles(telegram.channel_id, run))) for run in runs
+        ]
+        bundles = [bundle for _, items in run_bundles for bundle in items]
+        consumed_ids = {
+            ref.message_id
+            for bundle in bundles
+            for ref in (
+                *bundle.attachments,
+                *(part for model in bundle.models for part in model.parts),
+            )
+        }
+        ignored = [ref.message_id for ref in refs if ref.message_id not in consumed_ids]
+        for message_id in ignored:
+            log.error(
+                "Telegram message %s is attachment media with no following selected model",
+                telegram.message_link(message_id) or message_id,
+            )
+        failed += len(unavailable) + len(ignored)
+
+        if tracker is not None:
+            for bundle in bundles:
+                key = bundle_key(telegram.channel_id, bundle)
+                existing = tracker.get_staged(key)
+                requested_attachments = tuple(
+                    ref.message_id for ref in bundle.attachments
+                )
+                if (
+                    existing is not None
+                    and existing.attachment_message_ids != requested_attachments
+                ):
+                    failed += 1
+                    log.error(
+                        "Telegram bundle %s was already staged with attachment "
+                        "message IDs %s, but this link file selects %s; reconcile "
+                        "or remove the existing staged state before retrying",
+                        existing.folder_name,
+                        existing.attachment_message_ids,
+                        requested_attachments,
+                    )
+
+        if args.dry_run:
+            selections = [
+                describe_plan(telegram.channel_id, run)
+                for run, items in run_bundles
+                if items
+            ]
+            plans.append(
+                f"Channel {telegram.channel_id} ({channel}):\n"
+                + ("\n".join(selections) if selections else "No model media found.")
+            )
+            continue
+        if not bundles:
+            continue
+        if tracker is None:
+            raise RuntimeError("Linked-message staging requires an import tracker")
+        for run, items in run_bundles:
+            if not items:
+                continue
+            result = await stage_bundles(
+                telegram=telegram,
+                tracker=tracker,
+                refs=run,
+                staging_dir=args.staging_dir,
+                limit=len(items),
+                progress=progress,
+                concurrency=args.concurrency,
+            )
+            staged += result.staged
+            staged_bytes += result.staged_bytes
+            failed += result.failed
+
+    if args.dry_run:
+        print("\n\n".join(plans))
+    else:
+        print(
+            _staging_summary(args.staging_dir, staged, failed, staged_bytes)
+            + f" {selected} message link(s) selected."
+        )
+    return 1 if failed else 0
 
 
 async def _login(args: argparse.Namespace) -> AlexandriaClient:
@@ -998,6 +1142,16 @@ async def run(args: argparse.Namespace) -> int:
     )
 
     try:
+        if isinstance(args.download_only, Path):
+            if not args.dry_run:
+                tracker = ImportTracker(args.state)
+            return await download_linked_messages(
+                args=args,
+                telegram=telegram,
+                tracker=tracker,
+                progress=progress,
+            )
+
         await telegram.connect(_channel(args.channel))
         refs = await telegram.collect_media(min_message_id=args.from_message_id)
         if args.dry_run:

--- a/tools/telegram-importer/src/alexandria_telegram_importer/message_links.py
+++ b/tools/telegram-importer/src/alexandria_telegram_importer/message_links.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from collections import OrderedDict
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import urlsplit
+
+
+TELEGRAM_LINK_HOSTS = {"t.me", "telegram.me"}
+
+
+@dataclass(frozen=True, slots=True)
+class MessageLink:
+    channel: str | int
+    message_id: int
+    url: str
+
+
+def parse_message_link(value: str) -> MessageLink:
+    """Parse one public or private Telegram message URL."""
+    url = value.strip()
+    parsed = urlsplit(url)
+    host = (parsed.hostname or "").casefold().removeprefix("www.")
+    if parsed.scheme.casefold() not in {"http", "https"} or host not in TELEGRAM_LINK_HOSTS:
+        raise ValueError("expected an http(s) t.me message link")
+
+    parts = [part for part in parsed.path.split("/") if part]
+    if parts and parts[0].casefold() == "s":
+        parts = parts[1:]
+
+    if len(parts) == 3 and parts[0].casefold() == "c":
+        channel_text, message_text = parts[1:]
+        if not channel_text.isdigit() or int(channel_text) < 1:
+            raise ValueError("private channel ID must be a positive integer")
+        channel: str | int = int(f"-100{channel_text}")
+    elif len(parts) == 2:
+        channel_text, message_text = parts
+        if not channel_text or channel_text.startswith("+"):
+            raise ValueError("public message link must contain a channel username")
+        channel = f"@{channel_text.casefold()}"
+    else:
+        raise ValueError(
+            "expected t.me/<channel>/<message> or t.me/c/<channel>/<message>"
+        )
+
+    if not message_text.isdigit() or int(message_text) < 1:
+        raise ValueError("message ID must be a positive integer")
+    return MessageLink(channel=channel, message_id=int(message_text), url=url)
+
+
+def read_message_links(path: Path) -> tuple[MessageLink, ...]:
+    """Read, validate, and deduplicate a newline-delimited message-link file."""
+    try:
+        lines = path.read_text(encoding="utf-8-sig").splitlines()
+    except OSError as error:
+        raise ValueError(f"could not read {path}: {error}") from error
+
+    links: list[MessageLink] = []
+    seen: set[tuple[str | int, int]] = set()
+    for line_number, line in enumerate(lines, start=1):
+        value = line.strip()
+        if not value or value.startswith("#"):
+            continue
+        try:
+            link = parse_message_link(value)
+        except ValueError as error:
+            raise ValueError(f"{path}:{line_number}: {error}") from error
+        identity = (link.channel, link.message_id)
+        if identity not in seen:
+            seen.add(identity)
+            links.append(link)
+
+    if not links:
+        raise ValueError(f"{path} contains no Telegram message links")
+    return tuple(links)
+
+
+def group_message_links(
+    links: Iterable[MessageLink],
+) -> tuple[tuple[str | int, tuple[int, ...]], ...]:
+    """Group linked IDs by channel while preserving first-seen channel order."""
+    grouped: OrderedDict[str | int, list[int]] = OrderedDict()
+    for link in links:
+        grouped.setdefault(link.channel, []).append(link.message_id)
+    return tuple(
+        (channel, tuple(sorted(message_ids)))
+        for channel, message_ids in grouped.items()
+    )

--- a/tools/telegram-importer/src/alexandria_telegram_importer/telegram_source.py
+++ b/tools/telegram-importer/src/alexandria_telegram_importer/telegram_source.py
@@ -46,7 +46,25 @@ class TelegramSource:
             "Logged into Telegram as %s", getattr(me, "username", None) or me.first_name
         )
         selected = channel if channel is not None else await self._pick_channel()
-        self.entity = await self._client.get_entity(selected)
+        await self.select_channel(selected)
+
+    async def select_channel(self, channel: str | int) -> None:
+        """Select a source channel after the Telegram session is connected."""
+        selected = channel
+        try:
+            self.entity = await self._client.get_entity(selected)
+        except ValueError as error:
+            if not isinstance(selected, int):
+                raise
+            self.entity = None
+            async for dialog in self._client.iter_dialogs():
+                if utils.get_peer_id(dialog.entity) == selected:
+                    self.entity = dialog.entity
+                    break
+            if self.entity is None:
+                raise RuntimeError(
+                    f"Telegram channel {selected} is not visible to this account"
+                ) from error
         self.channel_id = utils.get_peer_id(self.entity)
         self.channel_username = getattr(self.entity, "username", None)
         log.info("Reading Telegram channel %s", getattr(self.entity, "title", selected))
@@ -93,6 +111,24 @@ class TelegramSource:
             return f"photo:{message.photo.id}:{size}"
         return None
 
+    @classmethod
+    def _media_ref(cls, message: Any) -> MediaRef | None:
+        filename = cls._filename(message)
+        if not filename:
+            return None
+        return MediaRef(
+            message_id=message.id,
+            filename=filename,
+            kind=(
+                MediaKind.MODEL
+                if is_model_filename(filename)
+                else MediaKind.ATTACHMENT
+            ),
+            caption=message.message.strip() if message.message else None,
+            size=message.file.size if message.file and message.file.size else 0,
+            media_identity=cls._media_identity(message),
+        )
+
     async def collect_media(self, *, min_message_id: int = 0) -> list[MediaRef]:
         refs: list[MediaRef] = []
         async for message in self._client.iter_messages(
@@ -100,24 +136,32 @@ class TelegramSource:
             reverse=True,
             min_id=min_message_id,
         ):
-            filename = self._filename(message)
-            if not filename:
-                continue
-            refs.append(
-                MediaRef(
-                    message_id=message.id,
-                    filename=filename,
-                    kind=(
-                        MediaKind.MODEL
-                        if is_model_filename(filename)
-                        else MediaKind.ATTACHMENT
-                    ),
-                    caption=message.message.strip() if message.message else None,
-                    size=message.file.size if message.file and message.file.size else 0,
-                    media_identity=self._media_identity(message),
-                ),
-            )
+            if ref := self._media_ref(message):
+                refs.append(ref)
         return refs
+
+    async def collect_media_by_ids(
+        self, message_ids: tuple[int, ...]
+    ) -> tuple[list[MediaRef], tuple[int, ...]]:
+        """Collect only explicitly selected messages, reporting missing media."""
+        messages = await self._client.get_messages(self.entity, ids=list(message_ids))
+        if not isinstance(messages, list):
+            messages = [messages]
+        by_id = {
+            message.id: message
+            for message in messages
+            if message is not None and getattr(message, "id", None) is not None
+        }
+        refs: list[MediaRef] = []
+        unavailable: list[int] = []
+        for message_id in message_ids:
+            message = by_id.get(message_id)
+            ref = self._media_ref(message) if message is not None else None
+            if ref is None:
+                unavailable.append(message_id)
+            else:
+                refs.append(ref)
+        return refs, tuple(unavailable)
 
     async def download(
         self,
@@ -194,4 +238,7 @@ class TelegramSource:
     def message_link(self, message_id: int) -> str | None:
         if self.channel_username:
             return f"https://t.me/{self.channel_username}/{message_id}"
+        peer_id = str(abs(self.channel_id))
+        if peer_id.startswith("100") and len(peer_id) > 3:
+            return f"https://t.me/c/{peer_id[3:]}/{message_id}"
         return None

--- a/tools/telegram-importer/src/alexandria_telegram_importer/tracker.py
+++ b/tools/telegram-importer/src/alexandria_telegram_importer/tracker.py
@@ -35,6 +35,7 @@ class StagedBundle:
     model_message_ids: tuple[int, ...]
     status: str
     downloaded_at: str
+    attachment_message_ids: tuple[int, ...] | None = None
     output_folders: tuple[str, ...] = ()
     cleanup_report: dict[str, Any] | None = None
     cleanup_attempts: int = 0
@@ -104,6 +105,7 @@ class ImportTracker:
                 source_channel_id INTEGER NOT NULL,
                 folder_name TEXT NOT NULL,
                 model_message_ids TEXT NOT NULL,
+                attachment_message_ids TEXT NOT NULL DEFAULT '[]',
                 status TEXT NOT NULL,
                 downloaded_at TEXT NOT NULL,
                 output_folders TEXT NOT NULL DEFAULT '[]',
@@ -120,6 +122,9 @@ class ImportTracker:
             ).fetchall()
         }
         staged_migrations = {
+            # NULL marks legacy rows whose original attachment selection is
+            # unknowable; exact-link reruns must ask for reconciliation.
+            "attachment_message_ids": "TEXT",
             "output_folders": "TEXT NOT NULL DEFAULT '[]'",
             "cleanup_report": "TEXT",
             "cleanup_attempts": "INTEGER NOT NULL DEFAULT 0",
@@ -330,6 +335,7 @@ class ImportTracker:
         source_channel_id: int,
         folder_name: str,
         model_message_ids: tuple[int, ...],
+        attachment_message_ids: tuple[int, ...] = (),
     ) -> StagedBundle:
         now = datetime.now(UTC).isoformat()
         with self._connection:
@@ -337,8 +343,9 @@ class ImportTracker:
                 """
                 INSERT INTO staged_bundles (
                     bundle_key, source_channel_id, folder_name,
-                    model_message_ids, status, downloaded_at, updated_at
-                ) VALUES (?, ?, ?, ?, 'downloaded', ?, ?)
+                    model_message_ids, attachment_message_ids,
+                    status, downloaded_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, 'downloaded', ?, ?)
                 ON CONFLICT(bundle_key) DO NOTHING
                 """,
                 (
@@ -346,6 +353,7 @@ class ImportTracker:
                     source_channel_id,
                     folder_name,
                     json.dumps(model_message_ids),
+                    json.dumps(attachment_message_ids),
                     now,
                     now,
                 ),
@@ -367,6 +375,11 @@ class ImportTracker:
             source_channel_id=row["source_channel_id"],
             folder_name=row["folder_name"],
             model_message_ids=tuple(json.loads(row["model_message_ids"])),
+            attachment_message_ids=(
+                tuple(json.loads(row["attachment_message_ids"]))
+                if row["attachment_message_ids"] is not None
+                else None
+            ),
             status=row["status"],
             downloaded_at=row["downloaded_at"],
             output_folders=tuple(json.loads(row["output_folders"] or "[]")),

--- a/tools/telegram-importer/tests/test_cli.py
+++ b/tools/telegram-importer/tests/test_cli.py
@@ -17,6 +17,7 @@ from alexandria_telegram_importer.parallel_download import (
     DEFAULT_CONNECTIONS,
     MAX_CONNECTIONS,
 )
+from alexandria_telegram_importer.models import MediaKind, MediaRef
 
 
 def test_should_import_one_model_at_a_time_by_default() -> None:
@@ -143,6 +144,16 @@ def test_should_reject_a_non_positive_download_count() -> None:
         parser().parse_args(["--staging-dir", "/tmp/work", "--download-only", "0"])
 
 
+def test_should_accept_a_message_link_file_for_download_only(tmp_path) -> None:
+    links = tmp_path / "links.txt"
+    args = parser().parse_args(
+        ["--staging-dir", str(tmp_path / "work"), "--download-only", str(links)]
+    )
+
+    validate_staging_args(args)
+    assert args.download_only == links
+
+
 def test_should_accept_each_staging_mode(tmp_path) -> None:
     for extra in (["--download-only", "5"], ["--upload-only"], ["--stage", "5"]):
         args = parser().parse_args(["--staging-dir", str(tmp_path), *extra])
@@ -242,6 +253,165 @@ async def test_should_upload_without_touching_telegram(monkeypatch, tmp_path) ->
 
     assert await cli.run(args) == 0
     assert connected == []
+
+
+async def test_should_stage_only_messages_selected_by_links(
+    monkeypatch, tmp_path
+) -> None:
+    from alexandria_telegram_importer import cli
+
+    links = tmp_path / "links.txt"
+    links.write_text(
+        "https://t.me/first/30\n"
+        "https://t.me/first/10\n"
+        "https://t.me/c/123/20\n",
+        encoding="utf-8",
+    )
+    selections: list[tuple[str | int, tuple[int, ...]]] = []
+    staged_refs: list[tuple[int, ...]] = []
+
+    class FakeTelegram:
+        channel_id = 0
+        channel_username = None
+
+        def __init__(self, **kwargs) -> None:
+            pass
+
+        async def connect(self, channel) -> None:
+            self.channel_id = -1001
+            self.channel_username = "first"
+            selections.append((channel, ()))
+
+        async def select_channel(self, channel) -> None:
+            self.channel_id = channel
+            self.channel_username = None
+            selections.append((channel, ()))
+
+        async def collect_media_by_ids(self, message_ids):
+            channel, _ = selections[-1]
+            selections[-1] = (channel, message_ids)
+            return (
+                [
+                    MediaRef(
+                        message_id=message_id,
+                        filename=f"model-{message_id}.zip",
+                        kind=MediaKind.MODEL,
+                    )
+                    for message_id in message_ids
+                ],
+                (),
+            )
+
+        def message_link(self, message_id):
+            return f"https://t.me/source/{message_id}"
+
+        async def close(self) -> None:
+            return None
+
+    async def fake_stage_bundles(**kwargs):
+        staged_refs.append(tuple(ref.message_id for ref in kwargs["refs"]))
+        return cli.StagingResult((), (), 100)
+
+    monkeypatch.setenv("TELEGRAM_API_ID", "1")
+    monkeypatch.setenv("TELEGRAM_API_HASH", "hash")
+    monkeypatch.setattr(cli, "TelegramSource", FakeTelegram)
+    monkeypatch.setattr(cli, "stage_bundles", fake_stage_bundles)
+
+    args = parser().parse_args(
+        [
+            "--download-only",
+            str(links),
+            "--staging-dir",
+            str(tmp_path / "staging"),
+            "--state",
+            str(tmp_path / "state.sqlite3"),
+        ]
+    )
+
+    assert await cli.run(args) == 0
+    assert selections == [("@first", (10, 30)), (-100123, (20,))]
+    assert staged_refs == [(10,), (30,), (20,)]
+
+
+async def test_should_reject_changed_attachments_for_an_existing_staged_bundle(
+    monkeypatch, tmp_path
+) -> None:
+    from alexandria_telegram_importer import cli
+    from alexandria_telegram_importer.grouping import build_bundles
+    from alexandria_telegram_importer.staging import bundle_key
+    from alexandria_telegram_importer.tracker import ImportTracker
+
+    state = tmp_path / "state.sqlite3"
+    model = MediaRef(message_id=10, filename="dragon.zip", kind=MediaKind.MODEL)
+    bundle = next(build_bundles(-1001, [model]))
+    tracker = ImportTracker(state)
+    try:
+        tracker.record_staged(
+            bundle_key=bundle_key(-1001, bundle),
+            source_channel_id=-1001,
+            folder_name="000010-dragon",
+            model_message_ids=(10,),
+            attachment_message_ids=(),
+        )
+    finally:
+        tracker.close()
+
+    links = tmp_path / "links.txt"
+    links.write_text(
+        "https://t.me/first/9\nhttps://t.me/first/10\n",
+        encoding="utf-8",
+    )
+
+    class FakeTelegram:
+        channel_id = -1001
+        channel_username = "first"
+
+        def __init__(self, **kwargs) -> None:
+            pass
+
+        async def connect(self, channel) -> None:
+            assert channel == "@first"
+
+        async def collect_media_by_ids(self, message_ids):
+            assert message_ids == (9, 10)
+            return (
+                [
+                    MediaRef(
+                        message_id=9,
+                        filename="render.jpg",
+                        kind=MediaKind.ATTACHMENT,
+                    ),
+                    model,
+                ],
+                (),
+            )
+
+        def message_link(self, message_id):
+            return f"https://t.me/first/{message_id}"
+
+        async def download(self, *args, **kwargs):
+            raise AssertionError("an already-staged bundle must not download again")
+
+        async def close(self) -> None:
+            return None
+
+    monkeypatch.setenv("TELEGRAM_API_ID", "1")
+    monkeypatch.setenv("TELEGRAM_API_HASH", "hash")
+    monkeypatch.setattr(cli, "TelegramSource", FakeTelegram)
+    args = parser().parse_args(
+        [
+            "--download-only",
+            str(links),
+            "--staging-dir",
+            str(tmp_path / "staging"),
+            "--state",
+            str(state),
+            "--no-progress",
+        ]
+    )
+
+    assert await cli.run(args) == 1
+    assert not (tmp_path / "staging").exists()
 
 
 async def _ready(value):

--- a/tools/telegram-importer/tests/test_message_links.py
+++ b/tools/telegram-importer/tests/test_message_links.py
@@ -1,0 +1,84 @@
+from pathlib import Path
+
+import pytest
+
+from alexandria_telegram_importer.message_links import (
+    MessageLink,
+    group_message_links,
+    parse_message_link,
+    read_message_links,
+)
+
+
+@pytest.mark.parametrize(
+    ("url", "channel", "message_id"),
+    [
+        ("https://t.me/ModelChannel/123", "@modelchannel", 123),
+        ("https://t.me/s/ModelChannel/456?single", "@modelchannel", 456),
+        ("http://www.telegram.me/ModelChannel/789", "@modelchannel", 789),
+        ("https://t.me/c/2050123456/321", -1002050123456, 321),
+    ],
+)
+def test_should_parse_supported_message_links(
+    url: str,
+    channel: str | int,
+    message_id: int,
+) -> None:
+    assert parse_message_link(url) == MessageLink(channel, message_id, url)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://example.com/channel/123",
+        "https://t.me/channel",
+        "https://t.me/+invite/123",
+        "https://t.me/c/not-a-channel/123",
+        "https://t.me/channel/not-a-message",
+        "https://t.me/c/123/456/789",
+    ],
+)
+def test_should_reject_non_message_links(url: str) -> None:
+    with pytest.raises(ValueError):
+        parse_message_link(url)
+
+
+def test_should_read_comments_blank_lines_and_deduplicate_links(tmp_path: Path) -> None:
+    path = tmp_path / "links.txt"
+    path.write_text(
+        "# selected models\n"
+        "\n"
+        "https://t.me/chan/30\n"
+        "https://t.me/chan/10\n"
+        "https://t.me/chan/30\n"
+        "https://t.me/c/123/20\n",
+        encoding="utf-8",
+    )
+
+    links = read_message_links(path)
+
+    assert links == (
+        MessageLink("@chan", 30, "https://t.me/chan/30"),
+        MessageLink("@chan", 10, "https://t.me/chan/10"),
+        MessageLink(-100123, 20, "https://t.me/c/123/20"),
+    )
+    assert group_message_links(links) == (
+        ("@chan", (10, 30)),
+        (-100123, (20,)),
+    )
+
+
+def test_should_report_the_line_containing_an_invalid_link(tmp_path: Path) -> None:
+    path = tmp_path / "links.txt"
+    path.write_text("\nhttps://example.com/nope\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match=r"links\.txt:2"):
+        read_message_links(path)
+
+
+def test_should_reject_an_empty_link_file(tmp_path: Path) -> None:
+    path = tmp_path / "links.txt"
+    path.write_text("# nothing selected\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="contains no Telegram message links"):
+        read_message_links(path)

--- a/tools/telegram-importer/tests/test_telegram_source.py
+++ b/tools/telegram-importer/tests/test_telegram_source.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 
 import pytest
 from telethon.errors import FileReferenceExpiredError
+from telethon.tl.types import Channel, ChatPhotoEmpty
 
 from alexandria_telegram_importer import parallel_download, telegram_source
 from alexandria_telegram_importer.models import MediaKind, MediaRef
@@ -59,7 +60,74 @@ def source_with(client, *, connections: int = 1) -> TelegramSource:
     source._client = client
     source._downloads = SimpleNamespace(size=connections)
     source.entity = object()
+    source.channel_id = -1002050123456
+    source.channel_username = None
     return source
+
+
+def downloadable_message(message_id: int, filename: str | None):
+    file = (
+        SimpleNamespace(name=filename, ext=".zip", size=1024)
+        if filename is not None
+        else None
+    )
+    return SimpleNamespace(
+        id=message_id,
+        file=file,
+        document=SimpleNamespace(id=message_id) if file else None,
+        photo=None,
+        message=f"Caption {message_id}",
+    )
+
+
+@pytest.mark.asyncio
+async def test_should_collect_only_selected_message_ids_and_report_missing_media() -> None:
+    class SelectionClient:
+        async def get_messages(self, _entity, ids):
+            assert ids == [10, 20, 30]
+            return [
+                downloadable_message(10, "dragon.zip"),
+                downloadable_message(20, None),
+                None,
+            ]
+
+    source = source_with(SelectionClient())
+
+    refs, unavailable = await source.collect_media_by_ids((10, 20, 30))
+
+    assert [(ref.message_id, ref.filename) for ref in refs] == [(10, "dragon.zip")]
+    assert unavailable == (20, 30)
+
+
+def test_should_build_a_private_message_link_from_the_peer_id() -> None:
+    source = source_with(RecordingTelethonClient())
+
+    assert source.message_link(321) == "https://t.me/c/2050123456/321"
+
+
+@pytest.mark.asyncio
+async def test_should_resolve_an_uncached_private_channel_from_dialogs() -> None:
+    selected = Channel(
+        id=2050123456,
+        title="Private models",
+        photo=ChatPhotoEmpty(),
+        date=None,
+        access_hash=123,
+    )
+
+    class FreshSessionClient:
+        async def get_entity(self, _channel):
+            raise ValueError("entity is not cached")
+
+        async def iter_dialogs(self):
+            yield SimpleNamespace(entity=selected)
+
+    source = source_with(FreshSessionClient())
+
+    await source.select_channel(-1002050123456)
+
+    assert source.entity is selected
+    assert source.channel_id == -1002050123456
 
 
 @pytest.mark.asyncio

--- a/tools/telegram-importer/tests/test_tracker.py
+++ b/tools/telegram-importer/tests/test_tracker.py
@@ -304,6 +304,7 @@ def test_should_record_and_read_back_a_staged_bundle(tmp_path) -> None:
             source_channel_id=-100987654,
             folder_name="002501-dragon-set",
             model_message_ids=(2501, 2502),
+            attachment_message_ids=(2499, 2500),
         )
 
         staged = tracker.get_staged("abc123")
@@ -311,6 +312,7 @@ def test_should_record_and_read_back_a_staged_bundle(tmp_path) -> None:
         assert staged is not None
         assert staged.folder_name == "002501-dragon-set"
         assert staged.model_message_ids == (2501, 2502)
+        assert staged.attachment_message_ids == (2499, 2500)
         assert staged.status == "downloaded"
         assert staged.downloaded_at
     finally:
@@ -463,6 +465,7 @@ def test_should_migrate_cleanup_columns_into_an_existing_staged_table(tmp_path) 
 
         assert staged is not None
         assert staged.output_folders == ()
+        assert staged.attachment_message_ids is None
         assert staged.cleanup_attempts == 0
         assert staged.updated_at == staged.downloaded_at
     finally:


### PR DESCRIPTION
## Summary

- extend `--download-only` to accept either the existing bundle count or a newline-delimited Telegram message-link file
- resolve exact public and private message links across multiple channels without scanning intervening history
- preserve grouping boundaries across unlisted message gaps and report unavailable or ungrouped selected media
- persist staged attachment selections so corrected or legacy-unknown reruns fail visibly instead of silently keeping incomplete folders
- document link formats, recovery behavior, and the companion utility architecture

## Why

Operators sometimes know the exact Telegram posts they want to stage and should not need to scan or walk an entire channel to download them. The selected-link path reuses the existing staging layout and upload workflow while keeping numeric `--download-only N` behavior intact.

## Validation

- `uv run --extra test pytest` — 284 passed
- `uv run --extra test alexandria-telegram-import --help`
- `git diff --check`
- consolidated reviewer pass plus targeted follow-up on private-channel resolution and staged attachment idempotency
