### PR TITLE
fix: recover from Telegram download pool failures

### DIFF
--- a/tools/telegram-importer/README.md
+++ b/tools/telegram-importer/README.md
@@ -414,6 +414,11 @@ This applies to documents larger than 512 KB, which covers model archives. Photo
 
 The connections are opened once and reused for the whole run, and they are separate from `--concurrency`: `N` concurrent models share the same pool of download connections rather than each opening their own. Raising both multiplies Telegram's view of the account's activity, so raise `--concurrency` first and only lower `--download-connections` if flood waits appear.
 
+If Telegram terminates the parallel pool with a transport error such as HTTP
+429, the importer disables that pool for the rest of the run and retries
+through Telethon's managed single-connection downloader. The remaining files
+continue at reduced speed instead of inheriting disconnected pooled senders.
+
 ## Progress output
 
 In an interactive terminal the importer pins a live block below the scrolling log: an overall bar, a running tally of this run's outcomes, and one row per model being imported.

--- a/tools/telegram-importer/src/alexandria_telegram_importer/parallel_download.py
+++ b/tools/telegram-importer/src/alexandria_telegram_importer/parallel_download.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import asyncio
 import copy
+import inspect
 import logging
 from collections.abc import Callable
 from pathlib import Path
@@ -69,15 +70,19 @@ class ConnectionPool:
         self._size = size
         self._senders: dict[int, list[MTProtoSender]] = {}
         self._lock = asyncio.Lock()
+        self._disabled = False
 
     @property
     def size(self) -> int:
-        return self._size
+        # A size of one makes `plan` select Telethon's normal downloader.
+        return 1 if self._disabled else self._size
 
     async def senders(self, dc_id: int) -> list[MTProtoSender]:
         # The lock makes the whole first build atomic, so concurrent imports
         # cannot each open a full set of connections for the same data centre.
         async with self._lock:
+            if self._disabled:
+                raise UnsupportedDownload("parallel download pool is disabled")
             if (existing := self._senders.get(dc_id)) is not None:
                 return existing
             created: list[MTProtoSender] = []
@@ -91,6 +96,20 @@ class ConnectionPool:
             log.debug("Opened %d download connections to DC %d", len(created), dc_id)
             self._senders[dc_id] = created
             return created
+
+    async def disable(self) -> None:
+        """Stop parallel downloads after a transport-level pool failure.
+
+        Telegram can terminate an extra MTProto connection with a transport
+        429. Telethon deliberately leaves that sender disconnected, so keeping
+        it in the pool would make every later file fail immediately.
+
+        Do not disconnect here: concurrent downloads may still own requests on
+        healthy senders in the shared pool, and Telethon cancels those requests
+        during disconnect. Normal source teardown closes the disabled pool once
+        every staging task has drained.
+        """
+        self._disabled = True
 
     async def _connect(self, dc_id: int) -> MTProtoSender:
         client = self._client
@@ -139,6 +158,15 @@ async def _disconnect_quietly(sender: MTProtoSender) -> None:
         await sender.disconnect()
     except Exception as error:  # noqa: BLE001 - teardown must not mask the real fault
         log.debug("Could not close a download connection: %s", error)
+    # A transport 429 completes Telethon's disconnected future with the same
+    # exception. Retrieve it during teardown so asyncio does not report a
+    # misleading "Future exception was never retrieved" after the fallback.
+    disconnected = getattr(sender, "disconnected", None)
+    if inspect.isawaitable(disconnected):
+        try:
+            await disconnected
+        except Exception as error:  # noqa: BLE001 - the request already owns the fault
+            log.debug("Download connection ended with: %s", error)
 
 
 def plan(message: Any, connections: int) -> tuple[Any, int, int] | None:

--- a/tools/telegram-importer/src/alexandria_telegram_importer/telegram_source.py
+++ b/tools/telegram-importer/src/alexandria_telegram_importer/telegram_source.py
@@ -7,7 +7,11 @@ from pathlib import Path
 from typing import Any
 
 from telethon import TelegramClient, utils
-from telethon.errors import FileReferenceExpiredError, FloodWaitError
+from telethon.errors import (
+    FileReferenceExpiredError,
+    FloodWaitError,
+    InvalidBufferError,
+)
 from telethon.tl.types import Channel
 
 from . import parallel_download
@@ -227,6 +231,19 @@ class TelegramSource:
                     target.name,
                     error,
                 )
