### PR TITLE
fix: allow unbounded staged downloads

### DIFF
--- a/tools/telegram-importer/src/alexandria_telegram_importer/cli.py
+++ b/tools/telegram-importer/src/alexandria_telegram_importer/cli.py
@@ -402,12 +402,12 @@ async def stage_bundles(
     tracker: ImportTracker,
     refs: list[MediaRef],
     staging_dir: Path,
-    limit: int,
+    limit: int | None,
     progress: ProgressReporter,
     concurrency: int = 1,
     exclude_keys: set[str] | None = None,
 ) -> StagingResult:
-    """Stage up to `limit` not-yet-staged bundles.
+    """Stage up to `limit` not-yet-staged bundles, or all when it is omitted.
 
     Returns the new persisted bundle records plus failures and downloaded bytes.
     `concurrency` bundles are staged at once, matching the direct import path.
@@ -416,7 +416,7 @@ async def stage_bundles(
     stager = BundleStager(telegram=telegram, root=staging_dir)
     pending = []
     for bundle in build_bundles(telegram.channel_id, refs):
-        if len(pending) >= limit:
+        if limit is not None and len(pending) >= limit:
             break
         key = bundle_key(telegram.channel_id, bundle)
         if key not in already:

--- a/tools/telegram-importer/tests/test_cli.py
+++ b/tools/telegram-importer/tests/test_cli.py
@@ -306,6 +306,49 @@ async def test_should_not_limit_staging_when_download_only_has_no_count(
     assert limits == [None]
 
 
+async def test_should_stage_every_pending_bundle_when_limit_is_omitted(
+    monkeypatch, tmp_path
+) -> None:
+    from alexandria_telegram_importer import cli
+    from alexandria_telegram_importer.progress import NullProgress
+
+    recorded: list[dict] = []
+
+    class FakeTracker:
+        def staged_keys(self, channel_id):
+            return set()
+
+        def record_staged(self, **kwargs):
+            recorded.append(kwargs)
+            return SimpleNamespace(folder_name=kwargs["folder_name"])
+
+    class FakeStager:
+        def __init__(self, *, telegram, root) -> None:
+            self.root = root
+
+        async def stage(self, bundle, handle):
+            folder = self.root / str(bundle.models[0].first_message_id)
+            folder.mkdir(parents=True)
+            return folder
+
+    monkeypatch.setattr(cli, "BundleStager", FakeStager)
+    result = await cli.stage_bundles(
+        telegram=SimpleNamespace(channel_id=-100123),
+        tracker=FakeTracker(),
+        refs=[
+            MediaRef(1, "first.zip", MediaKind.MODEL),
+            MediaRef(2, "preview.jpg", MediaKind.ATTACHMENT),
+            MediaRef(3, "second.zip", MediaKind.MODEL),
+        ],
+        staging_dir=tmp_path / "staging",
+        limit=None,
+        progress=NullProgress(),
+    )
+
+    assert [item["model_message_ids"] for item in recorded] == [(1,), (3,)]
+    assert len(result.items) == 2
+
+
 async def test_should_stage_only_messages_selected_by_links(
     monkeypatch, tmp_path
 ) -> None:


### PR DESCRIPTION
## Summary

Allow `--download-only` without a count to pass an unbounded staging limit through the pipeline.

## Root cause

The CLI represented a bare `--download-only` as an unbounded (`None`) limit, but `stage_bundles` still compared pending bundle counts directly against that value.

## Validation

- `uv run --extra test pytest`
- `uv run --extra test python -m compileall -q src`