+            except (ConnectionError, InvalidBufferError) as error:
+                # A transport-level 429 permanently disconnects Telethon's
+                # custom sender. Retaining that sender poisons every later
+                # parallel download, while the client's main connection often
+                # remains healthy. Retire the pool and finish this run through
+                # Telethon's managed downloader instead.
+                log.warning(
+                    "Parallel download transport failed for %s; disabling it "
+                    "for this run and falling back to one connection: %s",
+                    target.name,
+                    error,
+                )
+                await self._downloads.disable()
 
         downloaded = await self._client.download_media(
             message, file=str(target), progress_callback=on_progress

--- a/tools/telegram-importer/tests/test_parallel_download.py
+++ b/tools/telegram-importer/tests/test_parallel_download.py
@@ -364,5 +364,53 @@ async def test_should_open_each_connection_once_and_reuse_it(monkeypatch) -> Non
     assert all(sender.disconnected for sender in opened)
 
 
+@pytest.mark.asyncio
+async def test_should_not_cancel_requests_when_disabling_pool(monkeypatch) -> None:
+    opened = []
+
+    class RecordingSender:
+        def __init__(self, _auth_key, loggers=None) -> None:
+            self.disconnected = False
+            self.pending = []
+            opened.append(self)
+
+        async def connect(self, _connection) -> None:
+            pass
+
+        async def send(self, _request) -> str:
+            future = asyncio.get_running_loop().create_future()
+            self.pending.append(future)
+            return await future
+
+        async def disconnect(self) -> None:
+            self.disconnected = True
+            for future in self.pending:
+                if not future.done():
+                    future.cancel()
+
+    monkeypatch.setattr(parallel_download, "MTProtoSender", RecordingSender)
+    pool = ConnectionPool(FakeClientForPool(), 1)
+    sender = (await pool.senders(2))[0]
+    first = asyncio.create_task(sender.send("first"))
+    second = asyncio.create_task(sender.send("second"))
+    await asyncio.sleep(0)
+
+    await pool.disable()
+
+    assert pool.size == 1
+    assert not sender.disconnected
+    assert not first.done()
+    assert not second.done()
+    with pytest.raises(UnsupportedDownload, match="disabled"):
+        await pool.senders(2)
+
+    sender.pending[0].set_result("first")
+    sender.pending[1].set_result("second")
+    assert await asyncio.gather(first, second) == ["first", "second"]
+
+    await pool.close()
+    assert all(sender.disconnected for sender in opened)
+
+
 async def _instant_sleep(_seconds) -> None:
     return None

--- a/tools/telegram-importer/tests/test_telegram_source.py
+++ b/tools/telegram-importer/tests/test_telegram_source.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
-from telethon.errors import FileReferenceExpiredError
+from telethon.errors import FileReferenceExpiredError, InvalidBufferError
 from telethon.tl.types import Channel, ChatPhotoEmpty
 
 from alexandria_telegram_importer import parallel_download, telegram_source
@@ -198,6 +198,46 @@ async def test_should_fall_back_to_telethon_when_parallel_download_is_unsupporte
     path = await source.download(ref, tmp_path)
 
     assert path.read_bytes() == b"payload"
+    assert client.calls == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "transport_error",
+    [
+        ConnectionError("Cannot send requests while disconnected"),
+        InvalidBufferError((-429).to_bytes(4, "little", signed=True)),
+    ],
+)
+async def test_should_disable_a_broken_parallel_pool_and_fall_back_to_telethon(
+    tmp_path, monkeypatch, transport_error
+) -> None:
+    client = RecordingTelethonClient()
+
+    class FailedPool:
+        size = 4
+        disabled = False
+
+        async def disable(self) -> None:
+            self.disabled = True
+            self.size = 1
+
+    source = source_with(client, connections=4)
+    source._downloads = FailedPool()
+    monkeypatch.setattr(
+        telegram_source.parallel_download, "plan", lambda *_: ("loc", 2, 4096)
+    )
+
+    async def fail(*_args, **_kwargs):
+        raise transport_error
+
+    monkeypatch.setattr(telegram_source.parallel_download, "download", fail)
+    ref = MediaRef(message_id=7, filename="dragon.zip", kind=MediaKind.MODEL)
+
+    path = await source.download(ref, tmp_path)
+
+    assert path.read_bytes() == b"payload"
+    assert source._downloads.disabled is True
     assert client.calls == 1
 
 


### PR DESCRIPTION
## Summary

- disable the custom parallel Telegram download pool after transport failures
- retry affected and subsequent downloads through Telethon's managed downloader
- preserve requests already using healthy pooled senders during concurrent staging
- consume terminal sender futures and document the reduced-speed fallback

## Root cause

Telegram can terminate an extra MTProto connection with a transport-level HTTP
429. Telethon then leaves that sender disconnected, but the importer retained
the sender in its shared pool. Every later archive reused the dead sender and
failed immediately with `Cannot send requests while disconnected`.

The main Telethon connection can remain healthy during this failure, so the
importer now retires the parallel path for the rest of the run and continues
through the managed downloader.

## Validation

- `uv run --extra test pytest -q`
- 290 tests passed
- consolidated reviewer pass plus targeted concurrency follow-up
